### PR TITLE
feat: bypass translation services when selecting a single word

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -419,6 +419,13 @@ export const I18N = {
     ja: `翻訳サービス (複数選択可)`,
     ko: `번역 서비스 (다중 선택 지원)`,
   },
+  single_word_no_trans: {
+    zh: `单个单词划词不调用翻译服务`,
+    en: `Do not use translation services for single word`,
+    zh_TW: `單個單詞劃詞不調用翻譯服務`,
+    ja: `単一単語は翻訳サービスを使用しない`,
+    ko: `단일 단어는 번역 서비스를 사용하지 않음`,
+  },
   translate_timing: {
     zh: `翻译时机`,
     en: `Translate Timing`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -83,6 +83,7 @@ export const DEFAULT_TRANBOX_SHORTCUT = ["AltLeft", "KeyS"];
 export const DEFAULT_TRANBOX_SETTING = {
   transOpen: true, // 是否启用划词翻译
   apiSlugs: [OPT_TRANS_MICROSOFT],
+  singleWordNoTrans: false, // 划词为单个单词时仅使用默认翻译服务
   fromLang: "auto",
   toLang: "zh-CN",
   toLang2: "en",

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -56,6 +56,7 @@ export default function Tranbox() {
   const {
     transOpen,
     apiSlugs,
+    singleWordNoTrans = false,
     fromLang,
     toLang,
     toLang2 = "en",
@@ -113,6 +114,20 @@ export default function Tranbox() {
                     {api.apiName}
                   </MenuItem>
                 ))}
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                fullWidth
+                select
+                size="small"
+                name="singleWordNoTrans"
+                value={singleWordNoTrans}
+                label={i18n("single_word_no_trans")}
+                onChange={handleChange}
+              >
+                <MenuItem value={false}>{i18n("disable")}</MenuItem>
+                <MenuItem value={true}>{i18n("enable")}</MenuItem>
               </TextField>
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>

--- a/src/views/Selection/TranBox.js
+++ b/src/views/Selection/TranBox.js
@@ -21,6 +21,8 @@ import { sendBgMsg } from "../../libs/msg.js";
 import { isExt } from "../../libs/client.js";
 import { useTheme, alpha } from "@mui/material/styles";
 import Logo from "../../components/Logo";
+import { isValidWord } from "../../libs/utils";
+import { OPT_TRANS_MICROSOFT } from "../../config";
 
 function TranBoxHeader({
   setShowBox,
@@ -337,6 +339,16 @@ export default function TranBox(props) {
   const setHideClickAway = props.setHideClickAway;
   const followSelection = props.followSelection;
   const setFollowSelection = props.setFollowSelection;
+
+  let realApiSlugs = props.tranboxSetting.apiSlugs;
+  if (
+    props.tranboxSetting.singleWordNoTrans &&
+    isValidWord(props.text)
+  ) {
+    // Do not call any translation APIs, rely solely on dictionaries/suggestions
+    realApiSlugs = [];
+  }
+
   return (
     <SettingProvider context="tranbox">
       <ThemeProvider styles={props.extStyles}>
@@ -367,7 +379,7 @@ export default function TranBox(props) {
               simpleStyle={simpleStyle}
               text={props.text}
               setText={props.setText}
-              apiSlugs={props.tranboxSetting.apiSlugs}
+              apiSlugs={realApiSlugs}
               fromLang={props.tranboxSetting.fromLang}
               toLang={props.tranboxSetting.toLang}
               toLang2={props.tranboxSetting.toLang2}

--- a/src/views/Selection/TranForm.js
+++ b/src/views/Selection/TranForm.js
@@ -76,6 +76,10 @@ export default function TranForm({
   }, [text]);
 
   useEffect(() => {
+    setApiSlugs(initApiSlugs);
+  }, [initApiSlugs]);
+
+  useEffect(() => {
     if (!editMode) {
       setEditText(text);
     }


### PR DESCRIPTION
## Motivation

Currently, the extension's word translation feature triggers all configured translation services (including user-defined AI services). When a user selects a **single word**, they usually only need a quick dictionary lookup (like Bing dictionary or Youdao suggestion) to understand the meaning. Calling AI translation services for a single word can be relatively slow and unnecessarily consumes tokens.

## Scope

Added a `singleWordNoTrans` boolean option to the translation box settings (defaults to `false`). When enabled, selecting a single word (validated by `isValidWord`) will bypass all translation services. The translation box will then solely rely on the built-in dictionary and word suggestions, offering a much faster and token-free experience for simple vocabulary lookups.

## Implementation Steps

1. Added `singleWordNoTrans` setting parameter to the global configurations.
2. Displayed the new switch in the Options -> Tranbox UI page (`单个单词划词不调用翻译服务`).
3. Intercepted the API calls in `TranBox.js`: if `singleWordNoTrans` is enabled and the text is a valid single word, the `apiSlugs` array is cleared, relying purely on the dictionaries.