### PR TITLE
fix: `TypeError: Cannot read properties of undefined (reading 'trim')`

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -467,6 +467,11 @@ export class Translator {
     q.length > (this._setting.maxLength ?? TRANS_MAX_LENGTH);
 
   _render = (el) => {
+    // 检查元素是否有效
+    if (!el || typeof el.innerText === "undefined") {
+      return;
+    }
+
     let traEl = el.querySelector(APP_LCNAME);
 
     // 已翻译


### PR DESCRIPTION
## 问题描述
修复了在处理某些DOM元素时出现的TypeError错误：
`TypeError: Cannot read properties of undefined (reading 'trim')`

## 问题原因
某些DOM元素（如包含图片的段落元素）可能没有`innerText`属性，直接调用`.trim()`会导致错误。

## 解决方案
在`_render`方法开始处添加安全检查，当元素无效或缺少`innerText`属性时提前返回。

## 测试页面

https://github.com/GinWU05 ，DOM元素如下：

```xml
<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo mr-1 color-fg-muted">
    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
</svg>
```