### PR TITLE
feat(blob): 修复自动翻译不准的问题

### DIFF
--- a/src/libs/detect.js
+++ b/src/libs/detect.js
@@ -51,7 +51,7 @@ export const tryDetectLang = async (text, langDetector = "-") => {
     try {
       const res = await browser?.i18n?.detectLanguage(text);
       const lang = res?.languages?.[0]?.language;
-      if (lang && OPT_LANGS_MAP.has(lang)) {
+      if (res.isReliable && lang && OPT_LANGS_MAP.has(lang)) {
         deLang = lang;
       } else if (lang?.startsWith("zh")) {
         deLang = "zh-CN";

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -14,6 +14,7 @@ import {
   OPT_SPLIT_PARAGRAPH_TEXTLENGTH,
   MSG_INJECT_CSS,
   MSG_UPDATE_ICON,
+  OPT_LANGS_TO_SPEC,
 } from "../config";
 import { interpreter } from "./interpreter";
 import { clearFetchPool } from "./pool";
@@ -975,7 +976,13 @@ export class Translator {
     } = this.#rule;
     const { langDetector, skipLangs = [] } = this.#setting;
     if (fromLang === "auto") {
-      deLang = await tryDetectLang(node.textContent, langDetector);
+    // 与 #translateFetch 使用同一翻译服务，均来自 this.#apiSetting（rule.apiSlug + apisMap）
+    const apiType = this.#apiSetting?.apiType;
+    const langMap = apiType ? OPT_LANGS_TO_SPEC[apiType] : null;
+    const apiSupportsAutoDetect = langMap.get("auto");
+    
+    // 还是用检测下  google de auto当翻译zh 到葡萄牙语时有问题
+    deLang = await tryDetectLang(node.textContent, langDetector) || apiSupportsAutoDetect
       if (
         deLang &&
         (toLang.slice(0, 2) === deLang.slice(0, 2) ||


### PR DESCRIPTION
res = await browser?.i18n?.detectLanguage(text) 插件语言的判断 可能会不准
当返回res.isReliable 说明不可相信 
需要用翻译接口   自动翻译 如穿 auto   空字符 等