### PR TITLE
feat: 字幕翻译增强智能上下文与AI断句优化

### DIFF
--- a/src/apis/history.js
+++ b/src/apis/history.js
@@ -37,3 +37,7 @@ export const getMsgHistory = (apiSlug, maxSize) => {
   historyMap.set(apiSlug, msgHistory);
   return msgHistory;
 };
+
+export const clearMsgHistory = (apiSlug) => {
+  historyMap.delete(apiSlug);
+};

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -607,13 +607,17 @@ export const apiSubtitle = async ({
   events = [],
   apiSetting,
   docInfo,
+  prevContext = "",
+  nextContext = "",
 }) => {
+  if (!events?.length) return [];
   const cacheOpts = {
     apiSlug: apiSetting.apiSlug,
     videoId,
     chunkSign,
     fromLang,
     toLang,
+    segVer: 2,
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };
   const cacheInput = `${URL_CACHE_SUBTITLE}?${queryString.stringify(cacheOpts)}`;
@@ -628,6 +632,8 @@ export const apiSubtitle = async ({
     to: toLang,
     apiSetting,
     docInfo,
+    prevContext,
+    nextContext,
   });
   if (subtitles?.length) {
     putHttpCachePolyfill(cacheInput, null, subtitles);

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -479,6 +479,7 @@ export const apiTranslate = async ({
   toLang,
   apiSetting = DEFAULT_API_SETTING,
   glossary,
+  docInfo,
   useCache = true,
   usePool = true,
 }) => {
@@ -542,6 +543,7 @@ export const apiTranslate = async ({
       glossary,
       apiSetting,
       usePool,
+      docInfo,
     });
   } else {
     const { value } = await handleTranslate([text], {
@@ -553,6 +555,7 @@ export const apiTranslate = async ({
       glossary,
       apiSetting,
       usePool,
+      docInfo,
     }).next();
     translation = value?.result;
   }
@@ -591,6 +594,7 @@ export const apiSubtitle = async ({
   toLang,
   events = [],
   apiSetting,
+  docInfo,
 }) => {
   const cacheOpts = {
     apiSlug: apiSetting.apiSlug,
@@ -610,6 +614,7 @@ export const apiSubtitle = async ({
     from: fromLang,
     to: toLang,
     apiSetting,
+    docInfo,
   });
   if (subtitles?.length) {
     putHttpCachePolyfill(cacheInput, null, subtitles);

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -484,9 +484,13 @@ export const apiTranslate = async ({
   docInfo,
   useCache = true,
   usePool = true,
+  signal,
 }) => {
   if (!text) {
     throw new Error("The text cannot be empty.");
+  }
+  if (signal?.aborted) {
+    throw new DOMException("The operation was aborted.", "AbortError");
   }
 
   const { apiType, apiSlug, useBatchFetch } = apiSetting;
@@ -515,6 +519,9 @@ export const apiTranslate = async ({
     if (cache?.trText) {
       return cache;
     }
+  }
+  if (signal?.aborted) {
+    throw new DOMException("The operation was aborted.", "AbortError");
   }
 
   // 请求接口数据
@@ -547,6 +554,7 @@ export const apiTranslate = async ({
       apiSetting,
       usePool,
       docInfo,
+      signal,
     });
   } else {
     const { value } = await handleTranslate([text], {
@@ -559,6 +567,7 @@ export const apiTranslate = async ({
       apiSetting,
       usePool,
       docInfo,
+      signal,
     }).next();
     translation = value?.result;
   }

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -14,12 +14,14 @@ import {
   MSG_BUILTINAI_TRANSLATE,
   OPT_TRANS_BUILTINAI,
   URL_CACHE_SUBTITLE,
+  URL_CACHE_CONTEXT,
   OPT_LANGS_TO_CODE,
 } from "../config";
 import { sha256, withTimeout } from "../libs/utils";
 import {
   handleTranslate,
   handleSubtitle,
+  handleSummarize,
   handleMicrosoftLangdetect,
 } from "./trans";
 import { getHttpCachePolyfill, putHttpCachePolyfill } from "../libs/cache";
@@ -503,6 +505,7 @@ export const apiTranslate = async ({
     fromLang,
     toLang,
     version: [v1, v2].join("."),
+    ...(docInfo?.summary && { ctx: docInfo.summary.slice(0, 50) }),
   };
   const cacheInput = `${URL_CACHE_TRAN}?${queryString.stringify(cacheOpts)}`;
 
@@ -602,6 +605,7 @@ export const apiSubtitle = async ({
     chunkSign,
     fromLang,
     toLang,
+    ctx: docInfo?.summary?.slice(0, 50) || "",
   };
   const cacheInput = `${URL_CACHE_SUBTITLE}?${queryString.stringify(cacheOpts)}`;
   const cache = await getHttpCachePolyfill(cacheInput);
@@ -622,4 +626,34 @@ export const apiSubtitle = async ({
   }
 
   return [];
+};
+
+// 上下文摘要
+export const apiSummarizeContext = async ({
+  videoId,
+  title,
+  description,
+  transcript,
+  apiSetting,
+}) => {
+  const cacheOpts = { apiSlug: apiSetting.apiSlug, videoId };
+  const cacheInput = `${URL_CACHE_CONTEXT}?${queryString.stringify(cacheOpts)}`;
+  const cache = await getHttpCachePolyfill(cacheInput);
+  if (cache) {
+    return cache;
+  }
+
+  const summary = await handleSummarize({
+    title,
+    description,
+    transcript,
+    apiSetting,
+  });
+
+  if (summary) {
+    putHttpCachePolyfill(cacheInput, null, summary);
+    return summary;
+  }
+
+  return "";
 };

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -789,6 +789,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     customBody,
     events,
     tone,
+    docInfo: externalDocInfo,
   } = args;
 
   if (API_SPE_TYPES.mulkeys.has(apiType)) {
@@ -800,9 +801,18 @@ export const genTransReq = async ({ reqHook, ...args }) => {
   }
 
   if (API_SPE_TYPES.ai.has(apiType)) {
-    const docInfo = getDocInfo();
+    const hasExternalDocInfo =
+      externalDocInfo &&
+      (externalDocInfo.title ||
+        externalDocInfo.description ||
+        externalDocInfo.summary);
+    const docInfo = hasExternalDocInfo ? externalDocInfo : getDocInfo();
 
-    args.systemPrompt = events
+    // 字幕翻译场景：docInfo 由外部显式传入，放入 system prompt，不重复写入 user prompt
+    const systemDocInfo = hasExternalDocInfo ? docInfo : {};
+    const userDocInfo = hasExternalDocInfo ? {} : docInfo;
+
+    let baseSystemPrompt = events
       ? genSubtitlePrompt({
         subtitlePrompt,
         from,
@@ -815,30 +825,45 @@ export const genTransReq = async ({ reqHook, ...args }) => {
         aiTerms,
       })
       : genSystemPrompt({
-        systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
-        from,
-        to,
-        fromLang,
-        toLang,
-        texts,
-        docInfo,
-        tone,
-      });
+          systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
+          from,
+          to,
+          fromLang,
+          toLang,
+          texts,
+          docInfo: userDocInfo,
+          tone,
+        });
+
+    // 将字幕上下文追加到 system prompt
+    if (!events && hasExternalDocInfo) {
+      const parts = [];
+      if (systemDocInfo.title) parts.push(`Title: ${systemDocInfo.title}`);
+      if (systemDocInfo.description)
+        parts.push(`Description: ${systemDocInfo.description}`);
+      if (systemDocInfo.summary)
+        parts.push(`Summary: ${systemDocInfo.summary}`);
+      if (parts.length) {
+        baseSystemPrompt += `\n\n# Context\n${parts.join("\n")}`;
+      }
+    }
+
+    args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
       ? JSON.stringify(events)
       : genUserPrompt({
-        nobatchUserPrompt,
-        useBatchFetch,
-        from,
-        to,
-        fromLang,
-        toLang,
-        texts,
-        docInfo,
-        tone,
-        glossary,
-        aiTerms,
-      });
+          nobatchUserPrompt,
+          useBatchFetch,
+          from,
+          to,
+          fromLang,
+          toLang,
+          texts,
+          docInfo: userDocInfo,
+          tone,
+          glossary,
+          aiTerms,
+        });
   }
 
   const {
@@ -1058,7 +1083,17 @@ export const parseTransRes = async (
  */
 export async function* handleTranslate(
   texts = [],
-  { from, to, fromLang, toLang, langMap, glossary, apiSetting, usePool }
+  {
+    from,
+    to,
+    fromLang,
+    toLang,
+    langMap,
+    glossary,
+    apiSetting,
+    usePool,
+    docInfo,
+  }
 ) {
   let history = null;
   let hisMsgs = [];
@@ -1098,6 +1133,7 @@ export async function* handleTranslate(
     hisMsgs,
     token,
     useStream: enableStream,
+    docInfo,
     ...apiSetting,
   });
 
@@ -1281,7 +1317,13 @@ export const handleMicrosoftLangdetect = async (texts = []) => {
  * @param {*} param0
  * @returns
  */
-export const handleSubtitle = async ({ events, from, to, apiSetting }) => {
+export const handleSubtitle = async ({
+  events,
+  from,
+  to,
+  apiSetting,
+  docInfo,
+}) => {
   const { apiType, fetchInterval, fetchLimit, httpTimeout } = apiSetting;
 
   const [input, init] = await genTransReq({
@@ -1289,6 +1331,7 @@ export const handleSubtitle = async ({ events, from, to, apiSetting }) => {
     events,
     from,
     to,
+    docInfo,
   });
 
   const res = await fetchData(input, init, {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1096,8 +1096,11 @@ export async function* handleTranslate(
     apiSetting,
     usePool,
     docInfo,
+    signal,
   }
 ) {
+  if (signal?.aborted) return;
+
   let history = null;
   let hisMsgs = [];
   const {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -262,20 +262,20 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
-const parseIndexSubtitleRes = (raw, events) => {
-  try {
-    const data = JSON.parse(raw);
-    if (!Array.isArray(data) || !data.length) return null;
+const geminiText = (parts) =>
+  (Array.isArray(parts) ? parts.find((p) => !p.thought) : undefined)?.text ??
+  "";
 
+const parseIndexSubtitleRes = (raw, events) => {
+  const buildResult = (data) => {
+    if (!Array.isArray(data) || !data.length) return null;
     const result = [];
     for (const seg of data) {
       const s = Number(seg.s ?? seg.start_id);
       const e = Number(seg.e ?? seg.end_id);
       if (!Number.isInteger(s) || !Number.isInteger(e)) continue;
-
       const startIdx = Math.max(0, Math.min(s, events.length - 1));
       const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
-
       result.push({
         start: events[startIdx].start,
         end: events[endIdx].end,
@@ -283,10 +283,24 @@ const parseIndexSubtitleRes = (raw, events) => {
         translation: String(seg.t ?? seg.translation ?? ""),
       });
     }
-
     return result.length ? result : null;
+  };
+
+  try {
+    return buildResult(JSON.parse(raw));
   } catch {
-    return null;
+    try {
+      const str = String(raw ?? "");
+      const last = Math.max(
+        str.lastIndexOf("},"),
+        str.lastIndexOf("}\n"),
+        str.lastIndexOf("}\r")
+      );
+      if (last < 0) return null;
+      return buildResult(JSON.parse(str.slice(0, last + 1) + "]"));
+    } catch {
+      return null;
+    }
   }
 };
 
@@ -511,6 +525,18 @@ const genGemini = ({
   }
 
   const userMsg = { role: "user", parts: [{ text: userPrompt }] };
+
+  const modelLower = String(model || "").toLowerCase();
+  const geminiMajor = Number(modelLower.match(/gemini[- ]?(\d+)/)?.[1]);
+  const isPro = modelLower.includes("pro");
+  const thinkingConfig = isPro
+    ? null
+    : Number.isFinite(geminiMajor) && geminiMajor >= 3
+      ? { thinkingLevel: "MINIMAL" }
+      : modelLower.includes("gemini-2.5")
+        ? { thinkingBudget: 0 }
+        : null;
+
   const body = {
     // system_instruction: {
     //   parts: {
@@ -528,12 +554,8 @@ const genGemini = ({
     generationConfig: {
       maxOutputTokens: maxTokens,
       temperature,
-      // topP: 0.8,
-      // topK: 10,
+      ...(thinkingConfig ? { thinkingConfig } : {}),
     },
-    // thinkingConfig: {
-    //   thinkingBudget: 0,
-    // },
     safetySettings: [
       {
         category: "HARM_CATEGORY_HARASSMENT",
@@ -909,6 +931,10 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     method = "POST",
   } = genReqFuncs[apiType](args);
 
+  if (events && apiType === OPT_TRANS_GEMINI && body?.generationConfig) {
+    body.generationConfig.responseMimeType = "application/json";
+  }
+
   // 合并用户自定义headers和body
   if (customHeader?.trim()) {
     Object.assign(headers, parseJsonObj(customHeader));
@@ -1068,7 +1094,7 @@ export const parseTransRes = async (
       if (history && userMsg && modelMsg) {
         history.add(userMsg, modelMsg);
       }
-      return parseAIRes(modelMsg?.parts?.[0]?.text ?? "", useBatchFetch);
+      return parseAIRes(geminiText(modelMsg?.parts), useBatchFetch);
     case OPT_TRANS_CLAUDE:
       modelMsg = { role: res?.role, content: res?.content?.text };
       if (history && userMsg && modelMsg) {
@@ -1392,7 +1418,7 @@ export const handleSubtitle = async ({
       return parseSTRes(res?.choices?.[0]?.message?.content ?? "", events);
     case OPT_TRANS_GEMINI:
       return parseSTRes(
-        res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "",
+        geminiText(res?.candidates?.[0]?.content?.parts),
         events
       );
     case OPT_TRANS_CLAUDE:
@@ -1466,14 +1492,14 @@ export const handleSummarize = async ({
     case OPT_TRANS_OLLAMA:
       return res?.choices?.[0]?.message?.content?.trim() || "";
     case OPT_TRANS_GEMINI:
-      return res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "";
+      return geminiText(res?.candidates?.[0]?.content?.parts).trim() || "";
     case OPT_TRANS_CLAUDE:
       return res?.content?.[0]?.text?.trim() || "";
     case OPT_TRANS_CUSTOMIZE:
       if (typeof res === "string") return res.trim();
       return (
         res?.choices?.[0]?.message?.content?.trim() ||
-        res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ||
+        geminiText(res?.candidates?.[0]?.content?.parts).trim() ||
         res?.content?.[0]?.text?.trim() ||
         ""
       );

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -176,6 +176,38 @@ const genSubtitlePrompt = ({
     .replaceAll(INPUT_PLACE_TO_LANG, toLang);
 };
 
+const normalizeSubtitleContext = (text) =>
+  String(text ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 400);
+
+const buildSubtitleUserPrompt = ({
+  events = [],
+  prevContext = "",
+  nextContext = "",
+}) => {
+  const mainInput = JSON.stringify(
+    events.map((e, i) => ({ id: i, text: e.text }))
+  );
+  const prev = normalizeSubtitleContext(prevContext);
+  const next = normalizeSubtitleContext(nextContext);
+  if (!prev && !next) return mainInput;
+  const sections = [];
+  if (prev) {
+    sections.push(
+      `[Previous context (read-only, do NOT segment)]\n${JSON.stringify(prev)}`
+    );
+  }
+  sections.push(`[Main input]\n${mainInput}`);
+  if (next) {
+    sections.push(
+      `[Next context (read-only, do NOT segment)]\n${JSON.stringify(next)}`
+    );
+  }
+  return sections.join("\n\n");
+};
+
 const parseAIRes = (raw, useBatchFetch = true) => {
   if (!raw) {
     return [];
@@ -281,6 +313,8 @@ const parseIndexSubtitleRes = (raw, events) => {
         end: events[endIdx].end,
         text: String(seg.o ?? seg.original ?? ""),
         translation: String(seg.t ?? seg.translation ?? ""),
+        _si: s,
+        _ei: e,
       });
     }
     return result.length ? result : null;
@@ -843,6 +877,8 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     customBody,
     events,
     tone,
+    prevContext,
+    nextContext,
     docInfo: externalDocInfo,
   } = args;
 
@@ -907,7 +943,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
-      ? JSON.stringify(events.map((e, i) => ({ id: i, text: e.text })))
+      ? buildSubtitleUserPrompt({ events, prevContext, nextContext })
       : genUserPrompt({
           nobatchUserPrompt,
           useBatchFetch,
@@ -1387,6 +1423,8 @@ export const handleSubtitle = async ({
   to,
   apiSetting,
   docInfo,
+  prevContext = "",
+  nextContext = "",
 }) => {
   const { apiType, fetchInterval, fetchLimit, httpTimeout } = apiSetting;
 
@@ -1396,6 +1434,8 @@ export const handleSubtitle = async ({
     from,
     to,
     docInfo,
+    prevContext,
+    nextContext,
   });
 
   const res = await fetchData(input, init, {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -807,9 +807,6 @@ export const genTransReq = async ({ reqHook, ...args }) => {
         externalDocInfo.description ||
         externalDocInfo.summary);
     const docInfo = hasExternalDocInfo ? externalDocInfo : getDocInfo();
-
-    // 字幕翻译场景：docInfo 由外部显式传入，放入 system prompt，不重复写入 user prompt
-    const systemDocInfo = hasExternalDocInfo ? docInfo : {};
     const userDocInfo = hasExternalDocInfo ? {} : docInfo;
 
     let baseSystemPrompt = events
@@ -831,18 +828,24 @@ export const genTransReq = async ({ reqHook, ...args }) => {
           fromLang,
           toLang,
           texts,
-          docInfo: userDocInfo,
+          docInfo,
           tone,
         });
 
-    // 将字幕上下文追加到 system prompt
-    if (!events && hasExternalDocInfo) {
+    // 上下文回退：当 prompt 模板缺少占位符时，追加 # Context 块
+    if (hasExternalDocInfo) {
+      const template = events
+        ? subtitlePrompt
+        : useBatchFetch
+          ? systemPrompt
+          : nobatchPrompt;
       const parts = [];
-      if (systemDocInfo.title) parts.push(`Title: ${systemDocInfo.title}`);
-      if (systemDocInfo.description)
-        parts.push(`Description: ${systemDocInfo.description}`);
-      if (systemDocInfo.summary)
-        parts.push(`Summary: ${systemDocInfo.summary}`);
+      if (docInfo.title && !template.includes(INPUT_PLACE_TITLE))
+        parts.push(`Title: ${docInfo.title}`);
+      if (docInfo.description && !template.includes(INPUT_PLACE_DESCRIPTION))
+        parts.push(`Description: ${docInfo.description}`);
+      if (docInfo.summary && !template.includes(INPUT_PLACE_SUMMARY))
+        parts.push(`Summary: ${docInfo.summary}`);
       if (parts.length) {
         baseSystemPrompt += `\n\n# Context\n${parts.join("\n")}`;
       }
@@ -1123,6 +1126,7 @@ export async function* handleTranslate(
   }
 
   const [input, init, userMsg] = await genTransReq({
+    ...apiSetting,
     texts,
     from,
     to,
@@ -1134,7 +1138,6 @@ export async function* handleTranslate(
     token,
     useStream: enableStream,
     docInfo,
-    ...apiSetting,
   });
 
   if (enableStream) {
@@ -1362,4 +1365,73 @@ export const handleSubtitle = async ({
   }
 
   return [];
+};
+
+/**
+ * 上下文摘要
+ * @param {*} param0
+ * @returns
+ */
+const summarizeSystemPrompt = `Analyze the video title, description, and transcript below. Produce a concise briefing (max 300 words) to help a subtitle translator understand the content accurately.
+
+Cover these aspects:
+1. Main topic, themes, and subject domain
+2. Key terminology with brief definitions or context
+3. Important proper nouns (people, organizations, products, places)
+4. Speaker's tone and register
+5. Abbreviations, jargon, or ambiguous terms needing consistent handling
+
+Output plain text only. No markdown, no formatting, no headers.`;
+
+export const handleSummarize = async ({
+  title,
+  description,
+  transcript,
+  apiSetting,
+}) => {
+  const { apiType, fetchInterval, fetchLimit, httpTimeout } = apiSetting;
+
+  const userPrompt = [
+    title && `Title: ${title}`,
+    description && `Description: ${description}`,
+    `\nTranscript:\n${transcript}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const [input, init] = await genTransReq({
+    ...apiSetting,
+    texts: [""],
+    from: "auto",
+    to: "en",
+    fromLang: "auto",
+    toLang: "en",
+    useBatchFetch: false,
+    nobatchPrompt: summarizeSystemPrompt,
+    nobatchUserPrompt: userPrompt,
+  });
+
+  const res = await fetchData(input, init, {
+    useCache: false,
+    usePool: true,
+    fetchInterval,
+    fetchLimit,
+    httpTimeout,
+  });
+
+  if (!res) return "";
+
+  switch (apiType) {
+    case OPT_TRANS_OPENAI:
+    case OPT_TRANS_GEMINI_2:
+    case OPT_TRANS_OPENROUTER:
+    case OPT_TRANS_OLLAMA:
+      return res?.choices?.[0]?.message?.content?.trim() || "";
+    case OPT_TRANS_GEMINI:
+      return res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "";
+    case OPT_TRANS_CLAUDE:
+      return res?.content?.[0]?.text?.trim() || "";
+    default:
+      return "";
+  }
 };

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -268,9 +268,8 @@ const parseSTRes = (raw) => {
   }
 
   try {
-    // const jsonString = extractJson(raw);
-    // const data = JSON.parse(jsonString);
-    const data = parseBilingualVtt(raw);
+    const cleaned = stripMarkdownCodeBlock(raw);
+    const data = parseBilingualVtt(cleaned);
     if (Array.isArray(data)) {
       return data;
     }

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1431,6 +1431,14 @@ export const handleSummarize = async ({
       return res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "";
     case OPT_TRANS_CLAUDE:
       return res?.content?.[0]?.text?.trim() || "";
+    case OPT_TRANS_CUSTOMIZE:
+      if (typeof res === "string") return res.trim();
+      return (
+        res?.choices?.[0]?.message?.content?.trim() ||
+        res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ||
+        res?.content?.[0]?.text?.trim() ||
+        ""
+      );
     default:
       return "";
   }

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -262,13 +262,45 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
-const parseSTRes = (raw) => {
+const parseIndexSubtitleRes = (raw, events) => {
+  try {
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data) || !data.length) return null;
+
+    const result = [];
+    for (const seg of data) {
+      const s = Number(seg.s ?? seg.start_id);
+      const e = Number(seg.e ?? seg.end_id);
+      if (!Number.isInteger(s) || !Number.isInteger(e)) continue;
+
+      const startIdx = Math.max(0, Math.min(s, events.length - 1));
+      const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
+
+      result.push({
+        start: events[startIdx].start,
+        end: events[endIdx].end,
+        text: String(seg.o ?? seg.original ?? ""),
+        translation: String(seg.t ?? seg.translation ?? ""),
+      });
+    }
+
+    return result.length ? result : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseSTRes = (raw, events = null) => {
   if (!raw) {
     return [];
   }
 
   try {
     const cleaned = stripMarkdownCodeBlock(raw);
+    if (events?.length) {
+      const indexResult = parseIndexSubtitleRes(cleaned, events);
+      if (indexResult?.length) return indexResult;
+    }
     const data = parseBilingualVtt(cleaned);
     if (Array.isArray(data)) {
       return data;
@@ -853,7 +885,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
-      ? JSON.stringify(events)
+      ? JSON.stringify(events.map((e, i) => ({ id: i, text: e.text })))
       : genUserPrompt({
           nobatchUserPrompt,
           useBatchFetch,
@@ -1357,11 +1389,14 @@ export const handleSubtitle = async ({
     case OPT_TRANS_GEMINI_2:
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
-      return parseSTRes(res?.choices?.[0]?.message?.content ?? "");
+      return parseSTRes(res?.choices?.[0]?.message?.content ?? "", events);
     case OPT_TRANS_GEMINI:
-      return parseSTRes(res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "");
+      return parseSTRes(
+        res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "",
+        events
+      );
     case OPT_TRANS_CLAUDE:
-      return parseSTRes(res?.content?.[0]?.text ?? "");
+      return parseSTRes(res?.content?.[0]?.text ?? "", events);
     case OPT_TRANS_CUSTOMIZE:
       return res;
     default:

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -500,7 +500,6 @@ Group the input word-level JSON into bilingual subtitle segments. Target Languag
 2. Each element: {"s":<first_word_id>,"e":<last_word_id>,"o":"merged original text","t":"translation"}
 3. "s" and "e" are inclusive word IDs from the input.
 4. Cover all input words exactly once (no gaps, no overlaps).
-5. Keep non-speech sounds (e.g., [Music]) as is in both "o" and "t".
 
 # Rules
 1. Merge words into complete sentences, split at natural pauses into readable segments.

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -493,35 +493,22 @@ Tone: ${INPUT_PLACE_TONE}
 ${INPUT_PLACE_GLOSSARY}
 
 # Task
-Convert the input word-level timestamp JSON into a bilingual WebVTT subtitle. Target Language: ${INPUT_PLACE_TO}.
+Group the input word-level JSON into bilingual subtitle segments. Target Language: ${INPUT_PLACE_TO}.
 
 # Output Contract
-1. Output plain text only. No markdown, no code fences, no backticks.
-2. First line: WEBVTT, then a blank line.
-3. Each cue = timestamp line + exactly 2 text lines (original + ${INPUT_PLACE_TO} translation).
-4. One blank line between cues. No cue numbers.
-5. No commentary, notes, or extra text outside the VTT structure.
+1. Output a JSON array only. No markdown, no code fences, no extra text.
+2. Each element: {"s":<first_word_id>,"e":<last_word_id>,"o":"merged original text","t":"translation"}
+3. "s" and "e" are inclusive word IDs from the input.
+4. Cover all input words exactly once (no gaps, no overlaps).
+5. Keep non-speech sounds (e.g., [Music]) as is in both "o" and "t".
 
 # Rules
-1. Merge words into complete sentences, then split at natural pauses into readable cues.
-2. Timestamps: MM:SS.mmm --> MM:SS.mmm (zero-padded, convert from input milliseconds).
-3. Translate using Context and Tone. Keep non-speech sounds (e.g., [Music]) as is on both lines.
-4. Every cue MUST have exactly 2 text lines. Never skip the translation line.
+1. Merge words into complete sentences, split at natural pauses into readable segments.
+2. Translate using Context and Tone.
 
-# Correct Example
-WEBVTT
-
-00:01.000 --> 00:03.500
-Hello world!
-你好，世界！
-
-00:04.000 --> 00:06.000
-Good morning.
-早上好。
-
-00:06.200 --> 00:07.400
-[Music]
-[Music]`;
+# Example
+Input: [{"id":0,"text":"Hello"},{"id":1,"text":"world!"},{"id":2,"text":"Good"},{"id":3,"text":"morning."}]
+Output: [{"s":0,"e":1,"o":"Hello world!","t":"你好，世界！"},{"s":2,"e":3,"o":"Good morning.","t":"早上好。"}]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {
   console.log("request hook args:", { args, url, body, headers, userMsg, method });

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -493,26 +493,35 @@ Tone: ${INPUT_PLACE_TONE}
 ${INPUT_PLACE_GLOSSARY}
 
 # Task
-Convert the input word-level timestamp JSON into a bilingual VTT file. Target Language: ${INPUT_PLACE_TO}.
+Convert the input word-level timestamp JSON into a bilingual WebVTT subtitle. Target Language: ${INPUT_PLACE_TO}.
+
+# Output Contract
+1. Output plain text only. No markdown, no code fences, no backticks.
+2. First line: WEBVTT, then a blank line.
+3. Each cue = timestamp line + exactly 2 text lines (original + ${INPUT_PLACE_TO} translation).
+4. One blank line between cues. No cue numbers.
+5. No commentary, notes, or extra text outside the VTT structure.
 
 # Rules
-1. Merge words into complete sentences first.
-2. Split long sentences into readable cues (max 42 chars/line, natural pauses).
-3. Strict Glossary Adherence: Use the provided Glossary for specific terms. If a word in the source text matches a key in the glossary, you MUST use the corresponding translation provided.
-4. Translate using the provided Context and Tone. Keep non-speech sounds (e.g., [Music]) as is.
-5. Convert timestamps to standard VTT format (MM:SS.mmm).
-6. Output ONLY the raw VTT content. No markdown, no notes.
+1. Merge words into complete sentences, then split at natural pauses into readable cues.
+2. Timestamps: MM:SS.mmm --> MM:SS.mmm (zero-padded, convert from input milliseconds).
+3. Translate using Context and Tone. Keep non-speech sounds (e.g., [Music]) as is on both lines.
+4. Every cue MUST have exactly 2 text lines. Never skip the translation line.
 
-# VTT Format Example
+# Correct Example
 WEBVTT
 
-1000 --> 3500
+00:01.000 --> 00:03.500
 Hello world!
 你好，世界！
 
-4000 --> 6000
+00:04.000 --> 00:06.000
 Good morning.
-早上好。`;
+早上好。
+
+00:06.200 --> 00:07.400
+[Music]
+[Music]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {
   console.log("request hook args:", { args, url, body, headers, userMsg, method });

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2437,6 +2437,20 @@ export const I18N = {
     ja: `AIによるインテリジェントな文分割`,
     ko: `AI 지능형 문장 분리`,
   },
+  ai_enhanced_context: {
+    zh: `增强智能上下文`,
+    en: `Enhanced Intelligent Context`,
+    zh_TW: `增強智慧上下文`,
+    ja: `強化インテリジェントコンテキスト`,
+    ko: `강화 지능형 컨텍스트`,
+  },
+  ai_context_analyzing: {
+    zh: `AI正在分析视频内容...`,
+    en: `AI is analyzing video content...`,
+    zh_TW: `AI正在分析影片內容...`,
+    ja: `AIが動画内容を分析中...`,
+    ko: `AI가 비디오 콘텐츠를 분석 중...`,
+  },
   ai_chunk_length: {
     zh: `AI处理切割长度(200-20000)`,
     en: `AI processing chunk length(200-20000)`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -135,6 +135,7 @@ export const DEFAULT_SUBTITLE_SETTING = {
   translationStyle: SUBTITLE_TRANSLATION_STYLE, // 译文样式
   enhanceMode: OPT_ENHANCE_MOBILE_OFF, // 增强功能：on/off/mobile_off
   showList: true, // 是否显示滚动字幕
+  aiContextSlug: "-", // 增强智能上下文分析服务
 };
 
 // 订阅列表

--- a/src/config/url.js
+++ b/src/config/url.js
@@ -4,6 +4,7 @@ export const URL_CACHE_TRAN = `https://${APP_LCNAME}/translate`;
 export const URL_CACHE_SUBTITLE = `https://${APP_LCNAME}/subtitle`;
 export const URL_CACHE_DELANG = `https://${APP_LCNAME}/detectlang`;
 export const URL_CACHE_BINGDICT = `https://${APP_LCNAME}/bingdict`;
+export const URL_CACHE_CONTEXT = `https://${APP_LCNAME}/context`;
 
 export const URL_KISS_WORKER = "https://github.com/fishjar/kiss-worker";
 export const URL_KISS_PROXY = "https://github.com/fishjar/kiss-proxy";

--- a/src/injectors/xmlhttp.js
+++ b/src/injectors/xmlhttp.js
@@ -1,21 +1,41 @@
 export const XMLHttpRequestInjector = () => {
   try {
+    const emitTimedtext = (url, response) => {
+      if (url && typeof response === "string") {
+        window.postMessage(
+          { type: "KISS_XHR_DATA_YOUTUBE", url, response },
+          window.location.origin
+        );
+      }
+    };
+
     const originalOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (...args) {
       const url = args[1];
       if (typeof url === "string" && url.includes("timedtext")) {
         this.addEventListener("load", function () {
-          window.postMessage(
-            {
-              type: "KISS_XHR_DATA_YOUTUBE",
-              url: this.responseURL,
-              response: this.responseText,
-            },
-            window.location.origin
-          );
+          emitTimedtext(this.responseURL, this.responseText);
         });
       }
       return originalOpen.apply(this, args);
+    };
+
+    const originalFetch = window.fetch;
+    window.fetch = async function (...args) {
+      const response = await originalFetch.apply(this, args);
+      try {
+        const input = args[0];
+        const inputUrl = typeof input === "string" ? input : input?.url || "";
+        const responseUrl = response?.url || inputUrl;
+        if (responseUrl.includes("timedtext")) {
+          response
+            .clone()
+            .text()
+            .then((text) => emitTimedtext(responseUrl, text))
+            .catch(() => {});
+        }
+      } catch (_) {}
+      return response;
     };
   } catch (err) {
     console.log("XMLHttpRequestInjector", err);

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -92,8 +92,13 @@ export function getStreamDelta(json, apiType) {
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
       return json.choices?.[0]?.delta?.content || "";
-    case OPT_TRANS_GEMINI:
-      return json.candidates?.[0]?.content?.parts?.[0]?.text || "";
+    case OPT_TRANS_GEMINI: {
+      const parts = json.candidates?.[0]?.content?.parts;
+      return (
+        (Array.isArray(parts) ? parts.find((p) => !p.thought) : undefined)
+          ?.text || ""
+      );
+    }
     case OPT_TRANS_CLAUDE:
       if (json.type === "content_block_delta") {
         return json.delta?.text || "";

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -743,12 +743,13 @@ export class BilingualSubtitleManager {
   async #translateAndStore(subtitle) {
     subtitle.isTranslating = true;
     try {
-      const { fromLang, toLang, apiSetting } = this.#setting;
+      const { fromLang, toLang, apiSetting, docInfo } = this.#setting;
       const { trText } = await apiTranslate({
         text: subtitle.text,
         fromLang,
         toLang,
         apiSetting,
+        docInfo,
       });
       subtitle.translation = trText;
     } catch (error) {

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -126,6 +126,7 @@ export class BilingualSubtitleManager {
   #throttledTriggerTranslations;
   #tooltipEl = null;
   #hoverTimeout = null; // 用于延迟显示/隐藏tooltip
+  #seekSyncRafId = null;
   #translationSessionId = 0;
   #abortController = null;
   #wasPlayingBeforeHover = false; //记录hover单词前视频是否处于播放状态
@@ -144,6 +145,7 @@ export class BilingualSubtitleManager {
     this.#abortController = new AbortController();
 
     this.onTimeUpdate = this.onTimeUpdate.bind(this);
+    this.onSeeking = this.onSeeking.bind(this);
     this.onSeek = this.onSeek.bind(this);
 
     this.#throttledTriggerTranslations = throttle(
@@ -187,6 +189,10 @@ export class BilingualSubtitleManager {
     this.onSubtitleUpdate = null;
     this.#removeEventListeners();
     this.#throttledTriggerTranslations?.cancel();
+    if (this.#seekSyncRafId !== null) {
+      cancelAnimationFrame(this.#seekSyncRafId);
+      this.#seekSyncRafId = null;
+    }
     this.#captionWindowEl?.parentElement?.parentElement?.remove();
     this.#formattedSubtitles = [];
     // 清理tooltip元素
@@ -610,6 +616,7 @@ export class BilingualSubtitleManager {
    */
   #attachEventListeners() {
     this.#videoEl.addEventListener("timeupdate", this.onTimeUpdate);
+    this.#videoEl.addEventListener("seeking", this.onSeeking);
     this.#videoEl.addEventListener("seeked", this.onSeek);
   }
 
@@ -618,6 +625,7 @@ export class BilingualSubtitleManager {
    */
   #removeEventListeners() {
     this.#videoEl.removeEventListener("timeupdate", this.onTimeUpdate);
+    this.#videoEl.removeEventListener("seeking", this.onSeeking);
     this.#videoEl.removeEventListener("seeked", this.onSeek);
   }
 
@@ -625,26 +633,53 @@ export class BilingualSubtitleManager {
    * 视频播放时间更新时的回调，负责更新字幕和触发预翻译。
    */
   onTimeUpdate() {
-    const currentTimeMs = this.#videoEl.currentTime * 1000;
-    const subtitleIndex = this.#findSubtitleIndexForTime(currentTimeMs);
+    this.#syncToCurrentTime();
+  }
 
-    if (subtitleIndex !== this.#currentSubtitleIndex) {
-      this.#currentSubtitleIndex = subtitleIndex;
-      const subtitle =
-        subtitleIndex !== -1 ? this.#formattedSubtitles[subtitleIndex] : null;
-      this.#updateCaptionDisplay(subtitle);
-    }
-
-    this.#throttledTriggerTranslations(currentTimeMs);
+  /**
+   * 用户正在拖动进度条时的回调。
+   */
+  onSeeking() {
+    this.#throttledTriggerTranslations.cancel();
+    this.#syncToCurrentTime({ forceRender: true, triggerTranslations: false });
   }
 
   /**
    * 用户拖动进度条后的回调。
    */
   onSeek() {
-    this.#currentSubtitleIndex = -1;
     this.#throttledTriggerTranslations.cancel();
-    this.onTimeUpdate();
+    this.#syncToCurrentTime({ forceRender: true });
+    this.#scheduleSeekSettledSync();
+  }
+
+  #scheduleSeekSettledSync() {
+    if (typeof requestAnimationFrame !== "function") return;
+    if (this.#seekSyncRafId !== null) {
+      cancelAnimationFrame(this.#seekSyncRafId);
+    }
+    this.#seekSyncRafId = requestAnimationFrame(() => {
+      this.#seekSyncRafId = requestAnimationFrame(() => {
+        this.#seekSyncRafId = null;
+        this.#syncToCurrentTime({ forceRender: true });
+      });
+    });
+  }
+
+  #syncToCurrentTime({ forceRender = false, triggerTranslations = true } = {}) {
+    const currentTimeMs = this.#videoEl.currentTime * 1000;
+    const subtitleIndex = this.#findSubtitleIndexForTime(currentTimeMs);
+
+    if (forceRender || subtitleIndex !== this.#currentSubtitleIndex) {
+      this.#currentSubtitleIndex = subtitleIndex;
+      this.#updateCaptionDisplay(
+        subtitleIndex !== -1 ? this.#formattedSubtitles[subtitleIndex] : null
+      );
+    }
+
+    if (triggerTranslations) {
+      this.#throttledTriggerTranslations(currentTimeMs);
+    }
   }
 
   /**
@@ -653,9 +688,20 @@ export class BilingualSubtitleManager {
    * @returns {number} 找到的字幕索引，-1 表示没找到。
    */
   #findSubtitleIndexForTime(currentTimeMs) {
-    return this.#formattedSubtitles.findIndex(
-      (sub) => currentTimeMs >= sub.start && currentTimeMs <= sub.end
-    );
+    const subs = this.#formattedSubtitles;
+    let lo = 0,
+      hi = subs.length - 1,
+      result = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      if (subs[mid].start <= currentTimeMs) {
+        result = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return result !== -1 && currentTimeMs <= subs[result].end ? result : -1;
   }
 
   /**
@@ -729,15 +775,26 @@ export class BilingualSubtitleManager {
    */
   #triggerTranslations(currentTimeMs) {
     const { preTrans = 90 } = this.#setting;
-    const lookAheadMs = preTrans * 1000;
+    const endTimeMs = currentTimeMs + preTrans * 1000;
+    const subs = this.#formattedSubtitles;
 
-    for (const sub of this.#formattedSubtitles) {
-      const isCurrent = sub.start <= currentTimeMs && sub.end >= currentTimeMs;
-      const isUpcoming =
-        sub.start > currentTimeMs && sub.start <= currentTimeMs + lookAheadMs;
-      const needsTranslation = !sub.translation && !sub.isTranslating;
+    let lo = 0,
+      hi = subs.length - 1,
+      startIdx = subs.length;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      if (subs[mid].end >= currentTimeMs) {
+        startIdx = mid;
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
 
-      if ((isCurrent || isUpcoming) && needsTranslation) {
+    for (let i = startIdx; i < subs.length; i++) {
+      const sub = subs[i];
+      if (sub.start > endTimeMs) break;
+      if (!sub.translation && !sub.isTranslating) {
         this.#translateAndStore(sub);
       }
     }
@@ -820,12 +877,7 @@ export class BilingualSubtitleManager {
   // 获取当前字幕的开始时间（使用重新分段后的时间）
   #getCurrentSubtitleStartTime() {
     const currentTimeMs = this.#videoEl.currentTime * 1000;
-    // 查找当前时间对应的字幕
-    const currentSubtitle = this.#formattedSubtitles.find(
-      (sub) => currentTimeMs >= sub.start && currentTimeMs <= sub.end
-    );
-
-    // 返回重新分段后的字幕开始时间，如果没有找到则返回当前时间
-    return currentSubtitle ? currentSubtitle.start : currentTimeMs;
+    const idx = this.#findSubtitleIndexForTime(currentTimeMs);
+    return idx !== -1 ? this.#formattedSubtitles[idx].start : currentTimeMs;
   }
 }

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -126,6 +126,8 @@ export class BilingualSubtitleManager {
   #throttledTriggerTranslations;
   #tooltipEl = null;
   #hoverTimeout = null; // 用于延迟显示/隐藏tooltip
+  #translationSessionId = 0;
+  #abortController = null;
   #wasPlayingBeforeHover = false; //记录hover单词前视频是否处于播放状态
   #hoverTarget = null;
 
@@ -139,6 +141,7 @@ export class BilingualSubtitleManager {
     this.#setting = setting;
     this.#videoEl = videoEl;
     this.#formattedSubtitles = formattedSubtitles;
+    this.#abortController = new AbortController();
 
     this.onTimeUpdate = this.onTimeUpdate.bind(this);
     this.onSeek = this.onSeek.bind(this);
@@ -178,6 +181,10 @@ export class BilingualSubtitleManager {
    */
   destroy() {
     logger.info("Bilingual Subtitle Manager: Destroying...");
+    this.#translationSessionId += 1;
+    this.#abortController?.abort();
+    this.#abortController = null;
+    this.onSubtitleUpdate = null;
     this.#removeEventListeners();
     this.#throttledTriggerTranslations?.cancel();
     this.#captionWindowEl?.parentElement?.parentElement?.remove();
@@ -741,6 +748,10 @@ export class BilingualSubtitleManager {
    * @param {object} subtitle - 需要翻译的字幕对象。
    */
   async #translateAndStore(subtitle) {
+    const sessionId = this.#translationSessionId;
+    const signal = this.#abortController?.signal;
+    if (signal?.aborted) return;
+
     subtitle.isTranslating = true;
     try {
       const { fromLang, toLang, apiSetting, docInfo } = this.#setting;
@@ -750,12 +761,17 @@ export class BilingualSubtitleManager {
         toLang,
         apiSetting,
         docInfo,
+        signal,
       });
+      if (sessionId !== this.#translationSessionId) return;
       subtitle.translation = trText;
     } catch (error) {
+      if (sessionId !== this.#translationSessionId) return;
+      if (error?.name === "AbortError") return;
       logger.info("Translation failed for:", subtitle.text, error);
       subtitle.translation = "[Translation failed]";
     } finally {
+      if (sessionId !== this.#translationSessionId) return;
       subtitle.isTranslating = false;
 
       const currentSubtitleIndexNow = this.#findSubtitleIndexForTime(

--- a/src/subtitle/Menus.js
+++ b/src/subtitle/Menus.js
@@ -211,13 +211,22 @@ export function Menus({
     return options;
   }, [aiEnabledApis, i18n]);
 
+  // 构建上下文分析服务选项
+  const aiContextOptions = useMemo(() => {
+    const options = [{ value: "-", label: i18n("disable") || "禁用" }];
+    aiEnabledApis.forEach((api) => {
+      options.push({ value: api.apiSlug, label: api.apiName });
+    });
+    return options;
+  }, [aiEnabledApis, i18n]);
+
   const status = useMemo(() => {
     if (progressed === 0) return i18n("waiting_subtitles");
     if (progressed === 100) return i18n("download_subtitles");
     return i18n("processing_subtitles");
   }, [progressed, i18n]);
 
-  const { segSlug, skipAd, isBilingual, showOrigin } = formData;
+  const { segSlug, skipAd, isBilingual, showOrigin, aiContextSlug } = formData;
 
   return (
     <div
@@ -240,6 +249,14 @@ export function Menus({
         options={segOptions}
         label={i18n("ai_segmentation")}
         disabled={segOptions.length <= 1}
+      />
+      <Select
+        onChange={handleChange}
+        name="aiContextSlug"
+        value={aiContextSlug || "-"}
+        options={aiContextOptions}
+        label={i18n("ai_enhanced_context")}
+        disabled={aiContextOptions.length <= 1}
       />
       <Switch
         onChange={handleChange}

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -1,5 +1,5 @@
 import { logger } from "../libs/log.js";
-import { apiSubtitle } from "../apis/index.js";
+import { apiSubtitle, apiSummarizeContext } from "../apis/index.js";
 import { BilingualSubtitleManager } from "./BilingualSubtitleManager.js";
 import { YouTubeSubtitleList } from "./YouTubeSubtitleList.js";
 import {
@@ -10,6 +10,7 @@ import {
   OPT_LANGS_SPEC_DEFAULT,
   OPT_ENHANCE_ON,
   OPT_ENHANCE_MOBILE_OFF,
+  API_SPE_TYPES,
 } from "../config";
 import { sleep, downloadBlobFile } from "../libs/utils.js";
 import { createLogoSVG } from "../libs/svg.js";
@@ -36,6 +37,7 @@ class YouTubeCaptionProvider {
   #progressedNum = 0;
   #fromLang = "auto";
   #docInfo = {};
+  #fullDescription = "";
 
   #processingId = null;
 
@@ -94,6 +96,7 @@ class YouTubeCaptionProvider {
       this.#progressed = 0;
       this.#fromLang = "auto";
       this.#docInfo = {};
+      this.#fullDescription = "";
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -214,6 +217,8 @@ class YouTubeCaptionProvider {
       this.#reProcessEvents();
     } else if (name === "showOrigin") {
       this.#toggleShowOrigin();
+    } else if (name === "aiContextSlug") {
+      this.#reProcessEventsWithContext();
     }
   }
 
@@ -247,8 +252,14 @@ class YouTubeCaptionProvider {
    * @private
    */
   #getMenuProps() {
-    const { transApis, segSlug, skipAd, isBilingual, showOrigin } =
-      this.#setting;
+    const {
+      transApis,
+      segSlug,
+      skipAd,
+      isBilingual,
+      showOrigin,
+      aiContextSlug,
+    } = this.#setting;
     return {
       i18n: this.#i18n,
       updateSetting: this.updateSetting.bind(this),
@@ -260,6 +271,7 @@ class YouTubeCaptionProvider {
         skipAd,
         isBilingual,
         showOrigin,
+        aiContextSlug,
       },
     };
   }
@@ -360,11 +372,16 @@ class YouTubeCaptionProvider {
       const url = `https://www.youtube.com/watch?v=${videoId}`;
       const html = await fetch(url).then((r) => r.text());
       const match = html.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/s);
-      if (!match) return [];
+      if (!match) return {};
       const data = JSON.parse(match[1]);
-      return data.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+      return {
+        captionTracks:
+          data.captions?.playerCaptionsTracklistRenderer?.captionTracks,
+        fullDescription: data.videoDetails?.shortDescription || "",
+      };
     } catch (err) {
       logger.info("Youtube Provider: get captionTracks", err);
+      return {};
     }
   }
 
@@ -488,7 +505,9 @@ class YouTubeCaptionProvider {
       this.#showNotification(this.#i18n("starting_to_process_subtitle"));
 
       const { toLang } = this.#setting;
-      const captionTracks = await this.#getCaptionTracks(videoId);
+      const { captionTracks, fullDescription } =
+        await this.#getCaptionTracks(videoId);
+      this.#fullDescription = fullDescription || "";
       const captionTrack = this.#findCaptionTrack(captionTracks, lang);
       if (!captionTrack) {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
@@ -525,6 +544,7 @@ class YouTubeCaptionProvider {
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
       this.#docInfo = getDocInfo();
+      await this.#enrichDocInfoWithAI(flatEvents);
 
       this.#processEvents({
         videoId,
@@ -589,6 +609,58 @@ class YouTubeCaptionProvider {
     this.#destroyManager();
 
     this.#processEvents({ videoId, flatEvents, fromLang });
+  }
+
+  async #enrichDocInfoWithAI(flatEvents) {
+    const { aiContextSlug, transApis } = this.#setting;
+
+    if (!aiContextSlug || aiContextSlug === "-") return;
+
+    const contextApiSetting = transApis?.find(
+      (api) => api.apiSlug === aiContextSlug
+    );
+    if (!contextApiSetting) return;
+    if (!API_SPE_TYPES.ai.has(contextApiSetting.apiType)) return;
+
+    const transcript = flatEvents
+      .map((e) => e.text)
+      .filter(Boolean)
+      .join(" ")
+      .slice(0, 8000);
+
+    if (transcript.length < 200) return;
+
+    try {
+      this.#showNotification(this.#i18n("ai_context_analyzing"));
+
+      const summary = await apiSummarizeContext({
+        videoId: this.#videoId,
+        title: this.#docInfo.title,
+        description: this.#fullDescription || this.#docInfo.description,
+        transcript,
+        apiSetting: contextApiSetting,
+      });
+
+      if (summary) {
+        this.#docInfo.summary = summary;
+      }
+    } catch (err) {
+      logger.info("Youtube Provider: AI context enrichment failed", err);
+    }
+  }
+
+  async #reProcessEventsWithContext() {
+    this.#progressed = 0;
+    this.#subtitles = [];
+
+    const videoId = this.#videoId;
+    const flatEvents = this.#flatEvents;
+    if (!videoId || !flatEvents.length) return;
+
+    this.#destroyManager();
+    this.#docInfo = getDocInfo();
+    await this.#enrichDocInfoWithAI(flatEvents);
+    this.#processEvents({ videoId, flatEvents, fromLang: this.#fromLang });
   }
 
   async #eventsToSubtitles({ videoId, flatEvents, fromLang }) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -19,6 +19,7 @@ import DomManager from "../libs/domManager.js";
 import { Menus } from "./Menus.js";
 import { buildBilingualVtt } from "./vtt.js";
 import { isMobile } from "../libs/mobile.js";
+import { getDocInfo } from "../libs/docInfo.js";
 
 const VIDEO_SELECT = "#container video";
 const CONTORLS_SELECT = ".ytp-right-controls";
@@ -34,6 +35,7 @@ class YouTubeCaptionProvider {
   #flatEvents = [];
   #progressedNum = 0;
   #fromLang = "auto";
+  #docInfo = {};
 
   #processingId = null;
 
@@ -91,6 +93,7 @@ class YouTubeCaptionProvider {
       this.#flatEvents = [];
       this.#progressed = 0;
       this.#fromLang = "auto";
+      this.#docInfo = {};
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -424,6 +427,7 @@ class YouTubeCaptionProvider {
         toLang,
         events,
         apiSetting: segApiSetting,
+        docInfo: this.#docInfo,
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
       if (Array.isArray(subtitles)) {
@@ -520,6 +524,7 @@ class YouTubeCaptionProvider {
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
+      this.#docInfo = getDocInfo();
 
       this.#processEvents({
         videoId,
@@ -667,7 +672,11 @@ class YouTubeCaptionProvider {
     this.#managerInstance = new BilingualSubtitleManager({
       videoEl,
       formattedSubtitles: this.#subtitles,
-      setting: { ...this.#setting, fromLang: this.#fromLang },
+      setting: {
+        ...this.#setting,
+        fromLang: this.#fromLang,
+        docInfo: this.#docInfo,
+      },
     });
 
     // todo 移到菜单切换

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -38,6 +38,7 @@ class YouTubeCaptionProvider {
   #fromLang = "auto";
   #docInfo = {};
   #fullDescription = "";
+  #selectedCaptionTrack = null;
 
   #processingId = null;
 
@@ -97,6 +98,7 @@ class YouTubeCaptionProvider {
       this.#fromLang = "auto";
       this.#docInfo = {};
       this.#fullDescription = "";
+      this.#selectedCaptionTrack = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -344,8 +346,11 @@ class YouTubeCaptionProvider {
       return null;
     }
 
-    // 优先返回用户选择的字幕轨
-    let captionTrack = captionTracks.find((item) => item.languageCode === lang);
+    // 优先返回用户选择的字幕轨，同语言下优先手动字幕
+    let captionTrack =
+      captionTracks.find(
+        (item) => item.languageCode === lang && item.kind !== "asr"
+      ) || captionTracks.find((item) => item.languageCode === lang);
     if (!captionTrack) {
       const asrTrack = captionTracks.find((item) => item.kind === "asr");
       if (asrTrack) {
@@ -517,6 +522,7 @@ class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
+      this.#selectedCaptionTrack = captionTrack;
 
       const capUrl = new URL(captionTrack.baseUrl);
       const events = await this.#getSubtitleEvents(
@@ -681,9 +687,10 @@ class YouTubeCaptionProvider {
     // 根据segSlug从transApis中查找对应的API设置
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
 
-    // potUrl.searchParams.get("kind") === "asr"
-    // 当segSlug不为"-"且segApiSetting存在时，启用AI断句
-    if (segSlug && segSlug !== "-" && segApiSetting) {
+    const isAutoCaption = this.#selectedCaptionTrack?.kind === "asr";
+
+    // 仅自动字幕(kind=asr)启用AI断句，人工字幕直接使用原字幕分段
+    if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
       logger.info("Youtube Provider: Starting AI ...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
 
@@ -722,6 +729,12 @@ class YouTubeCaptionProvider {
       } else {
         return [firstBatchSubtitles, 100];
       }
+    }
+
+    if (!isAutoCaption && segSlug && segSlug !== "-") {
+      logger.info(
+        "Youtube Provider: Skipping AI segmentation for manual captions."
+      );
     }
 
     return subtitlesFallback();

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -819,10 +819,9 @@ class YouTubeCaptionProvider {
       }
     }
 
-    if (!isAutoCaption && segSlug && segSlug !== "-") {
-      logger.info(
-        "Youtube Provider: Skipping AI segmentation for manual captions."
-      );
+    if (!isAutoCaption) {
+      // 人工字幕已是句级分段，直接使用无需合并
+      return [flatEvents.filter((e) => e.text), 100];
     }
 
     return subtitlesFallback();
@@ -1159,7 +1158,10 @@ class YouTubeCaptionProvider {
 
     events.forEach(({ segs = [], tStartMs = 0, dDurationMs = 0 }) => {
       segs.forEach(({ utf8 = "", tOffsetMs = 0 }, j) => {
-        const text = utf8.trim().replace(/\s+/g, " ");
+        const text = utf8
+          .replace(/<[^>]+>/g, "")
+          .trim()
+          .replace(/\s+/g, " ");
         const start = tStartMs + tOffsetMs;
 
         if (buffer) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -460,6 +460,8 @@ class YouTubeCaptionProvider {
   async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
     try {
       const events = chunkEvents.filter((item) => item.text);
+      if (!events.length) return [];
+
       const chunkSign = `${events[0].start} --> ${events[events.length - 1].end}`;
       logger.debug("Youtube Provider: aiSegment events", {
         videoId,
@@ -1006,6 +1008,7 @@ class YouTubeCaptionProvider {
     usePause = false,
     timeout = 1000,
     maxWords = 15,
+    maxDurationMs = 10000,
   } = {}) {
     const groupedPauseWords = {
       1: new Set([
@@ -1116,6 +1119,8 @@ class YouTubeCaptionProvider {
         const isEndOfSentence = /[.?!…\])]$/.test(lastSegment.text);
         const isPauseOfSentence = /[,]$/.test(lastSegment.text);
         const isTimeout = segment.start - lastSegment.end > timeout;
+        const isDurationExceeded =
+          segment.start - currentBuffer[0].start >= maxDurationMs;
         const isWordLimitExceeded =
           (usePause || isPauseOfSentence) && bufferWordCount >= maxWords;
 
@@ -1130,6 +1135,7 @@ class YouTubeCaptionProvider {
         if (
           isEndOfSentence ||
           isTimeout ||
+          isDurationExceeded ||
           isWordLimitExceeded ||
           startsWithSign ||
           startsWithPauseWord
@@ -1175,9 +1181,13 @@ class YouTubeCaptionProvider {
       });
     });
 
-    segments.push(buffer);
+    if (buffer) {
+      segments.push(buffer);
+    }
 
-    return segments;
+    return segments.filter(
+      (s) => s && typeof s.start === "number" && s.end > s.start
+    );
   }
 
   #splitEventsIntoChunks(flatEvents, chunkLength = 1000) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -38,7 +38,7 @@ class YouTubeCaptionProvider {
   #fromLang = "auto";
   #docInfo = {};
   #fullDescription = "";
-  #selectedCaptionTrack = null;
+  #interceptedCaptionKind = null;
 
   #processingId = null;
 
@@ -98,7 +98,7 @@ class YouTubeCaptionProvider {
       this.#fromLang = "auto";
       this.#docInfo = {};
       this.#fullDescription = "";
-      this.#selectedCaptionTrack = null;
+      this.#interceptedCaptionKind = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -336,21 +336,25 @@ class YouTubeCaptionProvider {
   }
 
   // todo: 优化逻辑
-  #findCaptionTrack(captionTracks, lang) {
+  #findCaptionTrack(captionTracks, lang, kind) {
     logger.debug("Youtube Provider: find caption track", {
       captionTracks,
       lang,
+      kind,
     });
 
     if (!captionTracks?.length) {
       return null;
     }
 
-    // 优先返回用户选择的字幕轨，同语言下优先手动字幕
-    let captionTrack =
-      captionTracks.find(
-        (item) => item.languageCode === lang && item.kind !== "asr"
-      ) || captionTracks.find((item) => item.languageCode === lang);
+    // 优先匹配用户选择的字幕轨（语言+kind完全一致）
+    let captionTrack = captionTracks.find(
+      (item) =>
+        item.languageCode === lang && (item.kind || null) === (kind || null)
+    );
+    if (!captionTrack) {
+      captionTrack = captionTracks.find((item) => item.languageCode === lang);
+    }
     if (!captionTrack) {
       const asrTrack = captionTracks.find((item) => item.kind === "asr");
       if (asrTrack) {
@@ -494,9 +498,13 @@ class YouTubeCaptionProvider {
     }
 
     const lang = potUrl.searchParams.get("lang");
+    const interceptedKind = potUrl.searchParams.get("kind") || null;
     const fromLang = this.#getFromLang(lang);
     if (this.#flatEvents.length) {
-      if (this.#isSameLang(lang, this.#fromLang)) {
+      if (
+        this.#isSameLang(lang, this.#fromLang) &&
+        interceptedKind === this.#interceptedCaptionKind
+      ) {
         logger.debug("Youtube Provider: video was processed:", videoId);
         return;
       }
@@ -517,12 +525,15 @@ class YouTubeCaptionProvider {
       const { captionTracks, fullDescription } =
         await this.#getCaptionTracks(videoId);
       this.#fullDescription = fullDescription || "";
-      const captionTrack = this.#findCaptionTrack(captionTracks, lang);
+      const captionTrack = this.#findCaptionTrack(
+        captionTracks,
+        lang,
+        interceptedKind
+      );
       if (!captionTrack) {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
-      this.#selectedCaptionTrack = captionTrack;
 
       const capUrl = new URL(captionTrack.baseUrl);
       const events = await this.#getSubtitleEvents(
@@ -553,6 +564,7 @@ class YouTubeCaptionProvider {
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
+      this.#interceptedCaptionKind = interceptedKind;
       this.#docInfo = getDocInfo();
       await this.#enrichDocInfoWithAI(flatEvents);
 
@@ -687,7 +699,7 @@ class YouTubeCaptionProvider {
     // 根据segSlug从transApis中查找对应的API设置
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
 
-    const isAutoCaption = this.#selectedCaptionTrack?.kind === "asr";
+    const isAutoCaption = this.#interceptedCaptionKind === "asr";
 
     // 仅自动字幕(kind=asr)启用AI断句，人工字幕直接使用原字幕分段
     if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -448,6 +448,10 @@ class YouTubeCaptionProvider {
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
       if (Array.isArray(subtitles)) {
+        // 断句服务和翻译服务不同时，清除断句的翻译，由翻译服务重新翻译
+        if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
+          return subtitles.map((sub) => ({ ...sub, translation: "" }));
+        }
         return subtitles;
       }
     } catch (err) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -634,19 +634,23 @@ class YouTubeCaptionProvider {
 
     if (transcript.length < 200) return;
 
+    // 捕获快照，防止切换视频时旧结果污染新docInfo
+    const videoId = this.#videoId;
+    const docInfo = this.#docInfo;
+
     try {
       this.#showNotification(this.#i18n("ai_context_analyzing"));
 
       const summary = await apiSummarizeContext({
-        videoId: this.#videoId,
-        title: this.#docInfo.title,
-        description: this.#fullDescription || this.#docInfo.description,
+        videoId,
+        title: docInfo.title,
+        description: this.#fullDescription || docInfo.description,
         transcript,
         apiSetting: contextApiSetting,
       });
 
-      if (summary) {
-        this.#docInfo.summary = summary;
+      if (summary && videoId === this.#videoId) {
+        docInfo.summary = summary;
       }
     } catch (err) {
       logger.info("Youtube Provider: AI context enrichment failed", err);

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -457,7 +457,31 @@ class YouTubeCaptionProvider {
     }
   }
 
-  async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
+  #getChunkContext(chunks, chunkIndex, side, maxEvents = 3, maxChars = 240) {
+    const NON_SPEECH_RE = /^\[.+\]$/i;
+    const adj =
+      side === "prev" ? chunks[chunkIndex - 1] : chunks[chunkIndex + 1];
+    if (!adj?.length) return "";
+    const picked =
+      side === "prev" ? adj.slice(-maxEvents) : adj.slice(0, maxEvents);
+    return picked
+      .map((e) => String(e?.text ?? "").trim())
+      .filter((t) => t && !NON_SPEECH_RE.test(t))
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, maxChars);
+  }
+
+  async #aiSegment({
+    videoId,
+    fromLang,
+    toLang,
+    chunkEvents,
+    segApiSetting,
+    prevContext = "",
+    nextContext = "",
+  }) {
     const NON_SPEECH_RE = /^\[.+\]$/i;
     const speechEvents = [];
     const nonSpeechEvents = [];
@@ -497,12 +521,53 @@ class YouTubeCaptionProvider {
         events: speechEvents,
         apiSetting: segApiSetting,
         docInfo: this.#docInfo,
+        prevContext,
+        nextContext,
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
-      if (Array.isArray(subtitles)) {
+      if (Array.isArray(subtitles) && subtitles.length) {
         let result = subtitles;
         if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
           result = subtitles.map((sub) => ({ ...sub, translation: "" }));
+        }
+
+        // 截断重试：检测 AI 是否覆盖了全部 speechEvents
+        const maxEi = Math.max(...result.map((s) => s._ei ?? -1));
+        if (maxEi >= 0 && maxEi < speechEvents.length - 1) {
+          const tailEvents = speechEvents.slice(maxEi + 1);
+          // 仅当尾部不超过原始的 50% 时重试（否则视为整体失败）
+          if (tailEvents.length <= speechEvents.length * 0.5) {
+            try {
+              const tailSign = `${tailEvents[0].start} --> ${tailEvents[tailEvents.length - 1].end}`;
+              const lastResultText = result[result.length - 1]?.text || "";
+              const tailSubs = await apiSubtitle({
+                videoId,
+                chunkSign: tailSign,
+                fromLang,
+                toLang,
+                events: tailEvents,
+                apiSetting: segApiSetting,
+                docInfo: this.#docInfo,
+                prevContext: [prevContext, lastResultText]
+                  .filter(Boolean)
+                  .join(" "),
+                nextContext,
+              });
+              if (tailSubs?.length) {
+                result = [...result, ...tailSubs];
+              } else {
+                result = [
+                  ...result,
+                  ...this.#formatSubtitles(tailEvents, fromLang),
+                ];
+              }
+            } catch {
+              result = [
+                ...result,
+                ...this.#formatSubtitles(tailEvents, fromLang),
+              ];
+            }
+          }
         }
 
         // 仅保留落在语音字幕间隙中的非语音条目，丢弃与语音重叠的
@@ -821,6 +886,8 @@ class YouTubeCaptionProvider {
         fromLang,
         toLang,
         segApiSetting,
+        prevContext: "",
+        nextContext: this.#getChunkContext(eventChunks, 0, "next"),
       });
       if (this.#isStaleProcessing(processingVersion)) return [[], 0];
 
@@ -829,9 +896,9 @@ class YouTubeCaptionProvider {
       }
 
       if (eventChunks.length > 1) {
-        const remainingChunks = eventChunks.slice(1);
         this.#processRemainingChunksAsync({
-          chunks: remainingChunks,
+          chunks: eventChunks,
+          startIndex: 1,
           videoId,
           fromLang,
           toLang,
@@ -1270,24 +1337,27 @@ class YouTubeCaptionProvider {
 
   async #processRemainingChunksAsync({
     chunks,
+    startIndex = 0,
     videoId,
     fromLang,
     toLang,
     segApiSetting,
     processingVersion,
   }) {
-    logger.info(`Youtube Provider: Starting for ${chunks.length} chunks.`);
+    logger.info(
+      `Youtube Provider: Starting async from chunk ${startIndex + 1}/${chunks.length}.`
+    );
 
-    for (let i = 0; i < chunks.length; i++) {
+    for (let i = startIndex; i < chunks.length; i++) {
       if (this.#isStaleProcessing(processingVersion)) {
         logger.info("Youtube Provider: Skip stale chunk processing.");
         break;
       }
 
       const chunkEvents = chunks[i];
-      const chunkNum = i + 2;
+      const chunkNum = i + 1;
       logger.debug(
-        `Youtube Provider: Processing subtitle chunk ${chunkNum}/${chunks.length + 1}: ${chunkEvents[0]?.start} --> ${chunkEvents[chunkEvents.length - 1]?.start}`
+        `Youtube Provider: Processing subtitle chunk ${chunkNum}/${chunks.length}: ${chunkEvents[0]?.start} --> ${chunkEvents[chunkEvents.length - 1]?.start}`
       );
 
       let subtitlesForThisChunk = [];
@@ -1299,6 +1369,8 @@ class YouTubeCaptionProvider {
           fromLang,
           toLang,
           segApiSetting,
+          prevContext: this.#getChunkContext(chunks, i, "prev"),
+          nextContext: this.#getChunkContext(chunks, i, "next"),
         });
         if (this.#isStaleProcessing(processingVersion)) break;
 
@@ -1327,7 +1399,7 @@ class YouTubeCaptionProvider {
       }
 
       if (subtitlesForThisChunk.length > 0) {
-        const progressed = Math.floor((chunkNum * 100) / (chunks.length + 1));
+        const progressed = Math.floor((chunkNum * 100) / chunks.length);
         this.#subtitles.push(...subtitlesForThisChunk);
         this.#subtitles.sort((a, b) => a.start - b.start);
         this.#progressed = progressed;

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -21,6 +21,7 @@ import { Menus } from "./Menus.js";
 import { buildBilingualVtt } from "./vtt.js";
 import { isMobile } from "../libs/mobile.js";
 import { getDocInfo } from "../libs/docInfo.js";
+import { clearMsgHistory } from "../apis/history.js";
 
 const VIDEO_SELECT = "#container video";
 const CONTORLS_SELECT = ".ytp-right-controls";
@@ -41,6 +42,8 @@ class YouTubeCaptionProvider {
   #interceptedCaptionKind = null;
 
   #processingId = null;
+  #processingVersion = 0;
+  #activeTrackKey = null;
 
   #managerInstance = null;
   #toggleButton = null;
@@ -90,6 +93,7 @@ class YouTubeCaptionProvider {
       logger.debug("Youtube Provider: yt-navigate-finish", this.#videoId);
 
       this.#destroyManager();
+      clearMsgHistory(this.#setting.apiSlug);
 
       this.#subtitles = [];
       this.#events = [];
@@ -99,6 +103,9 @@ class YouTubeCaptionProvider {
       this.#docInfo = {};
       this.#fullDescription = "";
       this.#interceptedCaptionKind = null;
+      this.#processingId = null;
+      this.#processingVersion += 1;
+      this.#activeTrackKey = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -332,7 +339,22 @@ class YouTubeCaptionProvider {
   }
 
   #isSameLang(lang1, lang2) {
+    if (!lang1 || !lang2) return false;
     return lang1.slice(0, 2) === lang2.slice(0, 2);
+  }
+
+  #buildTrackKey(potUrl) {
+    const p = potUrl.searchParams;
+    return [
+      p.get("v") || "",
+      p.get("lang") || "",
+      p.get("kind") || "",
+      p.get("tlang") || "",
+    ].join("|");
+  }
+
+  #isStaleProcessing(version) {
+    return version !== this.#processingVersion;
   }
 
   // todo: 优化逻辑
@@ -498,25 +520,38 @@ class YouTubeCaptionProvider {
     }
 
     const lang = potUrl.searchParams.get("lang");
-    const interceptedKind = potUrl.searchParams.get("kind") || null;
-    const fromLang = this.#getFromLang(lang);
-    if (this.#flatEvents.length) {
-      if (
-        this.#isSameLang(lang, this.#fromLang) &&
-        interceptedKind === this.#interceptedCaptionKind
-      ) {
-        logger.debug("Youtube Provider: video was processed:", videoId);
-        return;
-      }
-      this.#destroyManager();
-    }
-
-    if (videoId === this.#processingId) {
-      logger.debug("Youtube Provider: video is processing:", videoId);
+    if (!lang) {
+      logger.debug("Youtube Provider: timedtext lang not found:", url);
       return;
     }
 
-    this.#processingId = videoId;
+    const interceptedKind = potUrl.searchParams.get("kind") || null;
+    const trackKey = this.#buildTrackKey(potUrl);
+    const fromLang = this.#getFromLang(lang);
+
+    if (this.#flatEvents.length && trackKey === this.#activeTrackKey) {
+      logger.debug("Youtube Provider: track was processed:", trackKey);
+      return;
+    }
+
+    if (this.#processingId === trackKey) {
+      logger.debug("Youtube Provider: track is processing:", trackKey);
+      return;
+    }
+
+    const processingVersion = (this.#processingVersion += 1);
+    this.#processingId = trackKey;
+
+    if (this.#flatEvents.length) {
+      this.#destroyManager();
+      clearMsgHistory(this.#setting.apiSlug);
+      this.#subtitles = [];
+      this.#events = [];
+      this.#flatEvents = [];
+      this.#progressed = 0;
+      this.#activeTrackKey = null;
+      this.#interceptedCaptionKind = null;
+    }
 
     try {
       this.#showNotification(this.#i18n("starting_to_process_subtitle"));
@@ -524,6 +559,8 @@ class YouTubeCaptionProvider {
       const { toLang } = this.#setting;
       const { captionTracks, fullDescription } =
         await this.#getCaptionTracks(videoId);
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       this.#fullDescription = fullDescription || "";
       const captionTrack = this.#findCaptionTrack(
         captionTracks,
@@ -541,6 +578,8 @@ class YouTubeCaptionProvider {
         potUrl,
         responseText
       );
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       if (!events?.length) {
         logger.debug("Youtube Provider: events not got:", videoId);
         return;
@@ -560,34 +599,46 @@ class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: flatEvents not got:", videoId);
         return;
       }
+      if (this.#isStaleProcessing(processingVersion)) return;
 
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
       this.#interceptedCaptionKind = interceptedKind;
+      this.#activeTrackKey = trackKey;
       this.#docInfo = getDocInfo();
-      await this.#enrichDocInfoWithAI(flatEvents);
+      await this.#enrichDocInfoWithAI(flatEvents, processingVersion);
+      if (this.#isStaleProcessing(processingVersion)) return;
 
       this.#processEvents({
         videoId,
         flatEvents,
         fromLang,
+        processingVersion,
       });
     } catch (error) {
       logger.warn("Youtube Provider: handle subtitle", error);
       this.#showNotification(this.#i18n("subtitle_load_failed"));
     } finally {
-      this.#processingId = null;
+      if (
+        !this.#isStaleProcessing(processingVersion) &&
+        this.#processingId === trackKey
+      ) {
+        this.#processingId = null;
+      }
     }
   }
 
-  async #processEvents({ videoId, flatEvents, fromLang }) {
+  async #processEvents({ videoId, flatEvents, fromLang, processingVersion }) {
     try {
       const [subtitles, progressed] = await this.#eventsToSubtitles({
         videoId,
         flatEvents,
         fromLang,
+        processingVersion,
       });
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       if (!subtitles?.length) {
         logger.debug(
           "Youtube Provider: events to subtitles got empty",
@@ -628,15 +679,18 @@ class YouTubeCaptionProvider {
 
     this.#showNotification(this.#i18n("starting_reprocess_events"));
 
+    const processingVersion = (this.#processingVersion += 1);
     this.#destroyManager();
+    clearMsgHistory(this.#setting.apiSlug);
 
-    this.#processEvents({ videoId, flatEvents, fromLang });
+    this.#processEvents({ videoId, flatEvents, fromLang, processingVersion });
   }
 
-  async #enrichDocInfoWithAI(flatEvents) {
+  async #enrichDocInfoWithAI(flatEvents, processingVersion) {
     const { aiContextSlug, transApis } = this.#setting;
 
     if (!aiContextSlug || aiContextSlug === "-") return;
+    if (this.#isStaleProcessing(processingVersion)) return;
 
     const contextApiSetting = transApis?.find(
       (api) => api.apiSlug === aiContextSlug
@@ -667,7 +721,11 @@ class YouTubeCaptionProvider {
         apiSetting: contextApiSetting,
       });
 
-      if (summary && videoId === this.#videoId) {
+      if (
+        summary &&
+        videoId === this.#videoId &&
+        !this.#isStaleProcessing(processingVersion)
+      ) {
         docInfo.summary = summary;
       }
     } catch (err) {
@@ -683,13 +741,26 @@ class YouTubeCaptionProvider {
     const flatEvents = this.#flatEvents;
     if (!videoId || !flatEvents.length) return;
 
+    const processingVersion = (this.#processingVersion += 1);
     this.#destroyManager();
+    clearMsgHistory(this.#setting.apiSlug);
     this.#docInfo = getDocInfo();
-    await this.#enrichDocInfoWithAI(flatEvents);
-    this.#processEvents({ videoId, flatEvents, fromLang: this.#fromLang });
+    await this.#enrichDocInfoWithAI(flatEvents, processingVersion);
+    if (this.#isStaleProcessing(processingVersion)) return;
+    this.#processEvents({
+      videoId,
+      flatEvents,
+      fromLang: this.#fromLang,
+      processingVersion,
+    });
   }
 
-  async #eventsToSubtitles({ videoId, flatEvents, fromLang }) {
+  async #eventsToSubtitles({
+    videoId,
+    flatEvents,
+    fromLang,
+    processingVersion,
+  }) {
     const { segSlug, transApis, chunkLength, toLang } = this.#setting;
     const subtitlesFallback = () => [
       this.#formatSubtitles(flatEvents, fromLang),
@@ -703,6 +774,7 @@ class YouTubeCaptionProvider {
 
     // 仅自动字幕(kind=asr)启用AI断句，人工字幕直接使用原字幕分段
     if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
+      if (this.#isStaleProcessing(processingVersion)) return [[], 0];
       logger.info("Youtube Provider: Starting AI ...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
 
@@ -720,6 +792,7 @@ class YouTubeCaptionProvider {
         toLang,
         segApiSetting,
       });
+      if (this.#isStaleProcessing(processingVersion)) return [[], 0];
 
       if (!firstBatchSubtitles?.length) {
         return subtitlesFallback();
@@ -733,6 +806,7 @@ class YouTubeCaptionProvider {
           fromLang,
           toLang,
           segApiSetting,
+          processingVersion,
         });
 
         const processed = Math.floor(100 / eventChunks.length);
@@ -800,7 +874,7 @@ class YouTubeCaptionProvider {
       // todo: 将 subtitleListManager 实例传入 managerInstance
       // 监听字幕更新事件，在字幕翻译完成后更新字幕列表
       this.#managerInstance.onSubtitleUpdate = (updatedSubtitles) => {
-        this.#subtitleListManager.setBilingualSubtitles(updatedSubtitles);
+        this.#subtitleListManager?.setBilingualSubtitles(updatedSubtitles);
       };
 
       // 创建包含翻译信息的双语字幕数据（初始可能没有翻译）
@@ -833,6 +907,7 @@ class YouTubeCaptionProvider {
 
     logger.info("Youtube Provider: Destroying manager...");
 
+    this.#managerInstance.onSubtitleUpdate = null;
     this.#managerInstance.destroy();
     this.#managerInstance = null;
 
@@ -1159,10 +1234,16 @@ class YouTubeCaptionProvider {
     fromLang,
     toLang,
     segApiSetting,
+    processingVersion,
   }) {
     logger.info(`Youtube Provider: Starting for ${chunks.length} chunks.`);
 
     for (let i = 0; i < chunks.length; i++) {
+      if (this.#isStaleProcessing(processingVersion)) {
+        logger.info("Youtube Provider: Skip stale chunk processing.");
+        break;
+      }
+
       const chunkEvents = chunks[i];
       const chunkNum = i + 2;
       logger.debug(
@@ -1179,6 +1260,7 @@ class YouTubeCaptionProvider {
           toLang,
           segApiSetting,
         });
+        if (this.#isStaleProcessing(processingVersion)) break;
 
         if (aiSubtitles?.length > 0) {
           subtitlesForThisChunk = aiSubtitles;
@@ -1192,9 +1274,12 @@ class YouTubeCaptionProvider {
         subtitlesForThisChunk = this.#formatSubtitles(chunkEvents, fromLang);
       }
 
-      if (videoId !== this.#videoId) {
+      if (
+        videoId !== this.#videoId ||
+        this.#isStaleProcessing(processingVersion)
+      ) {
         logger.info(
-          "Youtube Provider: videoId changed!!",
+          "Youtube Provider: videoId changed or track replaced!",
           videoId,
           this.#videoId
         );

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -458,40 +458,68 @@ class YouTubeCaptionProvider {
   }
 
   async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
-    try {
-      const events = chunkEvents.filter((item) => item.text);
-      if (!events.length) return [];
+    const NON_SPEECH_RE = /^\[.+\]$/i;
+    const speechEvents = [];
+    const nonSpeechEvents = [];
 
-      const chunkSign = `${events[0].start} --> ${events[events.length - 1].end}`;
+    for (const item of chunkEvents) {
+      if (!item.text) continue;
+      if (NON_SPEECH_RE.test(item.text.trim())) {
+        nonSpeechEvents.push(item);
+      } else {
+        speechEvents.push(item);
+      }
+    }
+
+    const toStandaloneSub = (e) => ({
+      start: e.start,
+      end: e.end,
+      text: e.text,
+      translation: e.text,
+    });
+
+    if (!speechEvents.length) return nonSpeechEvents.map(toStandaloneSub);
+
+    try {
+      const chunkSign = `${speechEvents[0].start} --> ${speechEvents[speechEvents.length - 1].end}`;
       logger.debug("Youtube Provider: aiSegment events", {
         videoId,
         chunkSign,
         fromLang,
         toLang,
-        events,
+        speechEvents,
       });
       const subtitles = await apiSubtitle({
         videoId,
         chunkSign,
         fromLang,
         toLang,
-        events,
+        events: speechEvents,
         apiSetting: segApiSetting,
         docInfo: this.#docInfo,
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
       if (Array.isArray(subtitles)) {
-        // 断句服务和翻译服务不同时，清除断句的翻译，由翻译服务重新翻译
+        let result = subtitles;
         if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
-          return subtitles.map((sub) => ({ ...sub, translation: "" }));
+          result = subtitles.map((sub) => ({ ...sub, translation: "" }));
         }
-        return subtitles;
+
+        // 仅保留落在语音字幕间隙中的非语音条目，丢弃与语音重叠的
+        const gapCues = nonSpeechEvents
+          .filter(
+            (ns) =>
+              !result.some((sub) => ns.start < sub.end && ns.end > sub.start)
+          )
+          .map(toStandaloneSub);
+
+        return [...result, ...gapCues].sort((a, b) => a.start - b.start);
       }
     } catch (err) {
       logger.info("Youtube Provider: ai segmentation", err);
     }
 
-    return [];
+    return nonSpeechEvents.map(toStandaloneSub);
   }
 
   #getFromLang(lang) {

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -464,6 +464,7 @@ export default function SubtitleSetting() {
     enhanceMode = OPT_ENHANCE_MOBILE_OFF,
     showList = true,
     skipAd = false,
+    aiContextSlug = "-",
     windowStyle,
     originStyle,
     translationStyle,
@@ -522,6 +523,24 @@ export default function SubtitleSetting() {
                 name="segSlug"
                 value={segSlug}
                 label={i18n("ai_segmentation")}
+                onChange={handleChange}
+              >
+                <MenuItem value={"-"}>{i18n("disable")}</MenuItem>
+                {aiEnabledApis.map((api) => (
+                  <MenuItem key={api.apiSlug} value={api.apiSlug}>
+                    {api.apiName}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                select
+                fullWidth
+                size="small"
+                name="aiContextSlug"
+                value={aiContextSlug}
+                label={i18n("ai_enhanced_context")}
                 onChange={handleChange}
               >
                 <MenuItem value={"-"}>{i18n("disable")}</MenuItem>


### PR DESCRIPTION
## 概要
  - 使用LLM对视频标题、完整简介和转录文本进行摘要分析，为AI智能断句和翻译服务提供丰富上下文
  - 统一AI智能断句行为：断句与翻译使用不同API时仅使用断句时间戳，由翻译服务单独翻译；相同API时断句同时完成双语翻译
  - 修复上下文传递链路，确保增强上下文正确到达断句和翻译服务
  - 修复AI上下文分析竞态条件，防止切换视频时旧结果污染新视频

  ## 改动内容
  - 优化字幕AI提示词格式，添加Markdown代码块清理
  - 将视频上下文（标题/简介/摘要）传递到完整翻译链路
  - 添加 `aiContextSlug` 设置，合并启用开关和服务选择为单个Select控件
  - 从 `ytInitialPlayerResponse` 提取完整视频简介（不再使用被截断的meta description）
  - 按视频+API隔离缓存键，修复 `handleTranslate` 展开顺序防止 `docInfo` 被覆盖
  - 为 `handleSummarize` 添加自定义API（`OPT_TRANS_CUSTOMIZE`）支持
  - 添加无 `{{summary}}` 占位符的提示词统一上下文回退，覆盖断句和翻译两条路径

  ## 涉及文件
  - `src/apis/trans.js` — 翻译请求构建、上下文注入、摘要处理
  - `src/apis/index.js` — API入口、缓存键隔离、上下文摘要接口
  - `src/subtitle/YouTubeCaptionProvider.js` — 字幕编排、AI上下文分析、断句行为统一
  - `src/subtitle/BilingualSubtitleManager.js` — docInfo传递
  - `src/subtitle/Menus.js` — 合并UI控件
  - `src/views/Options/Subtitle.js` — 设置页UI合并
  - `src/config/` — 设置项、国际化、URL常量、提示词模板

<img width="2971" height="553" alt="image" src="https://github.com/user-attachments/assets/e8f628de-53d6-4366-92dd-71c201241ffb" />



说人话：
1：目前的智能断句会时不时格式错误，导致翻译不了（或者说翻译好了，但是ai没有根据格式提供），只剩下原文，现在改了一下有一些兜底措施，没那么容易出错
2：上下文（不是pr里写的这个）启用且翻译服务和智能断句不是同一个服务时，只有智能断句会获得上下文信息，翻译服务无法获得上下文信息，pr修复了这个问题
3：目前的视频字幕智能上下文还不够智能，只是机械获取标题简介总结，现在加了“智能增强上下文”在字幕翻译选项里，启用则在翻译前先用ai读取标题，简介（并且pr修改了获取，现在读取的是完整视频简介，而不是不点展开的部分有多少就读取多少），总结，字幕（直到填满设置的上下文上限），然后进行总结，提供视频背景和部分专有词汇
4：现在的智能断句感觉很奇怪，在智能断句和翻译服务不是同一个接口的情况下（例如翻译是gpt，断句是gemini），如果断句不能在一个请求内完成（也就是视频字幕很短），那么后面就会直接采用智能断句顺带的翻译结果。但是如果能在一个请求内完成就变成了会后续使用翻译服务进行翻译。现在pr改成了无论如何智能断句都会输出，但是如果翻译服务和智能断句不是同一个接口则清理掉智能断句的翻译部分重新翻译

在chrome测试使用了几个小时暂时没看到问题