### PR TITLE
fix: correct Chinese language codes mapping when using built-in AI

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -233,8 +233,8 @@ export const OPT_LANGS_SPEC_DEFAULT_UC = new Map(
 export const OPT_LANGS_TO_SPEC = {
   [OPT_TRANS_BUILTINAI]: new Map([
     ...OPT_LANGS_SPEC_DEFAULT,
-    ["zh-CN", "zh"],
-    ["zh-TW", "zh"],
+    ["zh-CN", "zh-Hans"],
+    ["zh-TW", "zh-Hant"],
   ]),
   [OPT_TRANS_GOOGLE]: OPT_LANGS_SPEC_DEFAULT,
   [OPT_TRANS_GOOGLE_2]: OPT_LANGS_SPEC_DEFAULT,


### PR DESCRIPTION
I checked chrome's documentation[1], which states: "Use [BCP 47](https://www.rfc-editor.org/info/bcp47) language short codes as strings"
I guess that's why we had this mapping in the first place:
https://github.com/fishjar/kiss-translator/blob/a839f2830987c84906ddf04bad4d7dc1fcc76e96/src/config/api.js#L236-L237

However, this mapping translates everything into simplified chinese when the target language is supported to be traditional chinese.

And, I did a quick test:
```
const translator = await Translator.create({
  sourceLanguage: 'en',
  targetLanguage: 'zh-Hant',
});
await translator.translate('Where is the next bus stop, please?'); //'請問下一個公車站在哪裡？'
```
It appears that chrome can take "zh-Hant" as target language and provide correct translations.

[1] https://developer.chrome.com/docs/ai/translator-api#language-support