### PR TITLE
Security: Overly permissive Trusted Types policy neutralizes XSS protections

### DIFF
--- a/src/libs/trustedTypes.js
+++ b/src/libs/trustedTypes.js
@@ -7,9 +7,28 @@ export const trustedTypesHelper = (() => {
   if (globalThis.trustedTypes && globalThis.trustedTypes.createPolicy) {
     try {
       policy = globalThis.trustedTypes.createPolicy(POLICY_NAME, {
-        createHTML: (string) => string,
-        createScript: (string) => string,
-        createScriptURL: (string) => string,
+        createHTML: (string) =>
+          String(string)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;"),
+        createScript: () => {
+          throw new TypeError("createScript is disabled");
+        },
+        createScriptURL: (string) => {
+          const url = String(string);
+
+          if (
+            url.startsWith("chrome-extension://") ||
+            url.startsWith("moz-extension://")
+          ) {
+            return url;
+          }
+
+          throw new TypeError("Untrusted script URL");
+        },
       });
     } catch (err) {
       if (err.message.includes("already exists")) {


### PR DESCRIPTION
## Problem

The Trusted Types policy returns input strings unchanged for `createHTML`, `createScript`, and `createScriptURL`. This defeats Trusted Types’ purpose by allowing arbitrary HTML/script/script URLs to be treated as trusted, increasing impact if any untrusted input reaches injection sinks.

**Severity**: `high`
**File**: `src/libs/trustedTypes.js`

## Solution

Replace pass-through policy functions with strict sanitization/allowlisting. Avoid defining `createScript` unless absolutely necessary, and constrain `createScriptURL` to vetted extension URLs. Prefer removing this custom policy and using safe DOM APIs that do not require Trusted Types bypasses.

## Changes

- `src/libs/trustedTypes.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
