### PR TITLE
fix: 切换翻译服务时无法自动刷新，必须重新载入页面才会生效

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -805,41 +805,41 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = events
       ? genSubtitlePrompt({
-        subtitlePrompt,
-        from,
-        to,
-        fromLang,
-        toLang,
-        texts,
-        docInfo,
-        tone,
-        aiTerms,
-      })
+          subtitlePrompt,
+          from,
+          to,
+          fromLang,
+          toLang,
+          texts,
+          docInfo,
+          tone,
+          aiTerms,
+        })
       : genSystemPrompt({
-        systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
-        from,
-        to,
-        fromLang,
-        toLang,
-        texts,
-        docInfo,
-        tone,
-      });
+          systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
+          from,
+          to,
+          fromLang,
+          toLang,
+          texts,
+          docInfo,
+          tone,
+        });
     args.userPrompt = events
       ? JSON.stringify(events)
       : genUserPrompt({
-        nobatchUserPrompt,
-        useBatchFetch,
-        from,
-        to,
-        fromLang,
-        toLang,
-        texts,
-        docInfo,
-        tone,
-        glossary,
-        aiTerms,
-      });
+          nobatchUserPrompt,
+          useBatchFetch,
+          from,
+          to,
+          fromLang,
+          toLang,
+          texts,
+          docInfo,
+          tone,
+          glossary,
+          aiTerms,
+        });
   }
 
   const {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -161,9 +161,7 @@ export const API_SPE_TYPES = {
     OPT_TRANS_EPHONEAI,
   ]),
   // 赞助商
-  sponsors: new Set([
-    OPT_TRANS_EPHONEAI
-  ])
+  sponsors: new Set([OPT_TRANS_EPHONEAI]),
 };
 
 export const BUILTIN_STONES = [

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -46,7 +46,8 @@ export const OPT_HIGHLIGHT_WORDS_ALL = [
 
 export const DEFAULT_SELECTOR =
   "h1, h2, h3, h4, h5, h6, li, p, dd, blockquote, figcaption, label, legend";
-export const DEFAULT_IGNORE_SELECTOR = "button, footer, pre, mark, nav, svg, img[src*='.svg'], [class*='logo'] svg, [id*='logo'] svg";
+export const DEFAULT_IGNORE_SELECTOR =
+  "button, footer, pre, mark, nav, svg, img[src*='.svg'], [class*='logo'] svg, [id*='logo'] svg";
 export const DEFAULT_KEEP_SELECTOR = `code, cite, math, .math, a:has(code)`;
 export const DEFAULT_RULE = {
   pattern: "", // 匹配网址

--- a/src/libs/fetch.js
+++ b/src/libs/fetch.js
@@ -30,12 +30,13 @@ export const fetchGM = async (
       onload: ({ response, responseHeaders, status, statusText }) => {
         const headers = {};
         try {
-          responseHeaders && responseHeaders.split("\n").forEach((line) => {
-            const [name, value] = line.split(":").map((item) => item.trim());
-            if (name && value) {
-              headers[name] = value;
-            }
-          });
+          responseHeaders &&
+            responseHeaders.split("\n").forEach((line) => {
+              const [name, value] = line.split(":").map((item) => item.trim());
+              if (name && value) {
+                headers[name] = value;
+              }
+            });
         } catch (e) {
           kissLog("fetchGM parse headers error", e);
         }

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -184,3 +184,47 @@ export const tryInitDefaultData = async () => {
     kissLog("init default", err);
   }
 };
+
+/**
+ * 监听设置变化
+ */
+export const addSettingListener = (callback) => {
+  if (isExt) {
+    browser.storage.onChanged.addListener((changes, area) => {
+      if (area === "local" && changes[STOKEY_SETTING]) {
+        try {
+          const newVal = JSON.parse(changes[STOKEY_SETTING].newValue);
+          if (newVal) callback(newVal);
+        } catch (err) {
+          kissLog("parse setting listener error", err);
+        }
+      }
+    });
+  } else if (isGm) {
+    const KISS_GM = window.KISS_GM || GM;
+    if (KISS_GM && typeof KISS_GM.addValueChangeListener === "function") {
+      KISS_GM.addValueChangeListener(
+        STOKEY_SETTING,
+        (name, old_value, new_value, remote) => {
+          try {
+            const newVal = JSON.parse(new_value);
+            if (newVal) callback(newVal);
+          } catch (err) {
+            kissLog("parse setting listener error", err);
+          }
+        }
+      );
+    }
+  } else {
+    window.addEventListener("storage", (e) => {
+      if (e.key === STOKEY_SETTING) {
+        try {
+          const newVal = JSON.parse(e.newValue);
+          if (newVal) callback(newVal);
+        } catch (err) {
+          kissLog("parse setting listener error", err);
+        }
+      }
+    });
+  }
+};

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -646,6 +646,15 @@ export class Translator {
     );
   }
 
+  // 更新配置
+  updateSetting(newSetting) {
+    if (!newSetting) return;
+    this.#setting = { ...Translator.DEFAULT_OPTIONS, ...newSetting };
+    this.#apisMap = new Map(
+      this.#setting.transApis.map((api) => [api.apiSlug, api])
+    );
+  }
+
   // 监控页面动态变化
   #createMutationObserver() {
     return new MutationObserver((mutations) => {
@@ -1291,7 +1300,7 @@ export class Translator {
       }
 
       const inner = document.createElement(transTag);
-      inner.lang = toLang
+      inner.lang = toLang;
       inner.className = `${Translator.KISS_CLASS.inner} ${this.#textClass[textStyle] || ""}`;
       if (textExtStyle?.trim()) {
         inner.style.cssText = textExtStyle; // 附加内联样式

--- a/src/libs/translatorManager.js
+++ b/src/libs/translatorManager.js
@@ -11,6 +11,7 @@ import {
   MSG_INPUT_TRANSLATE,
   newI18n,
 } from "../config";
+import { addSettingListener } from "./storage";
 import { touchTapListener } from "./touch";
 import { PopupManager } from "./popupManager";
 import { FabManager } from "./fabManager";
@@ -93,6 +94,12 @@ export default class TranslatorManager {
       this.#registerShortcuts();
       this.#registerMenus();
     }
+
+    addSettingListener((newSetting) => {
+      if (this._translator) {
+        this._translator.updateSetting(newSetting);
+      }
+    });
 
     this.#isActive = true;
     logger.info("TranslatorManager started.");

--- a/src/libs/trustedTypes.js
+++ b/src/libs/trustedTypes.js
@@ -1,5 +1,5 @@
 import { logger } from "./log";
-import DOMPurify from 'dompurify';
+import DOMPurify from "dompurify";
 
 export const trustedTypesHelper = (() => {
   const POLICY_NAME = "kiss-translator-policy";

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -11,7 +11,7 @@ import Typography from "@mui/material/Typography";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
-import StarIcon from '@mui/icons-material/Star';
+import StarIcon from "@mui/icons-material/Star";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
 import Alert from "@mui/material/Alert";
@@ -247,7 +247,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
     "gpt-5.4-nano",
     "gemini-3.1-flash-lite-preview",
     "grok-4.20-beta-0309-non-reasoning",
-  ]
+  ];
 
   return (
     <Stack spacing={3}>
@@ -320,8 +320,8 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
         <>
           <Box>
             <Grid container spacing={2} columns={12}>
-              {
-                apiType === OPT_TRANS_EPHONEAI ? <Grid item xs={12} sm={12} md={6} lg={3}>
+              {apiType === OPT_TRANS_EPHONEAI ? (
+                <Grid item xs={12} sm={12} md={6} lg={3}>
                   <ReusableAutocomplete
                     freeSolo
                     size="small"
@@ -332,7 +332,9 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
                     value={model}
                     onChange={handleChange}
                   />
-                </Grid> : <Grid item xs={12} sm={12} md={6} lg={3}>
+                </Grid>
+              ) : (
+                <Grid item xs={12} sm={12} md={6} lg={3}>
                   {/* todo： 改成 ReusableAutocomplete 可选择和填写模型 */}
                   <TextField
                     size="small"
@@ -343,7 +345,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
                     onChange={handleChange}
                   />
                 </Grid>
-              }
+              )}
               <Grid item xs={12} sm={12} md={6} lg={3}>
                 <ReusableAutocomplete
                   freeSolo
@@ -993,11 +995,9 @@ export default function Apis() {
                 onClick={() => handleMenuItemClick(apiOption.type)}
               >
                 {apiOption.label}
-                {
-                  API_SPE_TYPES.sponsors.has(apiOption.type) && (
-                    <StarIcon color="warning" sx={{ marginLeft: "0.2em" }} />
-                  )
-                }
+                {API_SPE_TYPES.sponsors.has(apiOption.type) && (
+                  <StarIcon color="warning" sx={{ marginLeft: "0.2em" }} />
+                )}
               </MenuItem>
             ))}
           </Menu>


### PR DESCRIPTION
在已经翻译的网页中切换翻译服务，可以立即自动刷新
旧方案会在切换到自定义翻译服务时，仍旧显示原有的翻译服务，
哪怕点了清除缓存也是如此，必须要刷新整个页面