### PR TITLE
给ollama增加system message

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -320,7 +320,7 @@ const genClaude = ({
   return [url, init];
 };
 
-const genOllama = ({ text, from, to, url, key, prompt, model }) => {
+const genOllama = ({ text, from, to, url, key, system,prompt, model }) => {
   prompt = prompt
     .replaceAll(INPUT_PLACE_FROM, from)
     .replaceAll(INPUT_PLACE_TO, to)
@@ -328,6 +328,7 @@ const genOllama = ({ text, from, to, url, key, prompt, model }) => {
 
   const data = {
     model,
+    system,
     prompt,
     stream: false,
   };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -537,8 +537,9 @@ const defaultOpenaiApi = {
 const defaultOllamaApi = {
   url: "http://localhost:11434/api/generate",
   key: "",
-  model: "llama3",
-  prompt: `Translate the following text from ${INPUT_PLACE_FROM} to ${INPUT_PLACE_TO}:\n\n${INPUT_PLACE_TEXT}`,
+  model: "llama3.1",
+  system:"You are a professional, authentic machine translation engine.",
+  prompt: `Translate the following text from ${INPUT_PLACE_FROM} to ${INPUT_PLACE_TO},output translation directly without any additional text:\n\n${INPUT_PLACE_TEXT}`,
   fetchLimit: 1,
   fetchInterval: 500,
 };

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -115,6 +115,7 @@ function ApiFields({ translator }) {
     url = "",
     key = "",
     model = "",
+    system = "",
     prompt = "",
     systemPrompt = "",
     fetchLimit = DEFAULT_FETCH_LIMIT,
@@ -214,7 +215,6 @@ function ApiFields({ translator }) {
       )}
 
       {(translator.startsWith(OPT_TRANS_OPENAI) ||
-        translator.startsWith(OPT_TRANS_OLLAMA) ||
         translator === OPT_TRANS_CLAUDE ||
         translator === OPT_TRANS_GEMINI) && (
         <>
@@ -223,6 +223,34 @@ function ApiFields({ translator }) {
             label={"MODEL"}
             name="model"
             value={model}
+            onChange={handleChange}
+          />
+          <TextField
+            size="small"
+            label={"PROMPT"}
+            name="prompt"
+            value={prompt}
+            onChange={handleChange}
+            multiline
+            maxRows={10}
+          />
+        </>
+      )}
+      
+      {(translator.startsWith(OPT_TRANS_OLLAMA)) && (
+        <>
+          <TextField
+            size="small"
+            label={"MODEL"}
+            name="model"
+            value={model}
+            onChange={handleChange}
+          />
+          <TextField
+            size="small"
+            label={"SYSTEM MESSAGE"}
+            name="system"
+            value={system}
             onChange={handleChange}
           />
           <TextField


### PR DESCRIPTION
给ollama配置了system message，预置了沉浸式翻译一样的提示词。
个人测试下来的情况：
qwen2.5(7b、14b)基本不会出现翻译后画蛇添足再回答解释的情况。没有配置system前，14b比较频繁会出现翻译后又回答的情况；
llama3.1出现回答的概率也降低了。
其他端侧模型未测试。