### PR TITLE
feat: 划词翻译功能增强

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2346,6 +2346,13 @@ export const I18N = {
     ja: `ミニ/通常モード`,
     ko: `미니/일반 모드`,
   },
+  btn_tip_dark_mode: {
+    zh: `亮色/暗色/跟随系统`,
+    en: `Light/Dark/Auto`,
+    zh_TW: `亮色/暗色/跟隨系統`,
+    ja: `ライト/ダーク/自動`,
+    ko: `라이트/다크/자동`,
+  },
   api_placeholder: {
     zh: `占位符`,
     en: `Placeholder`,

--- a/src/config/msg.js
+++ b/src/config/msg.js
@@ -15,7 +15,6 @@ export const MSG_OPEN_TRANBOX = "open_tranbox";
 export const MSG_TRANS_GETRULE = "trans_getrule";
 export const MSG_TRANS_PUTRULE = "trans_putrule";
 export const MSG_TRANS_CURRULE = "trans_currule";
-export const MSG_TRANSBOX_TOGGLE = "toggle_transbox";
 export const MSG_POPUP_TOGGLE = "toggle_popup";
 export const MSG_MOUSEHOVER_TOGGLE = "toggle_mousehover";
 export const MSG_HOVERNODE_TOGGLE = "toggle_hover_node";

--- a/src/libs/translatorManager.js
+++ b/src/libs/translatorManager.js
@@ -22,9 +22,7 @@ import {
   MSG_TRANS_TOGGLE,
   MSG_TRANS_TOGGLE_STYLE,
   MSG_TRANS_GETRULE,
-  MSG_TRANS_PUTRULE,
   MSG_OPEN_TRANBOX,
-  MSG_TRANSBOX_TOGGLE,
   MSG_POPUP_TOGGLE,
   MSG_MOUSEHOVER_TOGGLE,
   MSG_TRANSINPUT_TOGGLE,
@@ -283,22 +281,17 @@ export default class TranslatorManager {
         break;
       case MSG_TRANS_GETRULE:
         break;
-      case MSG_TRANS_PUTRULE:
-        this._translator.updateRule(args);
-        break;
       case MSG_OPEN_TRANBOX:
         document.dispatchEvent(
           new CustomEvent(EVENT_KISS_INNER, {
             detail: { action: MSG_OPEN_TRANBOX },
           })
         );
+        this._transboxManager?.toggle();
+        this._translator.toggleTransbox();
         break;
       case MSG_POPUP_TOGGLE:
         this._popupManager?.toggle();
-        break;
-      case MSG_TRANSBOX_TOGGLE:
-        this._transboxManager?.toggle();
-        this._translator.toggleTransbox();
         break;
       case MSG_MOUSEHOVER_TOGGLE:
         this._translator.toggleMouseHover();

--- a/src/libs/translatorManager.js
+++ b/src/libs/translatorManager.js
@@ -22,6 +22,7 @@ import {
   MSG_TRANS_TOGGLE,
   MSG_TRANS_TOGGLE_STYLE,
   MSG_TRANS_GETRULE,
+  MSG_TRANS_PUTRULE,
   MSG_OPEN_TRANBOX,
   MSG_POPUP_TOGGLE,
   MSG_MOUSEHOVER_TOGGLE,
@@ -280,6 +281,9 @@ export default class TranslatorManager {
         this._translator.toggleStyle();
         break;
       case MSG_TRANS_GETRULE:
+        break;
+      case MSG_TRANS_PUTRULE:
+        this._translator.updateRule(args);
         break;
       case MSG_OPEN_TRANBOX:
         document.dispatchEvent(

--- a/src/views/Popup/PopupCont.js
+++ b/src/views/Popup/PopupCont.js
@@ -16,7 +16,7 @@ import {
   MSG_TRANS_PUTRULE,
   MSG_SAVE_RULE,
   MSG_COMMAND_SHORTCUTS,
-  MSG_TRANSBOX_TOGGLE,
+  MSG_OPEN_TRANBOX,
   MSG_MOUSEHOVER_TOGGLE,
   MSG_TRANSINPUT_TOGGLE,
   OPT_LANGS_FROM,
@@ -66,9 +66,9 @@ export default function PopupCont({
       }));
 
       if (!processActions) {
-        await sendTabMsg(MSG_TRANSBOX_TOGGLE);
+        await sendTabMsg(MSG_OPEN_TRANBOX);
       } else {
-        processActions({ action: MSG_TRANSBOX_TOGGLE });
+        processActions({ action: MSG_OPEN_TRANBOX });
       }
     } catch (err) {
       kissLog("toggle transbox", err);

--- a/src/views/Selection/DraggableResizable.js
+++ b/src/views/Selection/DraggableResizable.js
@@ -259,14 +259,16 @@ export default function DraggableResizable({
           sx={() => {
             const containerStyle = autoHeight
               ? {
-                  maxWidth: size.w,
+                  width: size.w,
                   maxHeight: size.h,
                   overflow: "hidden auto",
+                  wordBreak: "break-word",
                 }
               : {
-                  maxWidth: size.w,
+                  width: size.w,
                   height: size.h,
                   overflow: "hidden auto",
+                  wordBreak: "break-word",
                 };
 
             const scrollbarTrackColor =

--- a/src/views/Selection/TranBox.js
+++ b/src/views/Selection/TranBox.js
@@ -12,6 +12,9 @@ import PushPinOutlinedIcon from "@mui/icons-material/PushPinOutlined";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import CloseIcon from "@mui/icons-material/Close";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import BrightnessAutoIcon from "@mui/icons-material/BrightnessAuto";
 import Typography from "@mui/material/Typography";
 import { useI18n } from "../../hooks/I18n";
 import { useCallback, useState } from "react";
@@ -23,6 +26,7 @@ import { useTheme, alpha } from "@mui/material/styles";
 import Logo from "../../components/Logo";
 import { isValidWord } from "../../libs/utils";
 import { OPT_TRANS_MICROSOFT } from "../../config";
+import { useDarkMode } from "../../hooks/ColorMode";
 
 function TranBoxHeader({
   setShowBox,
@@ -35,6 +39,7 @@ function TranBoxHeader({
 }) {
   const theme = useTheme();
   const i18n = useI18n();
+  const { darkMode, toggleDarkMode } = useDarkMode();
 
   const iconColor = theme.palette.text.secondary;
 
@@ -229,6 +234,46 @@ function TranBoxHeader({
               />
             ) : (
               <UnfoldLessIcon sx={{ width: 16, height: 16 }} />
+            )}
+          </IconButton>
+
+          <IconButton
+            size="small"
+            title={i18n("btn_tip_dark_mode")}
+            onMouseLeave={blurOnLeave}
+            onClick={toggleDarkMode}
+            sx={{
+              ...baseBtnStyle,
+              "&:hover": {
+                backgroundColor: theme.palette.warning.light + "20",
+                transform: "scale(1.05)",
+                boxShadow: theme.shadows[2],
+                "& svg": { color: theme.palette.warning.main },
+              },
+              "&:active": {
+                transform: "scale(0.95)",
+                backgroundColor: theme.palette.warning.light + "40",
+              },
+            }}
+          >
+            {darkMode === "dark" ? (
+              <DarkModeIcon
+                sx={{
+                  width: 16,
+                  height: 16,
+                  color: theme.palette.warning.main,
+                }}
+              />
+            ) : darkMode === "auto" ? (
+              <BrightnessAutoIcon
+                sx={{
+                  width: 16,
+                  height: 16,
+                  color: theme.palette.info.main,
+                }}
+              />
+            ) : (
+              <LightModeIcon sx={{ width: 16, height: 16 }} />
             )}
           </IconButton>
 


### PR DESCRIPTION
1. 为划词翻译添加快键
2. 支持划词弹窗的色彩模式切换（方便使用夜间模式插件时弹窗反而变成白底）
3. 支持划词弹窗的尺寸可被拖曳修改宽度，更方便取词，并能自动记忆宽度大小