### PR TITLE
feat: 添加划词翻译交互功能

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1929,6 +1929,27 @@ export const I18N = {
     ja: `翻訳ボックスの高さ自動調整`,
     ko: `번역 상자 높이 자동 조절`,
   },
+  tranbox_interact_mode: {
+    zh: `翻译框内交互模式`,
+    en: `Transbox Interact Mode`,
+    zh_TW: `翻譯框內互動模式`,
+    ja: `翻訳ボックス内インタラクションモード`,
+    ko: `번역 상자 내 인터랙션 모드`,
+  },
+  tranbox_interact_click: {
+    zh: `单击选中文本触发翻译`,
+    en: `Click selected text to translate`,
+    zh_TW: `單擊選取文字觸發翻譯`,
+    ja: `選択したテキストをクリックして翻訳`,
+    ko: `선택한 텍스트를 클릭하여 번역`,
+  },
+  tranbox_interact_dblclick: {
+    zh: `双击选中文本触发翻译`,
+    en: `Double-click selected text to translate`,
+    zh_TW: `雙擊選取文字觸發翻譯`,
+    ja: `選択したテキストをダブルクリックして翻訳`,
+    ko: `선택한 텍스트를 더블클릭하여 번역`,
+  },
   translate_start_hook: {
     zh: `翻译开始钩子函数`,
     en: `Translate Start Hook`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -79,6 +79,8 @@ export const OPT_TRANBOX_TRIGGER_ALL = [
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
 ];
+export const OPT_TRANBOX_INTERACT_CLICK = "click"; // 单击翻译框内选中文本触发新翻译
+export const OPT_TRANBOX_INTERACT_DBLCLICK = "dblclick"; // 双击翻译框内选中文本触发新翻译
 export const DEFAULT_TRANBOX_SHORTCUT = ["AltLeft", "KeyS"];
 export const DEFAULT_TRANBOX_SETTING = {
   transOpen: true, // 是否启用划词翻译
@@ -97,6 +99,7 @@ export const DEFAULT_TRANBOX_SETTING = {
   followSelection: false, // 翻译框是否跟随选中文本
   autoHeight: false, // 自适应高度
   triggerMode: OPT_TRANBOX_TRIGGER_CLICK, // 触发翻译方式
+  tranboxInteractMode: "-", // 翻译框内交互模式（单选，"-"表示禁用）
   // extStyles: "", // 附加样式
   enDict: OPT_DICT_BING, // 英文词典
   enSug: OPT_SUG_YOUDAO, // 英文建议

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -5,7 +5,17 @@ import useAutoHideTranBtn from "./useAutoHideTranBtn";
 import {
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
+  OPT_TRANBOX_INTERACT_CLICK,
+  OPT_TRANBOX_INTERACT_DBLCLICK,
 } from "../config";
+
+// 判断事件是否发生在翻译框内部（兼容 Shadow DOM 事件重定向）
+function isEventInTranbox(e) {
+  const path = e.composedPath ? e.composedPath() : [];
+  return path.some(
+    (el) => el.classList && el.classList.contains("KT-draggable")
+  );
+}
 
 export default function useSelectionController({
   tranboxSetting,
@@ -16,7 +26,11 @@ export default function useSelectionController({
   setBoxPosition,
   hideClickAway,
 }) {
-  const { hideTranBtn = false, triggerMode } = tranboxSetting;
+  const {
+    hideTranBtn = false,
+    triggerMode,
+    tranboxInteractMode = "-",
+  } = tranboxSetting;
 
   const [showBox, setShowBox] = useState(false);
   const [showBtn, setShowBtn] = useState(false);
@@ -75,11 +89,13 @@ export default function useSelectionController({
   }, [triggerMode]);
 
   // 监听划词事件
+  // 注意：翻译框内容区域已通过 onMouseUp/onTouchEnd stopPropagation 阻止事件冒泡，
+  // 因此此处的 handleMouseup 不会被翻译框内的选中操作触发。
   useEffect(() => {
     const eventName = isMobile ? "touchend" : "mouseup";
 
     async function handleMouseup(e) {
-      // e.stopPropagation();
+      // e.stopPropagation();\
       if (e.button === 2) return;
 
       await sleep(200);
@@ -128,6 +144,41 @@ export default function useSelectionController({
     boxSize,
     setBoxPosition,
   ]);
+
+  // 监听翻译框内交互事件（单击/双击选中文本触发新翻译）
+  // 使用 composedPath 判断事件来源，兼容 Shadow DOM 事件重定向
+  // 注意：翻译框内容区域已通过 stopPropagation 阻止 mouseup 冒泡到 window，
+  // 因此此处改用 document 捕获阶段监听，以接收翻译框内的事件。
+  useEffect(() => {
+    if (
+      tranboxInteractMode !== OPT_TRANBOX_INTERACT_CLICK &&
+      tranboxInteractMode !== OPT_TRANBOX_INTERACT_DBLCLICK
+    ) {
+      return;
+    }
+
+    const eventName =
+      tranboxInteractMode === OPT_TRANBOX_INTERACT_DBLCLICK
+        ? "dblclick"
+        : "mouseup";
+
+    function handleInteract(e) {
+      // 只响应来自翻译框内部的事件（通过 composedPath 跨越 Shadow DOM 边界检测）
+      if (!isEventInTranbox(e)) return;
+
+      const selection = window.getSelection();
+      const currentSelectedText = selection?.toString()?.trim() || "";
+      if (!currentSelectedText) return;
+
+      handleOpenTranbox(currentSelectedText);
+    }
+
+    // 使用 capture=true 以在 stopPropagation 之前捕获到翻译框内的事件
+    document.addEventListener(eventName, handleInteract, true);
+    return () => {
+      document.removeEventListener(eventName, handleInteract, true);
+    };
+  }, [tranboxInteractMode, handleOpenTranbox]);
 
   // 点击空白处隐藏翻译框
   useEffect(() => {

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -9,6 +9,8 @@ import {
   OPT_LANGS_TO,
   OPT_TRANBOX_TRIGGER_CLICK,
   OPT_TRANBOX_TRIGGER_ALL,
+  OPT_TRANBOX_INTERACT_CLICK,
+  OPT_TRANBOX_INTERACT_DBLCLICK,
   OPT_DICT_BING,
   OPT_DICT_ALL,
   OPT_SUG_ALL,
@@ -70,6 +72,7 @@ export default function Tranbox() {
     followSelection = false,
     autoHeight = false,
     triggerMode = OPT_TRANBOX_TRIGGER_CLICK,
+    tranboxInteractMode = "-",
     // extStyles = "",
     enDict = OPT_DICT_BING,
     enSug = OPT_SUG_YOUDAO,
@@ -276,6 +279,26 @@ export default function Tranbox() {
               >
                 <MenuItem value={false}>{i18n("disable")}</MenuItem>
                 <MenuItem value={true}>{i18n("enable")}</MenuItem>
+              </TextField>
+            </Grid>
+
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                fullWidth
+                select
+                size="small"
+                name="tranboxInteractMode"
+                value={tranboxInteractMode}
+                label={i18n("tranbox_interact_mode")}
+                onChange={handleChange}
+              >
+                <MenuItem value="-">{i18n("disable")}</MenuItem>
+                <MenuItem value={OPT_TRANBOX_INTERACT_CLICK}>
+                  {i18n("tranbox_interact_click")}
+                </MenuItem>
+                <MenuItem value={OPT_TRANBOX_INTERACT_DBLCLICK}>
+                  {i18n("tranbox_interact_dblclick")}
+                </MenuItem>
               </TextField>
             </Grid>
 

--- a/src/views/Selection/DraggableResizable.js
+++ b/src/views/Selection/DraggableResizable.js
@@ -254,6 +254,8 @@ export default function DraggableResizable({
         </Pointer>
         <Box
           className="KT-draggable-container"
+          onMouseUp={(e) => e.stopPropagation()}
+          onTouchEnd={(e) => e.stopPropagation()}
           sx={() => {
             const containerStyle = autoHeight
               ? {

--- a/src/views/Selection/TranForm.js
+++ b/src/views/Selection/TranForm.js
@@ -145,7 +145,6 @@ export default function TranForm({
     return apiSlugs.filter((slug) => validSlugs.has(slug));
   }, [apiSlugs, optApis]);
 
-
   return (
     <Stack spacing={simpleStyle ? 1 : 2}>
       {!simpleStyle && (


### PR DESCRIPTION
在[简洁模式]+[选中触发]时，旧版本无法部分选中，会直接将翻译结果作为新的输入进行翻译。
现在添加了多个可选项，支持单击翻译、双击翻译和禁用