### PR TITLE
fix bug: 处理标签页通信时未建立的连接

### DIFF
--- a/src/libs/msg.js
+++ b/src/libs/msg.js
@@ -14,7 +14,7 @@ export const getCurTab = async () => {
 
 export const getCurTabId = async () => {
   const tab = await getCurTab();
-  return tab.id;
+  return tab?.id;
 };
 
 /**
@@ -34,5 +34,15 @@ export const sendBgMsg = (action, args) =>
  */
 export const sendTabMsg = async (action, args) => {
   const tabId = await getCurTabId();
-  return browser.tabs.sendMessage(tabId, { action, args });
+  if (!tabId) return;
+  return browser.tabs.sendMessage(tabId, { action, args }).catch((err) => {
+    if (
+      err?.message?.includes("Could not establish connection") ||
+      err?.message?.includes("Receiving end does not exist")
+    ) {
+      console.warn("sendTabMsg warning: ", err?.message);
+    } else {
+      throw err;
+    }
+  });
 };


### PR DESCRIPTION
当 sendTabMsg 尝试向无法接收消息的标签页发送消息时，会抛出一个未处理的 promise rejection："Could not establish connection. Receiving end does not exist."

本次提交通过以下方式修复了此问题：
在 sendTabMsg 中添加一个 .catch() 块，以处理这些预期的连接错误，并改为记录一条警告。
在 getCurTabId 中使用可选链（optional chaining）tab?.id，以防止当活动标签页意外为 undefined 时出现解构错误。