### PR TITLE
增加虚线框的翻译样式

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -424,6 +424,10 @@ export const I18N = {
     zh: `下划虚线`,
     en: `Dashed Underline`,
   },
+  dash_box: {
+    zh: `虚线框`,
+    en: `Dashed Box`,
+  },
   wavy_line: {
     zh: `下划波浪线`,
     en: `Wavy Underline`,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -391,6 +391,7 @@ export const OPT_STYLE_NONE = "style_none"; // 无
 export const OPT_STYLE_LINE = "under_line"; // 下划线
 export const OPT_STYLE_DOTLINE = "dot_line"; // 点状线
 export const OPT_STYLE_DASHLINE = "dash_line"; // 虚线
+export const OPT_STYLE_DASHBOX = "dash_box"; // 虚线框
 export const OPT_STYLE_WAVYLINE = "wavy_line"; // 波浪线
 export const OPT_STYLE_FUZZY = "fuzzy"; // 模糊
 export const OPT_STYLE_HIGHLIGHT = "highlight"; // 高亮
@@ -401,6 +402,7 @@ export const OPT_STYLE_ALL = [
   OPT_STYLE_LINE,
   OPT_STYLE_DOTLINE,
   OPT_STYLE_DASHLINE,
+  OPT_STYLE_DASHBOX,
   OPT_STYLE_WAVYLINE,
   OPT_STYLE_FUZZY,
   OPT_STYLE_HIGHLIGHT,
@@ -411,6 +413,7 @@ export const OPT_STYLE_USE_COLOR = [
   OPT_STYLE_LINE,
   OPT_STYLE_DOTLINE,
   OPT_STYLE_DASHLINE,
+  OPT_STYLE_DASHBOX,
   OPT_STYLE_WAVYLINE,
   OPT_STYLE_HIGHLIGHT,
   OPT_STYLE_BLOCKQUOTE,

--- a/src/views/Content/index.js
+++ b/src/views/Content/index.js
@@ -5,6 +5,7 @@ import {
   OPT_STYLE_DOTLINE,
   OPT_STYLE_DASHLINE,
   OPT_STYLE_WAVYLINE,
+  OPT_STYLE_DASHBOX,
   OPT_STYLE_FUZZY,
   OPT_STYLE_HIGHLIGHT,
   OPT_STYLE_BLOCKQUOTE,
@@ -48,6 +49,19 @@ const StyledSpan = styled("span")`
             opacity: 1;
             -webkit-opacity: 1;
           }
+        `;
+      case OPT_STYLE_DASHBOX: // 虚线框
+        return css`
+          color: ${bgColor || DEFAULT_COLOR};
+          border: 1px dashed ${bgColor || DEFAULT_COLOR};
+          background: transparent;
+          display: block;
+          padding: 5px 5px;
+          box-sizing: border-box;
+          white-space: normal;
+          word-wrap: break-word;
+          overflow-wrap: break-word;
+          line-height: 1.4;
         `;
       case OPT_STYLE_FUZZY: // 模糊
         return css`


### PR DESCRIPTION
很喜欢隔壁沉浸式翻译的虚线框模式

感觉有一些必要在默认选项中加上

<img width="836" height="812" alt="{4B4F4F83-BD8A-4CC4-A7D7-5593DAAB5FA6}" src="https://github.com/user-attachments/assets/07f9ff90-3291-4bb4-ad3e-3f02c7a5e39d" />
<img width="2300" height="379" alt="{D57B9352-D3C0-4114-8CDF-070546887528}" src="https://github.com/user-attachments/assets/853c1a37-f0b4-4661-8b25-be60f521120c" />
