### PR TITLE
fix: 改用事件索引模式替代LLM时间戳算术，消除字幕断句漂移

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -270,6 +270,23 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
+const getPauseLevel = (gapMs) => {
+  if (!Number.isFinite(gapMs) || gapMs <= 300) return 0;
+  if (gapMs <= 600) return 1;
+  if (gapMs <= 1200) return 2;
+  return 3;
+};
+
+const formatIndexSubtitleEvents = (events) =>
+  events.map((e, i) => {
+    const item = { id: i, text: e.text };
+    if (i > 0) {
+      const p = getPauseLevel(e.start - events[i - 1].end);
+      if (p) item.p = p;
+    }
+    return item;
+  });
+
 const usesIndexSubtitleInput = (prompt = "") => {
   if (/\{\s*["']?s["']?\s*:/.test(prompt) && /\bid\b/i.test(prompt))
     return true;
@@ -991,7 +1008,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     args.userPrompt = events
       ? JSON.stringify(
           usesIndexSubtitleInput(subtitlePrompt)
-            ? events.map((e, i) => ({ id: i, text: e.text }))
+            ? formatIndexSubtitleEvents(events)
             : events
         )
       : genUserPrompt({

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -270,13 +270,45 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
-const parseSTRes = (raw) => {
+const parseIndexSubtitleRes = (raw, events) => {
+  try {
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data) || !data.length) return null;
+
+    const result = [];
+    for (const seg of data) {
+      const s = Number(seg.s ?? seg.start_id);
+      const e = Number(seg.e ?? seg.end_id);
+      if (!Number.isInteger(s) || !Number.isInteger(e)) continue;
+
+      const startIdx = Math.max(0, Math.min(s, events.length - 1));
+      const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
+
+      result.push({
+        start: events[startIdx].start,
+        end: events[endIdx].end,
+        text: String(seg.o ?? seg.original ?? ""),
+        translation: String(seg.t ?? seg.translation ?? ""),
+      });
+    }
+
+    return result.length ? result : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseSTRes = (raw, events = null) => {
   if (!raw) {
     return [];
   }
 
   try {
     const cleaned = stripMarkdownCodeBlock(raw);
+    if (events?.length) {
+      const indexResult = parseIndexSubtitleRes(cleaned, events);
+      if (indexResult?.length) return indexResult;
+    }
     const data = parseBilingualVtt(cleaned);
     if (Array.isArray(data)) {
       return data;
@@ -950,7 +982,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
-      ? JSON.stringify(events)
+      ? JSON.stringify(events.map((e, i) => ({ id: i, text: e.text })))
       : genUserPrompt({
           nobatchUserPrompt,
           useBatchFetch,
@@ -1469,11 +1501,14 @@ export const handleSubtitle = async ({
     case OPT_TRANS_GEMINI_2:
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
-      return parseSTRes(res?.choices?.[0]?.message?.content ?? "");
+      return parseSTRes(res?.choices?.[0]?.message?.content ?? "", events);
     case OPT_TRANS_GEMINI:
-      return parseSTRes(res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "");
+      return parseSTRes(
+        res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "",
+        events
+      );
     case OPT_TRANS_CLAUDE:
-      return parseSTRes(res?.content?.[0]?.text ?? "");
+      return parseSTRes(res?.content?.[0]?.text ?? "", events);
     case OPT_TRANS_CUSTOMIZE:
       return res;
     default:

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -276,9 +276,8 @@ const parseSTRes = (raw) => {
   }
 
   try {
-    // const jsonString = extractJson(raw);
-    // const data = JSON.parse(jsonString);
-    const data = parseBilingualVtt(raw);
+    const cleaned = stripMarkdownCodeBlock(raw);
+    const data = parseBilingualVtt(cleaned);
     if (Array.isArray(data)) {
       return data;
     }

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -270,6 +270,13 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
+const usesIndexSubtitleInput = (prompt = "") => {
+  if (/\{\s*["']?s["']?\s*:/.test(prompt) && /\bid\b/i.test(prompt))
+    return true;
+  if (/WEBVTT|MM:SS\.mmm|-->/i.test(prompt)) return false;
+  return false;
+};
+
 const parseIndexSubtitleRes = (raw, events) => {
   try {
     const data = JSON.parse(raw);
@@ -982,7 +989,11 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
-      ? JSON.stringify(events.map((e, i) => ({ id: i, text: e.text })))
+      ? JSON.stringify(
+          usesIndexSubtitleInput(subtitlePrompt)
+            ? events.map((e, i) => ({ id: i, text: e.text }))
+            : events
+        )
       : genUserPrompt({
           nobatchUserPrompt,
           useBatchFetch,

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -633,10 +633,11 @@ Group the input word-level JSON into bilingual subtitle segments. Target Languag
 
 # Rules
 1. Merge words into complete sentences, split at natural pauses into readable segments.
-2. Translate using Context and Tone.
+2. Some input words include "p" (pause level 1-3). Higher "p" suggests a stronger sentence boundary, but grammar and meaning take priority.
+3. Translate using Context and Tone.
 
 # Example
-Input: [{"id":0,"text":"Hello"},{"id":1,"text":"world!"},{"id":2,"text":"Good"},{"id":3,"text":"morning."}]
+Input: [{"id":0,"text":"Hello"},{"id":1,"text":"world!"},{"id":2,"text":"Good","p":2},{"id":3,"text":"morning."}]
 Output: [{"s":0,"e":1,"o":"Hello world!","t":"你好，世界！"},{"s":2,"e":3,"o":"Good morning.","t":"早上好。"}]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -630,7 +630,6 @@ Group the input word-level JSON into bilingual subtitle segments. Target Languag
 2. Each element: {"s":<first_word_id>,"e":<last_word_id>,"o":"merged original text","t":"translation"}
 3. "s" and "e" are inclusive word IDs from the input.
 4. Cover all input words exactly once (no gaps, no overlaps).
-5. Keep non-speech sounds (e.g., [Music]) as is in both "o" and "t".
 
 # Rules
 1. Merge words into complete sentences, split at natural pauses into readable segments.

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -623,26 +623,35 @@ Tone: ${INPUT_PLACE_TONE}
 ${INPUT_PLACE_GLOSSARY}
 
 # Task
-Convert the input word-level timestamp JSON into a bilingual VTT file. Target Language: ${INPUT_PLACE_TO}.
+Convert the input word-level timestamp JSON into a bilingual WebVTT subtitle. Target Language: ${INPUT_PLACE_TO}.
+
+# Output Contract
+1. Output plain text only. No markdown, no code fences, no backticks.
+2. First line: WEBVTT, then a blank line.
+3. Each cue = timestamp line + exactly 2 text lines (original + ${INPUT_PLACE_TO} translation).
+4. One blank line between cues. No cue numbers.
+5. No commentary, notes, or extra text outside the VTT structure.
 
 # Rules
-1. Merge words into complete sentences first.
-2. Split long sentences into readable cues (max 42 chars/line, natural pauses).
-3. Strict Glossary Adherence: Use the provided Glossary for specific terms. If a word in the source text matches a key in the glossary, you MUST use the corresponding translation provided.
-4. Translate using the provided Context and Tone. Keep non-speech sounds (e.g., [Music]) as is.
-5. Convert timestamps to standard VTT format (MM:SS.mmm).
-6. Output ONLY the raw VTT content. No markdown, no notes.
+1. Merge words into complete sentences, then split at natural pauses into readable cues.
+2. Timestamps: MM:SS.mmm --> MM:SS.mmm (zero-padded, convert from input milliseconds).
+3. Translate using Context and Tone. Keep non-speech sounds (e.g., [Music]) as is on both lines.
+4. Every cue MUST have exactly 2 text lines. Never skip the translation line.
 
-# VTT Format Example
+# Correct Example
 WEBVTT
 
-1000 --> 3500
+00:01.000 --> 00:03.500
 Hello world!
 你好，世界！
 
-4000 --> 6000
+00:04.000 --> 00:06.000
 Good morning.
-早上好。`;
+早上好。
+
+00:06.200 --> 00:07.400
+[Music]
+[Music]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {
   console.log("request hook args:", { args, url, body, headers, userMsg, method });

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -623,35 +623,22 @@ Tone: ${INPUT_PLACE_TONE}
 ${INPUT_PLACE_GLOSSARY}
 
 # Task
-Convert the input word-level timestamp JSON into a bilingual WebVTT subtitle. Target Language: ${INPUT_PLACE_TO}.
+Group the input word-level JSON into bilingual subtitle segments. Target Language: ${INPUT_PLACE_TO}.
 
 # Output Contract
-1. Output plain text only. No markdown, no code fences, no backticks.
-2. First line: WEBVTT, then a blank line.
-3. Each cue = timestamp line + exactly 2 text lines (original + ${INPUT_PLACE_TO} translation).
-4. One blank line between cues. No cue numbers.
-5. No commentary, notes, or extra text outside the VTT structure.
+1. Output a JSON array only. No markdown, no code fences, no extra text.
+2. Each element: {"s":<first_word_id>,"e":<last_word_id>,"o":"merged original text","t":"translation"}
+3. "s" and "e" are inclusive word IDs from the input.
+4. Cover all input words exactly once (no gaps, no overlaps).
+5. Keep non-speech sounds (e.g., [Music]) as is in both "o" and "t".
 
 # Rules
-1. Merge words into complete sentences, then split at natural pauses into readable cues.
-2. Timestamps: MM:SS.mmm --> MM:SS.mmm (zero-padded, convert from input milliseconds).
-3. Translate using Context and Tone. Keep non-speech sounds (e.g., [Music]) as is on both lines.
-4. Every cue MUST have exactly 2 text lines. Never skip the translation line.
+1. Merge words into complete sentences, split at natural pauses into readable segments.
+2. Translate using Context and Tone.
 
-# Correct Example
-WEBVTT
-
-00:01.000 --> 00:03.500
-Hello world!
-你好，世界！
-
-00:04.000 --> 00:06.000
-Good morning.
-早上好。
-
-00:06.200 --> 00:07.400
-[Music]
-[Music]`;
+# Example
+Input: [{"id":0,"text":"Hello"},{"id":1,"text":"world!"},{"id":2,"text":"Good"},{"id":3,"text":"morning."}]
+Output: [{"s":0,"e":1,"o":"Hello world!","t":"你好，世界！"},{"s":2,"e":3,"o":"Good morning.","t":"早上好。"}]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {
   console.log("request hook args:", { args, url, body, headers, userMsg, method });

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -127,6 +127,7 @@ export class BilingualSubtitleManager {
   #throttledTriggerTranslations;
   #tooltipEl = null;
   #hoverTimeout = null; // 用于延迟显示/隐藏tooltip
+  #seekSyncRafId = null;
   #wasPlayingBeforeHover = false; //记录hover单词前视频是否处于播放状态
   #hoverTarget = null;
 
@@ -142,6 +143,7 @@ export class BilingualSubtitleManager {
     this.#formattedSubtitles = formattedSubtitles;
 
     this.onTimeUpdate = this.onTimeUpdate.bind(this);
+    this.onSeeking = this.onSeeking.bind(this);
     this.onSeek = this.onSeek.bind(this);
 
     this.#throttledTriggerTranslations = throttle(
@@ -181,6 +183,10 @@ export class BilingualSubtitleManager {
     logger.info("Bilingual Subtitle Manager: Destroying...");
     this.#removeEventListeners();
     this.#throttledTriggerTranslations?.cancel();
+    if (this.#seekSyncRafId !== null) {
+      cancelAnimationFrame(this.#seekSyncRafId);
+      this.#seekSyncRafId = null;
+    }
     this.#captionWindowEl?.parentElement?.parentElement?.remove();
     this.#formattedSubtitles = [];
     // 清理tooltip元素
@@ -661,6 +667,7 @@ export class BilingualSubtitleManager {
    */
   #attachEventListeners() {
     this.#videoEl.addEventListener("timeupdate", this.onTimeUpdate);
+    this.#videoEl.addEventListener("seeking", this.onSeeking);
     this.#videoEl.addEventListener("seeked", this.onSeek);
   }
 
@@ -669,6 +676,7 @@ export class BilingualSubtitleManager {
    */
   #removeEventListeners() {
     this.#videoEl.removeEventListener("timeupdate", this.onTimeUpdate);
+    this.#videoEl.removeEventListener("seeking", this.onSeeking);
     this.#videoEl.removeEventListener("seeked", this.onSeek);
   }
 
@@ -676,26 +684,53 @@ export class BilingualSubtitleManager {
    * 视频播放时间更新时的回调，负责更新字幕和触发预翻译。
    */
   onTimeUpdate() {
-    const currentTimeMs = this.#videoEl.currentTime * 1000;
-    const subtitleIndex = this.#findSubtitleIndexForTime(currentTimeMs);
+    this.#syncToCurrentTime();
+  }
 
-    if (subtitleIndex !== this.#currentSubtitleIndex) {
-      this.#currentSubtitleIndex = subtitleIndex;
-      const subtitle =
-        subtitleIndex !== -1 ? this.#formattedSubtitles[subtitleIndex] : null;
-      this.#updateCaptionDisplay(subtitle);
-    }
-
-    this.#throttledTriggerTranslations(currentTimeMs);
+  /**
+   * 用户正在拖动进度条时的回调。
+   */
+  onSeeking() {
+    this.#throttledTriggerTranslations.cancel();
+    this.#syncToCurrentTime({ forceRender: true, triggerTranslations: false });
   }
 
   /**
    * 用户拖动进度条后的回调。
    */
   onSeek() {
-    this.#currentSubtitleIndex = -1;
     this.#throttledTriggerTranslations.cancel();
-    this.onTimeUpdate();
+    this.#syncToCurrentTime({ forceRender: true });
+    this.#scheduleSeekSettledSync();
+  }
+
+  #scheduleSeekSettledSync() {
+    if (typeof requestAnimationFrame !== "function") return;
+    if (this.#seekSyncRafId !== null) {
+      cancelAnimationFrame(this.#seekSyncRafId);
+    }
+    this.#seekSyncRafId = requestAnimationFrame(() => {
+      this.#seekSyncRafId = requestAnimationFrame(() => {
+        this.#seekSyncRafId = null;
+        this.#syncToCurrentTime({ forceRender: true });
+      });
+    });
+  }
+
+  #syncToCurrentTime({ forceRender = false, triggerTranslations = true } = {}) {
+    const currentTimeMs = this.#videoEl.currentTime * 1000;
+    const subtitleIndex = this.#findSubtitleIndexForTime(currentTimeMs);
+
+    if (forceRender || subtitleIndex !== this.#currentSubtitleIndex) {
+      this.#currentSubtitleIndex = subtitleIndex;
+      this.#updateCaptionDisplay(
+        subtitleIndex !== -1 ? this.#formattedSubtitles[subtitleIndex] : null
+      );
+    }
+
+    if (triggerTranslations) {
+      this.#throttledTriggerTranslations(currentTimeMs);
+    }
   }
 
   /**
@@ -801,15 +836,26 @@ export class BilingualSubtitleManager {
    */
   #triggerTranslations(currentTimeMs) {
     const { preTrans = 90 } = this.#setting;
-    const lookAheadMs = preTrans * 1000;
+    const endTimeMs = currentTimeMs + preTrans * 1000;
+    const subs = this.#formattedSubtitles;
 
-    for (const sub of this.#formattedSubtitles) {
-      const isCurrent = sub.start <= currentTimeMs && sub.end >= currentTimeMs;
-      const isUpcoming =
-        sub.start > currentTimeMs && sub.start <= currentTimeMs + lookAheadMs;
-      const needsTranslation = !sub.translation && !sub.isTranslating;
+    let lo = 0,
+      hi = subs.length - 1,
+      startIdx = subs.length;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      if (subs[mid].end >= currentTimeMs) {
+        startIdx = mid;
+        hi = mid - 1;
+      } else {
+        lo = mid + 1;
+      }
+    }
 
-      if ((isCurrent || isUpcoming) && needsTranslation) {
+    for (let i = startIdx; i < subs.length; i++) {
+      const sub = subs[i];
+      if (sub.start > endTimeMs) break;
+      if (!sub.translation && !sub.isTranslating) {
         this.#translateAndStore(sub);
       }
     }
@@ -885,12 +931,7 @@ export class BilingualSubtitleManager {
   // 获取当前字幕的开始时间（使用重新分段后的时间）
   #getCurrentSubtitleStartTime() {
     const currentTimeMs = this.#videoEl.currentTime * 1000;
-    // 查找当前时间对应的字幕
-    const currentSubtitle = this.#formattedSubtitles.find(
-      (sub) => currentTimeMs >= sub.start && currentTimeMs <= sub.end
-    );
-
-    // 返回重新分段后的字幕开始时间，如果没有找到则返回当前时间
-    return currentSubtitle ? currentSubtitle.start : currentTimeMs;
+    const idx = this.#findSubtitleIndexForTime(currentTimeMs);
+    return idx !== -1 ? this.#formattedSubtitles[idx].start : currentTimeMs;
   }
 }

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -471,6 +471,8 @@ class YouTubeCaptionProvider {
   async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
     try {
       const events = chunkEvents.filter((item) => item.text);
+      if (!events.length) return [];
+
       const chunkSign = `${events[0].start} --> ${events[events.length - 1].end}`;
       logger.debug("Youtube Provider: aiSegment events", {
         videoId,
@@ -989,6 +991,7 @@ class YouTubeCaptionProvider {
     usePause = false,
     timeout = 1000,
     maxWords = 15,
+    maxDurationMs = 10000,
   } = {}) {
     const groupedPauseWords = {
       1: new Set([
@@ -1099,6 +1102,8 @@ class YouTubeCaptionProvider {
         const isEndOfSentence = /[.?!…\])]$/.test(lastSegment.text);
         const isPauseOfSentence = /[,]$/.test(lastSegment.text);
         const isTimeout = segment.start - lastSegment.end > timeout;
+        const isDurationExceeded =
+          segment.start - currentBuffer[0].start >= maxDurationMs;
         const isWordLimitExceeded =
           (usePause || isPauseOfSentence) && bufferWordCount >= maxWords;
 
@@ -1113,6 +1118,7 @@ class YouTubeCaptionProvider {
         if (
           isEndOfSentence ||
           isTimeout ||
+          isDurationExceeded ||
           isWordLimitExceeded ||
           startsWithSign ||
           startsWithPauseWord
@@ -1161,9 +1167,13 @@ class YouTubeCaptionProvider {
       });
     });
 
-    segments.push(buffer);
+    if (buffer) {
+      segments.push(buffer);
+    }
 
-    return segments;
+    return segments.filter(
+      (s) => s && typeof s.start === "number" && s.end > s.start
+    );
   }
 
   #splitEventsIntoChunks(flatEvents, chunkLength = 1000) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -469,40 +469,73 @@ class YouTubeCaptionProvider {
   }
 
   async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
-    try {
-      const events = chunkEvents.filter((item) => item.text);
-      if (!events.length) return [];
+    const NON_SPEECH_RE = /^\[.+\]$/i;
+    const speechEvents = [];
+    const nonSpeechEvents = [];
 
-      const chunkSign = `${events[0].start} --> ${events[events.length - 1].end}`;
+    for (const item of chunkEvents) {
+      if (!item.text) continue;
+      if (NON_SPEECH_RE.test(item.text.trim())) {
+        nonSpeechEvents.push(item);
+      } else {
+        speechEvents.push(item);
+      }
+    }
+
+    const toStandaloneSub = (e) => ({
+      start: e.start,
+      end: e.end,
+      text: e.text,
+      translation: e.text,
+    });
+
+    if (!speechEvents.length) return nonSpeechEvents.map(toStandaloneSub);
+
+    try {
+      const chunkSign = `${speechEvents[0].start} --> ${speechEvents[speechEvents.length - 1].end}`;
       logger.debug("Youtube Provider: aiSegment events", {
         videoId,
         chunkSign,
         fromLang,
         toLang,
-        events,
+        speechEvents,
       });
       const subtitles = await apiSubtitle({
         videoId,
         chunkSign,
         fromLang,
         toLang,
-        events,
+        events: speechEvents,
         apiSetting: segApiSetting,
         docInfo: this.#docInfo,
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
       if (Array.isArray(subtitles)) {
         // 断句服务和翻译服务不同时，清除断句的翻译，由翻译服务重新翻译
-        if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
-          return subtitles.map((sub) => ({ ...sub, translation: "" }));
-        }
-        return subtitles;
+        const speechSubtitles =
+          segApiSetting.apiSlug !== this.#setting.apiSlug
+            ? subtitles.map((sub) => ({ ...sub, translation: "" }))
+            : subtitles;
+
+        // 仅保留落在语音字幕间隙中的非语音条目，丢弃与语音重叠的
+        const gapCues = nonSpeechEvents
+          .filter(
+            (ns) =>
+              !speechSubtitles.some(
+                (sub) => ns.start < sub.end && ns.end > sub.start
+              )
+          )
+          .map(toStandaloneSub);
+
+        return [...speechSubtitles, ...gapCues].sort(
+          (a, b) => a.start - b.start
+        );
       }
     } catch (err) {
       logger.info("Youtube Provider: ai segmentation", err);
     }
 
-    return [];
+    return nonSpeechEvents.map(toStandaloneSub);
   }
 
   #getFromLang(lang) {


### PR DESCRIPTION
这个PR是 #542 拆分出来的第1个PR，专注于AI字幕断句的输出契约重构

## 背景

  之前的 AI 字幕断句让 LLM 输出 VTT 格式时间戳（如 `00:01:23.456`），需要 LLM 自己做 ms → MM:SS.mmm 的算术转换。这个算术在长视频里会累积漂移，越往后字幕和视频越对不上。

  ASR 字幕中混入的非语音事件（`[Music]`、`[Applause]` 等）会作为普通 word 事件发给 AI，AI 断句时会把它们嵌进句子中间，产生类似 `disgusted [music] looks` 的不自然结果。

  AI 输出可能被包在 Markdown 代码块里（` ```json ... ``` `），原本的 JSON 解析没有清理这层包装。

  ## 改动

  ### 1. 输出契约改为事件索引（ b299cad ）

  AI 接收的输入从 `{start, end, text}` 改为 `{id, text}`，不再发送时间戳。AI 输出 `{s, e, o, t}` 的索引数组，由插件用原始事件的真实时间戳重建字幕条目。

  * `parseIndexSubtitleRes` 新增，负责索引到时间戳的还原
  * 保留 VTT 解析作为自定义 prompt 的兼容回退
  * `BilingualSubtitleManager` 增加 seeking 事件监听和二分查找优化

  ### 2. 非语音事件预过滤（ af7f117 ）

  在送 AI 之前用 `/^\[.+\]$/i` 把非语音事件剥离出来，只让 AI 处理语音字幕。AI 返回后做时间重叠检测：

  * 落在语音字幕间隙的 `[Music]` 保留为独立条目
  * 与语音字幕重叠的 `[Music]` 丢弃

  ### 3. 提示词清理（ 2e818ed ）

  * 新增 `stripMarkdownCodeBlock`，处理 AI 回包外层的 ` ```json``` ` 标记
  * 优化 prompt 模板的指令措辞

  ## 影响范围

  * **默认 prompt 用户**：自动获得新的索引模式，断句稳定性提升
  * **自定义 prompt 用户**：维持原有 VTT 路径，行为不变
  * **非 AI 断句用户**：不受影响