### PR TITLE
fix:(Ollama)Remove the <think></think> tags in deepseek-r1.

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -323,7 +323,11 @@ export const apiTranslate = async ({
     case OPT_TRANS_OLLAMA:
     case OPT_TRANS_OLLAMA_2:
     case OPT_TRANS_OLLAMA_3:
-      trText = res?.response;
+      if (res?.model.startsWith('deepseek-r1')) {
+        trText = res?.response.replace(/<think>[\s\S]*<\/think>/i, '');
+      }else{
+        trText = res?.response;
+      }
       isSame = text === trText;
       break;
     case OPT_TRANS_CUSTOMIZE:


### PR DESCRIPTION
When using the deepseek-r1 model in Ollama, remove the content between the <think></think> tags.