### PR TITLE
fix bug: 禁用翻译接口导致划词翻译出错

### DIFF
--- a/src/views/Selection/TranForm.js
+++ b/src/views/Selection/TranForm.js
@@ -140,6 +140,12 @@ export default function TranForm({
   const xs = useMemo(() => (isPlaygound ? 6 : 4), [isPlaygound]);
   const md = useMemo(() => (isPlaygound ? 3 : 4), [isPlaygound]);
 
+  const activeApiSlugs = useMemo(() => {
+    const validSlugs = new Set(optApis.map((api) => api.key));
+    return apiSlugs.filter((slug) => validSlugs.has(slug));
+  }, [apiSlugs, optApis]);
+
+
   return (
     <Stack spacing={simpleStyle ? 1 : 2}>
       {!simpleStyle && (
@@ -155,7 +161,7 @@ export default function TranForm({
                   }}
                   fullWidth
                   size="small"
-                  value={apiSlugs}
+                  value={activeApiSlugs}
                   name="apiSlugs"
                   label={i18n("translate_service_multiple")}
                   onChange={(e) => {
@@ -384,7 +390,7 @@ export default function TranForm({
         </>
       )}
 
-      {apiSlugs.map((slug) => (
+      {activeApiSlugs.map((slug) => (
         <TranCont
           key={slug}
           text={text}


### PR DESCRIPTION
当禁用一个翻译服务时，该服务虽然不再列为可选的翻译服务，但如果它之前已经保存在“划词翻译”配置中（即 apiSlugs中），那么 <TranForm /> 组件在渲染实际的翻译结果卡片和右侧的多选下拉框时，依然会直接遍历这个并没有被系统过滤的 apiSlugs 数组，从而导致其仍然被请求和显示。