### PR TITLE
feat: auto pierce deep shadow dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@mui/icons-material": "^5.15.15",
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "^5.15.15",
+    "query-selector-shadow-dom": "^1.0.1",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -70,5 +71,6 @@
     "@babel/preset-env": "^7.22.20",
     "prettier": "3.6.2",
     "react-app-rewired": "^2.2.1"
-  }
+  },
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mui/material':
         specifier: ^5.15.15
         version: 5.15.15(@emotion/react@11.11.1(@types/react@18.2.79)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.79)(react@18.2.0))(@types/react@18.2.79)(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      query-selector-shadow-dom:
+        specifier: ^1.0.1
+        version: 1.0.1
       query-string:
         specifier: ^8.1.0
         version: 8.1.0
@@ -4781,6 +4784,9 @@ packages:
   qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   query-string@8.1.0:
     resolution: {integrity: sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==}
@@ -11526,6 +11532,8 @@ snapshots:
   qs@6.11.0:
     dependencies:
       side-channel: 1.0.4
+
+  query-selector-shadow-dom@1.0.1: {}
 
   query-string@8.1.0:
     dependencies:

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -16,6 +16,7 @@ import {
   DEFAULT_FETCH_LIMIT,
   DEFAULT_FETCH_INTERVAL,
 } from "../config";
+import { querySelectorAllDeep } from "query-selector-shadow-dom";
 import Content from "../views/Content";
 import { updateFetchPool, clearFetchPool } from "./fetch";
 import { debounce, genEventName, getHtmlText } from "./utils";
@@ -206,9 +207,14 @@ export class Translator {
 
   _querySelectorAll = (selector, node) => {
     try {
-      return Array.from(node.querySelectorAll(selector));
+      return querySelectorAllDeep(selector, node);
     } catch (err) {
-      kissLog(selector, "querySelectorAll err");
+      kissLog(selector, "querySelectorAllDeep err");
+      try {
+        return Array.from(node.querySelectorAll(selector));
+      } catch (fallbackErr) {
+        kissLog(selector, "querySelectorAll fallback err");
+      }
     }
     return [];
   };


### PR DESCRIPTION
CSS query rules automatically penetrate all shadow DOMs, such as deep shadow DOMs on Reddit, directly relying on query-selector-shadow-dom implementation while maintaining compatibility with the original `>>>` rules.

<img width="689" height="534" alt="image" src="https://github.com/user-attachments/assets/0812a3bb-d6ce-4ad3-add5-880c473c53a7" />
