### PR TITLE
feat:ollama接口设置新增是否禁用深度思考参数

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -314,7 +314,7 @@ const genClaude = ({
   return [url, init];
 };
 
-const genOllama = ({ text, from, to, url, key, systemPrompt, userPrompt, model }) => {
+const genOllama = ({ text, from, to, think,url, key, systemPrompt, userPrompt,model }) => {
   systemPrompt = systemPrompt
     .replaceAll(INPUT_PLACE_FROM, from)
     .replaceAll(INPUT_PLACE_TO, to)
@@ -328,6 +328,7 @@ const genOllama = ({ text, from, to, url, key, systemPrompt, userPrompt, model }
     model,
     system: systemPrompt,
     prompt: userPrompt,
+    think: think,
     stream: false,
   };
 

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -186,8 +186,20 @@ export const I18N = {
     zh: `最大并发请求数量 (1-100)`,
     en: `Maximum Number Of Concurrent Requests (1-100)`,
   },
+  if_think:  {
+    zh: `启用或禁用模型的深度思考能力`,
+    en: `Enable or disable the model’s thinking behavior `,
+  },
+  think:  {
+    zh: `启用深度思考`,
+    en: `enable thinking`,
+  },
+  nothink:  {
+    zh: `禁用深度思考`,
+    en: `disable thinking`,
+  },
   think_ignore:  {
-    zh: `忽略以下模型的<think>输出,逗号(,)分割`,
+    zh: `忽略以下模型的<think>输出,逗号(,)分割,当模型支持思考但ollama不支持时需要填写本参数`,
     en: `Ignore the <think> block for the following models, comma (,) separated`,
   },
   fetch_interval: {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -543,6 +543,7 @@ const defaultOllamaApi = {
   model: "llama3.1",
   systemPrompt: `You are a professional, authentic machine translation engine.`,
   userPrompt: `Translate the following source text from ${INPUT_PLACE_FROM} to ${INPUT_PLACE_TO}. Output translation directly without any additional text.\n\nSource Text: ${INPUT_PLACE_TEXT}\n\nTranslated Text:`,
+  think:false,
   thinkIgnore:`qwen3,deepseek-r1`,
   fetchLimit: 1,
   fetchInterval: 500,

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -2,6 +2,7 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import LoadingButton from "@mui/lab/LoadingButton";
+import MenuItem from "@mui/material/MenuItem";
 import {
   OPT_TRANS_ALL,
   OPT_TRANS_MICROSOFT,
@@ -117,6 +118,7 @@ function ApiFields({ translator }) {
     model = "",
     systemPrompt = "",
     userPrompt = "",
+    think="",
     thinkIgnore = "",
     fetchLimit = DEFAULT_FETCH_LIMIT,
     fetchInterval = DEFAULT_FETCH_INTERVAL,
@@ -249,6 +251,17 @@ function ApiFields({ translator }) {
 
       {(translator.startsWith(OPT_TRANS_OLLAMA)) && (
         <>
+          <TextField
+            select
+            size="small"
+            name="think"
+            value={think}
+            label={i18n("if_think")}
+            onChange={handleChange}
+          >
+            <MenuItem value={false}>{i18n("nothink")}</MenuItem>
+            <MenuItem value={true}>{i18n("think")}</MenuItem>
+          </TextField>
           <TextField
             size="small"
             label={i18n("think_ignore")}


### PR DESCRIPTION
当选择禁用深度思考时，模型将不再输出思考过程，能大幅提升思考模型的翻译效率，现在可以愉快的用qwen3,deepseek-r1等模型进行翻译了。当然，如果你对翻译质量的些许提升需求远远高于翻译速度，那依然可以选择启用深度思考。
同样是7b参数，qwen3和deepseek-r1在禁用深度思考时，4070mobile显卡，翻译bbc.com文章，单次翻译的时间可以从8-15秒提升至1-3秒。
备注：如果ollama已更新至最新版但qwen3无法禁用深度思考时，[请更新qwen3后再尝试](https://github.com/ollama/ollama/issues/10954)。

参数如下：
![截图 2025-06-03 23-09-25](https://github.com/user-attachments/assets/66baa2a7-21d8-41f1-9c04-472ccedf13fa)
