### PR TITLE
feat: 支持划词弹窗的尺寸可被拖曳修改宽度

### DIFF
--- a/src/views/Selection/DraggableResizable.js
+++ b/src/views/Selection/DraggableResizable.js
@@ -259,14 +259,16 @@ export default function DraggableResizable({
           sx={() => {
             const containerStyle = autoHeight
               ? {
-                  maxWidth: size.w,
+                  width: size.w,
                   maxHeight: size.h,
                   overflow: "hidden auto",
+                  wordBreak: "break-word",
                 }
               : {
-                  maxWidth: size.w,
+                  width: size.w,
                   height: size.h,
                   overflow: "hidden auto",
+                  wordBreak: "break-word",
                 };
 
             const scrollbarTrackColor =


### PR DESCRIPTION
现在虽然也能修改宽度，但是在窄的地方会有黑边，而且最大尺寸也不如这个方案