### PR TITLE
允许用户自定义 hooks 中重写signal 参数，自定义超时时间

### DIFF
--- a/src/libs/fetch.js
+++ b/src/libs/fetch.js
@@ -108,7 +108,7 @@ export const fetchPatcher = async (input, init, transOpts, apiSetting) => {
     }
   }
 
-  if (AbortSignal?.timeout) {
+  if (AbortSignal?.timeout && !init.signal) {
     Object.assign(init, { signal: AbortSignal.timeout(TIMEOUT) });
   }
 


### PR DESCRIPTION
在 fetch 时判断 hooks 是否配置signal，如果配置了则不覆盖。