### PR TITLE
✨ Quality: Add SVG elements to default non-translation selectors

### DIFF
--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -46,7 +46,7 @@ export const OPT_HIGHLIGHT_WORDS_ALL = [
 
 export const DEFAULT_SELECTOR =
   "h1, h2, h3, h4, h5, h6, li, p, dd, blockquote, figcaption, label, legend";
-export const DEFAULT_IGNORE_SELECTOR = "button, footer, pre, mark, nav";
+export const DEFAULT_IGNORE_SELECTOR = "button, footer, pre, mark, nav, svg, img[src*='.svg'], [class*='logo'] svg, [id*='logo'] svg";
 export const DEFAULT_KEEP_SELECTOR = `code, cite, math, .math, a:has(code)`;
 export const DEFAULT_RULE = {
   pattern: "", // 匹配网址


### PR DESCRIPTION
## Problem

Add SVG-related selectors to the default 'skip translation' node selector configuration to prevent SVG logos and icons from being affected during full-page translation. This will fix the issue where Medium's logo (and other SVG elements) become enlarged when translation is enabled.

**Severity**: `high`
**File**: `src/config/rules.js`

## Solution

Find the default configuration for '不翻译节点选择器' (non-translation node selector) and add common SVG selectors like 'svg', '[class*="logo"] svg', 'img[src*=".svg"]', etc. The configuration likely has a structure with default rules that apply to all sites. Add SVG exclusion patterns to prevent translation engine from modifying SVG elements' styles or content.

## Changes

- `src/config/rules.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #585