### PR TITLE
refactor: 移动prompt和ai术语输入框到更多设置项内

### DIFF
--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -389,99 +389,6 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
             </Grid>
           </Box>
 
-          {useBatchFetch ? (
-            <TextField
-              size="small"
-              label={"Batch System Prompt"}
-              name="systemPrompt"
-              value={systemPrompt}
-              onChange={handleChange}
-              multiline
-              maxRows={10}
-              helperText={
-                <>
-                  {i18n("system_prompt_helper_1")}
-                  <Link
-                    component="button"
-                    sx={{ margin: "0 1em" }}
-                    data-output="json"
-                    onClick={handleUpdateSystemPrompt}
-                  >
-                    {i18n("json_output")}
-                  </Link>
-                  <Link
-                    component="button"
-                    sx={{ margin: "0 1em" }}
-                    data-output="xml"
-                    onClick={handleUpdateSystemPrompt}
-                  >
-                    {i18n("xml_output")}
-                  </Link>
-                  <Link
-                    component="button"
-                    sx={{ margin: "0 1em" }}
-                    data-output="textlines"
-                    onClick={handleUpdateSystemPrompt}
-                  >
-                    {i18n("textlines_output")}
-                  </Link>
-                  <br />
-                  {i18n("system_prompt_helper_2")}
-                </>
-              }
-            />
-          ) : (
-            <>
-              <TextField
-                size="small"
-                label={"System Prompt"}
-                name="nobatchPrompt"
-                value={nobatchPrompt}
-                onChange={handleChange}
-                multiline
-                maxRows={10}
-              />
-              <TextField
-                size="small"
-                label={"User Prompt"}
-                name="nobatchUserPrompt"
-                value={nobatchUserPrompt}
-                onChange={handleChange}
-                multiline
-                maxRows={10}
-              />
-            </>
-          )}
-
-          <TextField
-            size="small"
-            label={"Subtitle Prompt"}
-            name="subtitlePrompt"
-            value={subtitlePrompt}
-            onChange={handleChange}
-            multiline
-            maxRows={10}
-            helperText={i18n("system_prompt_helper")}
-          />
-          {/* <TextField
-            size="small"
-            label={"USER PROMPT"}
-            name="userPrompt"
-            value={userPrompt}
-            onChange={handleChange}
-            multiline
-            maxRows={10}
-          /> */}
-          <TextField
-            size="small"
-            label={i18n("ai_terms")}
-            helperText={i18n("ai_terms_helper")}
-            name="aiTerms"
-            value={aiTerms}
-            onChange={handleChange}
-            multiline
-            maxRows={10}
-          />
         </>
       )}
 
@@ -765,6 +672,95 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
               </Grid>
             </Grid>
           </Box>
+
+          {API_SPE_TYPES.ai.has(apiType) && (
+            <>
+              {useBatchFetch ? (
+                <TextField
+                  size="small"
+                  label={"Batch System Prompt"}
+                  name="systemPrompt"
+                  value={systemPrompt}
+                  onChange={handleChange}
+                  multiline
+                  maxRows={10}
+                  helperText={
+                    <>
+                      {i18n("system_prompt_helper_1")}
+                      <Link
+                        component="button"
+                        sx={{ margin: "0 1em" }}
+                        data-output="json"
+                        onClick={handleUpdateSystemPrompt}
+                      >
+                        {i18n("json_output")}
+                      </Link>
+                      <Link
+                        component="button"
+                        sx={{ margin: "0 1em" }}
+                        data-output="xml"
+                        onClick={handleUpdateSystemPrompt}
+                      >
+                        {i18n("xml_output")}
+                      </Link>
+                      <Link
+                        component="button"
+                        sx={{ margin: "0 1em" }}
+                        data-output="textlines"
+                        onClick={handleUpdateSystemPrompt}
+                      >
+                        {i18n("textlines_output")}
+                      </Link>
+                      <br />
+                      {i18n("system_prompt_helper_2")}
+                    </>
+                  }
+                />
+              ) : (
+                <>
+                  <TextField
+                    size="small"
+                    label={"System Prompt"}
+                    name="nobatchPrompt"
+                    value={nobatchPrompt}
+                    onChange={handleChange}
+                    multiline
+                    maxRows={10}
+                  />
+                  <TextField
+                    size="small"
+                    label={"User Prompt"}
+                    name="nobatchUserPrompt"
+                    value={nobatchUserPrompt}
+                    onChange={handleChange}
+                    multiline
+                    maxRows={10}
+                  />
+                </>
+              )}
+
+              <TextField
+                size="small"
+                label={"Subtitle Prompt"}
+                name="subtitlePrompt"
+                value={subtitlePrompt}
+                onChange={handleChange}
+                multiline
+                maxRows={10}
+                helperText={i18n("system_prompt_helper")}
+              />
+              <TextField
+                size="small"
+                label={i18n("ai_terms")}
+                helperText={i18n("ai_terms_helper")}
+                name="aiTerms"
+                value={aiTerms}
+                onChange={handleChange}
+                multiline
+                maxRows={10}
+              />
+            </>
+          )}
 
           {apiType !== OPT_TRANS_BUILTINAI && (
             <>


### PR DESCRIPTION
移动prompt和ai术语输入框到更多设置项内，避免界面混乱过长。