### PR TITLE
fix: skip translating child elements if parent will be translated

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -872,9 +872,19 @@ export class Translator {
     }
 
     rootNode.querySelectorAll(this.#rule.selector).forEach((node) => {
-      if (!node.closest?.(this.#ignoreSelector)) {
-        this.#startObserveNode(node);
+      if (node.closest?.(this.#ignoreSelector)) {
+        return;
       }
+
+      // 如果是内联元素，且有祖先也匹配选择器，则跳过（避免重复翻译）
+      if (!Translator.isBlockNode(node)) {
+        const ancestor = node.parentElement?.closest?.(this.#rule.selector);
+        if (ancestor && !ancestor.matches?.(this.#ignoreSelector)) {
+          return;
+        }
+      }
+
+      this.#startObserveNode(node);
     });
   }
 


### PR DESCRIPTION
修复这种问题

<img width="1962" height="1844" alt="图片" src="https://github.com/user-attachments/assets/5827a518-4a07-4847-bea8-c9da61d87125" />
