### PR TITLE
feat: 接口支持置顶、首字母排序及禁用自动沉底

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2045,6 +2045,20 @@ export const I18N = {
     ja: `無効にする`,
     ko: `비활성화 여부`,
   },
+  is_pinned: {
+    zh: `是否置顶`,
+    en: `Is Pinned`,
+    zh_TW: `是否置頂`,
+    ja: `ピン留め`,
+    ko: `고정 여부`,
+  },
+  sort_alphabetically: {
+    zh: `按字母排序`,
+    en: `Sort Alphabetically`,
+    zh_TW: `按字母排序`,
+    ja: `アルファベット順`,
+    ko: `알파벳순 정렬`,
+  },
   translate_selected: {
     zh: `是否启用划词翻译`,
     en: `If translate selected`,

--- a/src/hooks/Api.js
+++ b/src/hooks/Api.js
@@ -106,6 +106,38 @@ export function useApiList() {
     [updateSetting]
   );
 
+  const alphaSortApis = useCallback(
+    (direction = "asc") => {
+      updateSetting((prev) => {
+        const apis = prev?.transApis || [];
+        const pinnedApis = apis.filter((a) => a.sortOrder === -1);
+        const disabledApis = apis.filter((a) => a.isDisabled);
+        const normalApis = apis.filter(
+          (a) => a.sortOrder !== -1 && !a.isDisabled
+        );
+
+        const sorted = [...normalApis].sort((a, b) => {
+          const nameA = (a.apiName || "").toLowerCase();
+          const nameB = (b.apiName || "").toLowerCase();
+          return direction === "asc"
+            ? nameA.localeCompare(nameB)
+            : nameB.localeCompare(nameA);
+        });
+
+        const reassigned = sorted.map((api, index) => ({
+          ...api,
+          sortOrder: index,
+        }));
+
+        return {
+          ...prev,
+          transApis: [...pinnedApis, ...reassigned, ...disabledApis],
+        };
+      });
+    },
+    [updateSetting]
+  );
+
   return {
     transApis,
     userApis,
@@ -115,6 +147,7 @@ export function useApiList() {
     addApi,
     copyApi,
     deleteApi,
+    alphaSortApis,
   };
 }
 

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -14,6 +14,7 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 import StarIcon from "@mui/icons-material/Star";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import Alert from "@mui/material/Alert";
 import Menu from "@mui/material/Menu";
 import Grid from "@mui/material/Grid";
@@ -110,7 +111,7 @@ function TestButton({ api }) {
   );
 }
 
-function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
+function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
   const { api, update, reset } = useApiItem(apiSlug);
   const i18n = useI18n();
   const [formData, setFormData] = useState({});
@@ -144,9 +145,12 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
         [name]: value,
       };
 
-      // 关闭聚合翻译时，自动关闭流式传输
       if (name === "useBatchFetch" && value === false) {
         newData.useStream = false;
+      }
+
+      if (name === "isDisabled") {
+        newData.sortOrder = value ? 999 : 0;
       }
 
       return newData;
@@ -168,15 +172,10 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
   };
 
   const handleSave = () => {
-    // 过滤掉 api 对象中不存在的字段
-    // const updatedFields = Object.keys(formData).reduce((acc, key) => {
-    //   if (api && Object.keys(api).includes(key)) {
-    //     acc[key] = formData[key];
-    //   }
-    //   return acc;
-    // }, {});
-    // update(updatedFields);
     update(formData);
+    if (formData.isDisabled || formData.sortOrder === -1) {
+      onCollapse?.();
+    }
   };
 
   const handleReset = () => {
@@ -879,6 +878,23 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi }) {
           label={i18n("is_disabled")}
         />
 
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={sortOrder === -1}
+              onChange={(e) => {
+                setFormData((prev) => ({
+                  ...prev,
+                  sortOrder: e.target.checked ? -1 : 0,
+                }));
+              }}
+              disabled={isDisabled}
+            />
+          }
+          label={i18n("is_pinned")}
+        />
+
         <ShowMoreButton showMore={showMore} onChange={setShowMore} />
       </Stack>
 
@@ -913,6 +929,7 @@ function ApiAccordion({ api, isUserApi, deleteApi, copyApi }) {
             isUserApi={isUserApi}
             deleteApi={deleteApi}
             copyApi={copyApi}
+            onCollapse={() => setExpanded(false)}
           />
         )}
       </AccordionDetails>
@@ -922,7 +939,11 @@ function ApiAccordion({ api, isUserApi, deleteApi, copyApi }) {
 
 export default function Apis() {
   const i18n = useI18n();
-  const { userApis, builtinApis, addApi, deleteApi, copyApi } = useApiList();
+  const { userApis, builtinApis, addApi, deleteApi, copyApi, alphaSortApis } =
+    useApiList();
+
+  const [alphaSortDir, setAlphaSortDir] = useState("asc");
+  const [collapseKey, setCollapseKey] = useState(0);
 
   const apiTypes = useMemo(
     () =>
@@ -967,19 +988,34 @@ export default function Apis() {
         </Alert>
 
         <Box>
-          <Button
-            size="small"
-            id="add-api-button"
-            variant="contained"
-            onClick={handleClick}
-            aria-controls={open ? "add-api-menu" : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? "true" : undefined}
-            endIcon={<KeyboardArrowDownIcon />}
-            startIcon={<AddIcon />}
-          >
-            {i18n("add")}
-          </Button>
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <Button
+              size="small"
+              id="add-api-button"
+              variant="contained"
+              onClick={handleClick}
+              aria-controls={open ? "add-api-menu" : undefined}
+              aria-haspopup="true"
+              aria-expanded={open ? "true" : undefined}
+              endIcon={<KeyboardArrowDownIcon />}
+              startIcon={<AddIcon />}
+            >
+              {i18n("add")}
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={() => {
+                const newDir = alphaSortDir === "asc" ? "desc" : "asc";
+                setAlphaSortDir(newDir);
+                setCollapseKey((k) => k + 1);
+                alphaSortApis(newDir);
+              }}
+              startIcon={<SwapVertIcon />}
+            >
+              {i18n("sort_alphabetically")}
+            </Button>
+          </Stack>
           <Menu
             id="add-api-menu"
             anchorEl={anchorEl}
@@ -1006,7 +1042,7 @@ export default function Apis() {
         <Box>
           {userApis.map((api) => (
             <ApiAccordion
-              key={api.apiSlug}
+              key={`${collapseKey}-${api.apiSlug}`}
               api={api}
               isUserApi={true}
               deleteApi={deleteApi}
@@ -1016,7 +1052,11 @@ export default function Apis() {
         </Box>
         <Box>
           {builtinApis.map((api) => (
-            <ApiAccordion key={api.apiSlug} api={api} copyApi={copyApi} />
+            <ApiAccordion
+              key={`${collapseKey}-${api.apiSlug}`}
+              api={api}
+              copyApi={copyApi}
+            />
           ))}
         </Box>
       </Stack>


### PR DESCRIPTION
接口设置页面新增 置顶 、 首字母排序 及 禁用自动沉底 三项功能。

1. 接口置顶 — transApis 每项新增 isPinned 字段。置顶接口在列表中独立分区显示（用户接口上方），不参与排序，可跨内置/自定义接口使用。
2. 首字母排序 — 设置项 sortApiAsc 持久化至 setting （随 kiss-worker / WebDAV 同步）。排序比较器 disabledLastSort 依次按 isDisabled （沉底）→ apiName （字母序）→ sortOrder （兜底）三级排序。
3. 禁用自动沉底 + 收起 — 比较器第一优先级为 isDisabled ，被禁用接口自动沉底； ApiAccordion 监听 isDisabled 变化自动收起面板。
4. UI — “添加”按钮旁新增 variant="outlined" 排序按钮， SwapVertIcon + 文字"首字母排序"，风格与收藏词汇操作栏一致。


<img width="614" height="1216" alt="image" src="https://github.com/user-attachments/assets/8ef6b7c4-aeec-4165-b27d-7e58211854fb" />

<img width="921" height="412" alt="image" src="https://github.com/user-attachments/assets/b6816933-8bb1-4dc1-aa6f-894c84f7485f" />

<img width="742" height="1263" alt="image" src="https://github.com/user-attachments/assets/a0b58b00-6fcb-4ffc-963d-219f3e9f88df" />
