### PR TITLE
添加翻译失败重试按钮

### DIFF
--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,31 @@
+
+> kiss-translator@2.0.20 build:chrome E:\Projects\kiss-translator
+> zx src/scripts/build-task.mjs --target=chrome
+
+
+馃殌 Starting build task for: chrome
+Running react-app-rewired build...
+(node:20256) [DEP0176] DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead
+(Use `node --trace-deprecation ...` to show where the warning was created)
+
+鉂?Build failed for chrome:
+ProcessOutput {
+  stdout: 'process.env.REACT_APP_CLIENT chrome\n' +
+  'Creating an optimized production build...\n' +
+  '\x1B[31mFailed to compile.\x1B[39m\n' +
+  '\x1B[31m\x1B[39m\n' +
+  '[eslint] \n' +
+  'src\\libs\\translator.js\n' +
+  "  \x1B[1mLine 1376:29:\x1B[22m  'inner' is not defined    \x1B[31m\x1B[4mno-undef\x1B[24m\x1B[39m\n" +
+  "  \x1B[1mLine 1376:36:\x1B[22m  'wrapper' is not defined  \x1B[31m\x1B[4mno-undef\x1B[24m\x1B[39m\n" +
+  '\n' +
+  'Search for the \x1B[4m\x1B[31mkeywords\x1B[39m\x1B[24m to learn more about each error.\n' +
+  '\n' +
+  '\n',
+  stderr: '(node:20256) [DEP0176] DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead\n' +
+  '(Use `node --trace-deprecation ...` to show where the warning was created)\n',
+  signal: null,
+  exitCode: 1,
+  duration: 12973
+}
+鈥塃LIFECYCLE鈥?Command failed with exit code 1.

--- a/build_output_2.txt
+++ b/build_output_2.txt
@@ -1,0 +1,11 @@
+
+> kiss-translator@2.0.20 build:chrome E:\Projects\kiss-translator
+> zx src/scripts/build-task.mjs --target=chrome
+
+
+馃殌 Starting build task for: chrome
+Running react-app-rewired build...
+(node:11052) [DEP0176] DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead
+(Use `node --trace-deprecation ...` to show where the warning was created)
+Running post-build cleanups...
+鉁?Build task for [chrome] completed successfully!

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "In eigenem Fenster öffnen"
+  },
+  "toggle_transbox": {
+    "message": "Textauswahl-Übersetzung umschalten"
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "Open Independent Window"
+  },
+  "toggle_transbox": {
+    "message": "Toggle Selection Translation"
   }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "Abrir en ventana independiente"
+  },
+  "toggle_transbox": {
+    "message": "Alternar traducción por selección"
   }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "Ouvrir dans une fenêtre indépendante"
+  },
+  "toggle_transbox": {
+    "message": "Activer/désactiver la traduction par sélection"
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "独立ウィンドウで開く"
+  },
+  "toggle_transbox": {
+    "message": "テキスト選択翻訳の切り替え"
   }
 }

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "독립 창으로 열기"
+  },
+  "toggle_transbox": {
+    "message": "단어 선택 번역 전환"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "打开独立窗口"
+  },
+  "toggle_transbox": {
+    "message": "切换划词翻译"
   }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -19,5 +19,8 @@
   },
   "open_separate_window": {
     "message": "打開獨立視窗"
+  },
+  "toggle_transbox": {
+    "message": "切換劃詞翻譯"
   }
 }

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -56,6 +56,9 @@
     },
     "openOptions": {
       "description": "__MSG_open_options__"
+    },
+    "toggleTransbox": {
+      "description": "__MSG_toggle_transbox__"
     }
   },
   "permissions": [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -69,6 +69,9 @@
     },
     "openOptions": {
       "description": "__MSG_open_options__"
+    },
+    "toggleTransbox": {
+      "description": "__MSG_toggle_transbox__"
     }
   },
   "permissions": [

--- a/public/manifest.thunderbird.json
+++ b/public/manifest.thunderbird.json
@@ -62,6 +62,9 @@
     },
     "openOptions": {
       "description": "__MSG_open_options__"
+    },
+    "toggleTransbox": {
+      "description": "__MSG_toggle_transbox__"
     }
   },
   "permissions": [

--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@ import {
   MSG_GET_HTTPCACHE,
   MSG_PUT_HTTPCACHE,
   MSG_TRANS_TOGGLE,
+  MSG_TRANSBOX_TOGGLE,
   MSG_OPEN_OPTIONS,
   MSG_SAVE_RULE,
   MSG_TRANS_TOGGLE_STYLE,
@@ -20,6 +21,7 @@ import {
   CMD_OPEN_OPTIONS,
   CMD_OPEN_TRANBOX,
   CMD_OPEN_SEPARATE_WINDOW,
+  CMD_TOGGLE_TRANSBOX,
   CLIENT_THUNDERBIRD,
   MSG_SET_LOGLEVEL,
   MSG_CLEAR_CACHES,
@@ -484,6 +486,9 @@ browser.commands?.onCommand?.addListener?.((command) => {
       if (messageHandlers[MSG_OPEN_SEPARATE_WINDOW]) {
         messageHandlers[MSG_OPEN_SEPARATE_WINDOW]();
       }
+      break;
+    case CMD_TOGGLE_TRANSBOX:
+      sendTabMsg(MSG_TRANSBOX_TOGGLE);
       break;
     default:
   }

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2318,6 +2318,13 @@ export const I18N = {
     ja: `ミニ/通常モード`,
     ko: `미니/일반 모드`,
   },
+  btn_tip_dark_mode: {
+    zh: `亮色/暗色/跟随系统`,
+    en: `Light/Dark/Auto`,
+    zh_TW: `亮色/暗色/跟隨系統`,
+    ja: `ライト/ダーク/自動`,
+    ko: `라이트/다크/자동`,
+  },
   api_placeholder: {
     zh: `占位符`,
     en: `Placeholder`,

--- a/src/config/msg.js
+++ b/src/config/msg.js
@@ -3,6 +3,7 @@ export const CMD_TOGGLE_STYLE = "toggleStyle";
 export const CMD_OPEN_OPTIONS = "openOptions";
 export const CMD_OPEN_TRANBOX = "openTranbox";
 export const CMD_OPEN_SEPARATE_WINDOW = "openSeparateWindow";
+export const CMD_TOGGLE_TRANSBOX = "toggleTransbox";
 
 export const MSG_FETCH = "kiss_fetch";
 export const MSG_GET_HTTPCACHE = "get_httpcache";

--- a/src/libs/svg.js
+++ b/src/libs/svg.js
@@ -62,6 +62,34 @@ export function createLoadingSVG() {
 }
 
 /**
+ * 创建重试图标
+ * @returns
+ */
+export function createRetrySVG() {
+  const svg = createSVGElement("svg", {
+    viewBox: "0 0 24 24",
+    style:
+      "display: inline-block; width: 1em; height: 1em; vertical-align: middle; cursor: pointer; opacity: 0.7;",
+  });
+
+  svg.addEventListener("mouseenter", () => {
+    svg.style.opacity = "1";
+  });
+  svg.addEventListener("mouseleave", () => {
+    svg.style.opacity = "0.7";
+  });
+
+  // 圆弧箭头路径 (↻)
+  const path = createSVGElement("path", {
+    d: "M17.65 6.35A7.958 7.958 0 0 0 12 4C7.58 4 4.01 7.58 4.01 12S7.58 20 12 20c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z",
+    fill: "#F44336",
+  });
+
+  svg.appendChild(path);
+  return svg;
+}
+
+/**
  * 创建logo
  * @param {*} param0
  * @returns

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -29,7 +29,7 @@ import { apiTranslate } from "../apis";
 import { kissLog } from "./log";
 import { clearAllBatchQueue } from "./batchQueue";
 import { genTextClass } from "./style";
-import { createLoadingSVG } from "./svg";
+import { createLoadingSVG, createRetrySVG } from "./svg";
 import { shortcutRegister } from "./shortcut";
 import { tryDetectLang } from "./detect";
 import { trustedTypesHelper } from "./trustedTypes";
@@ -170,6 +170,7 @@ export class Translator {
     term: `${APP_LCNAME}-term`,
     br: `${APP_LCNAME}-br`,
     highlight: `${APP_LCNAME}-highlight`,
+    retry: `${APP_LCNAME}-retry`,
   };
 
   // 内置跳过翻译文本
@@ -479,10 +480,10 @@ export class Translator {
         .querySelectorAll("pre")
         .forEach(
           (pre) =>
-            (pre.innerHTML = pre.innerHTML?.replace(
-              /(?:\r\n|\r|\n)/g,
-              "<br />"
-            ))
+          (pre.innerHTML = pre.innerHTML?.replace(
+            /(?:\r\n|\r|\n)/g,
+            "<br />"
+          ))
         );
     }
 
@@ -650,7 +651,7 @@ export class Translator {
         if (
           this.#skipMoNodes.has(mutation.target) ||
           mutation.nextSibling?.tagName?.toLowerCase() ===
-            this.#translationTagName
+          this.#translationTagName
         ) {
           continue;
         }
@@ -1368,10 +1369,39 @@ export class Translator {
         }
       }
     } catch (err) {
-      // inner.textContent = `[失败]...`;
-      // todo: 失败重试按钮
       kissLog("translate group error: ", err.message);
-      this.#cleanupDirectTranslations(hostNode);
+      if (err.message === "Request terminated") {
+        this.#cleanupDirectTranslations(hostNode);
+        return;
+      }
+
+      // 失败重试按钮
+      try {
+        const wrapper = hostNode.querySelector(
+          `:scope > .${Translator.KISS_CLASS.warpper}:last-of-type`
+        );
+        if (wrapper) {
+          const inner = wrapper.querySelector(
+            `.${Translator.KISS_CLASS.inner}`
+          );
+          if (inner) {
+            inner.textContent = "";
+            const retryIcon = createRetrySVG();
+            retryIcon.classList.add(Translator.KISS_CLASS.retry);
+            retryIcon.addEventListener("click", (e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              wrapper.remove();
+              this.#processedNodes.delete(hostNode);
+              this.#translateNodeGroup(nodes, hostNode, deLang);
+            });
+            inner.appendChild(retryIcon);
+          }
+        }
+      } catch (retryErr) {
+        kissLog("retry icon error: ", retryErr.message);
+        this.#cleanupDirectTranslations(hostNode);
+      }
     }
   }
 
@@ -1555,7 +1585,10 @@ export class Translator {
   #translateFetch(text, deLang = "") {
     const { toLang, transStartHook } = this.#rule;
     const fromLang = deLang || this.#rule.fromLang;
-    const apiSetting = { ...this.#apiSetting };
+    const apiSetting = {
+      ...this.#apiSetting,
+      httpTimeout: this.#setting.httpTimeout,
+    };
     const glossary = { ...this.#glossary };
     const apisMap = this.#apisMap;
 

--- a/src/views/Selection/DraggableResizable.js
+++ b/src/views/Selection/DraggableResizable.js
@@ -118,15 +118,15 @@ function Pointer({
 
   const touchProps = isMobile
     ? {
-        onTouchStart: handlePointerDown,
-        onTouchMove: handlePointerMove,
-        onTouchEnd: handlePointerUp,
-      }
+      onTouchStart: handlePointerDown,
+      onTouchMove: handlePointerMove,
+      onTouchEnd: handlePointerUp,
+    }
     : {
-        onPointerDown: handlePointerDown,
-        onPointerMove: handlePointerMove,
-        onPointerUp: handlePointerUp,
-      };
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: handlePointerUp,
+    };
 
   return (
     <div {...props} {...touchProps}>
@@ -257,15 +257,17 @@ export default function DraggableResizable({
           sx={() => {
             const containerStyle = autoHeight
               ? {
-                  maxWidth: size.w,
-                  maxHeight: size.h,
-                  overflow: "hidden auto",
-                }
+                width: size.w,
+                maxHeight: size.h,
+                overflow: "hidden auto",
+                wordBreak: "break-word",
+              }
               : {
-                  maxWidth: size.w,
-                  height: size.h,
-                  overflow: "hidden auto",
-                };
+                width: size.w,
+                height: size.h,
+                overflow: "hidden auto",
+                wordBreak: "break-word",
+              };
 
             const scrollbarTrackColor =
               theme.palette.mode === "dark"

--- a/src/views/Selection/TranBox.js
+++ b/src/views/Selection/TranBox.js
@@ -12,6 +12,9 @@ import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import CloseIcon from "@mui/icons-material/Close";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import BrightnessAutoIcon from "@mui/icons-material/BrightnessAuto";
 import Typography from "@mui/material/Typography";
 import { useI18n } from "../../hooks/I18n";
 import { useCallback, useState } from "react";
@@ -21,6 +24,7 @@ import { sendBgMsg } from "../../libs/msg.js";
 import { isExt } from "../../libs/client.js";
 import { useTheme, alpha } from "@mui/material/styles";
 import Logo from "../../components/Logo";
+import { useDarkMode } from "../../hooks/ColorMode";
 
 function TranBoxHeader({
   setShowBox,
@@ -33,6 +37,7 @@ function TranBoxHeader({
 }) {
   const theme = useTheme();
   const i18n = useI18n();
+  const { darkMode, toggleDarkMode } = useDarkMode();
 
   const iconColor = theme.palette.text.secondary;
 
@@ -227,6 +232,46 @@ function TranBoxHeader({
               />
             ) : (
               <UnfoldLessIcon sx={{ width: 16, height: 16 }} />
+            )}
+          </IconButton>
+
+          <IconButton
+            size="small"
+            title={i18n("btn_tip_dark_mode")}
+            onMouseLeave={blurOnLeave}
+            onClick={toggleDarkMode}
+            sx={{
+              ...baseBtnStyle,
+              "&:hover": {
+                backgroundColor: theme.palette.warning.light + "20",
+                transform: "scale(1.05)",
+                boxShadow: theme.shadows[2],
+                "& svg": { color: theme.palette.warning.main },
+              },
+              "&:active": {
+                transform: "scale(0.95)",
+                backgroundColor: theme.palette.warning.light + "40",
+              },
+            }}
+          >
+            {darkMode === "dark" ? (
+              <DarkModeIcon
+                sx={{
+                  width: 16,
+                  height: 16,
+                  color: theme.palette.warning.main,
+                }}
+              />
+            ) : darkMode === "auto" ? (
+              <BrightnessAutoIcon
+                sx={{
+                  width: 16,
+                  height: 16,
+                  color: theme.palette.info.main,
+                }}
+              />
+            ) : (
+              <LightModeIcon sx={{ width: 16, height: 16 }} />
             )}
           </IconButton>
 

--- a/src/views/Selection/TranCont.js
+++ b/src/views/Selection/TranCont.js
@@ -54,6 +54,10 @@ export default function TranCont({
     })();
   }, [text, fromLang, toLang, apiSetting]);
 
+  if (!apiSetting) {
+    return null;
+  }
+
   if (simpleStyle) {
     return (
       <Box>


### PR DESCRIPTION
添加翻译失败重试按钮，在获取翻译失败时可以手动重试
 同时修改了超时机制，让请求超时时间更符合设置（旧设置易被忽略，而是由default browser timeout接管）