### PR TITLE
fix: 按用户选择的字幕轨决定 AI 断句，人工字幕保持原始分段

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -34,6 +34,7 @@ class YouTubeCaptionProvider {
   #flatEvents = [];
   #progressedNum = 0;
   #fromLang = "auto";
+  #selectedCaptionTrack = null;
 
   #processingId = null;
 
@@ -91,6 +92,7 @@ class YouTubeCaptionProvider {
       this.#flatEvents = [];
       this.#progressed = 0;
       this.#fromLang = "auto";
+      this.#selectedCaptionTrack = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -329,10 +331,11 @@ class YouTubeCaptionProvider {
       return null;
     }
 
-    // 优先返回用户选择的 且非自动生成的 字幕轨
-    let captionTrack = captionTracks.find(
-      (item) => item.languageCode === lang && item.kind !== "asr"
-    );
+    // 优先返回用户选择的字幕轨，同语言下优先手动字幕
+    let captionTrack =
+      captionTracks.find(
+        (item) => item.languageCode === lang && item.kind !== "asr"
+      ) || captionTracks.find((item) => item.languageCode === lang);
     if (!captionTrack) {
       const asrTrack = captionTracks.find((item) => item.kind === "asr");
       if (asrTrack) {
@@ -496,6 +499,7 @@ class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
+      this.#selectedCaptionTrack = captionTrack;
 
       const capUrl = new URL(captionTrack.baseUrl);
       const events = await this.#getSubtitleEvents(
@@ -602,9 +606,10 @@ class YouTubeCaptionProvider {
     // 根据segSlug从transApis中查找对应的API设置
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
 
-    // potUrl.searchParams.get("kind") === "asr"
-    // 当segSlug不为"-"且segApiSetting存在时，启用AI断句
-    if (segSlug && segSlug !== "-" && segApiSetting) {
+    const isAutoCaption = this.#selectedCaptionTrack?.kind === "asr";
+
+    // 仅自动字幕(kind=asr)启用AI断句，人工字幕直接使用原字幕分段
+    if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
       logger.info("Youtube Provider: Starting AI ...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
 
@@ -643,6 +648,12 @@ class YouTubeCaptionProvider {
       } else {
         return [firstBatchSubtitles, 100];
       }
+    }
+
+    if (!isAutoCaption && segSlug && segSlug !== "-") {
+      logger.info(
+        "Youtube Provider: Skipping AI segmentation for manual captions."
+      );
     }
 
     return subtitlesFallback();

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -34,7 +34,7 @@ class YouTubeCaptionProvider {
   #flatEvents = [];
   #progressedNum = 0;
   #fromLang = "auto";
-  #selectedCaptionTrack = null;
+  #interceptedCaptionKind = null;
 
   #processingId = null;
 
@@ -92,7 +92,7 @@ class YouTubeCaptionProvider {
       this.#flatEvents = [];
       this.#progressed = 0;
       this.#fromLang = "auto";
-      this.#selectedCaptionTrack = null;
+      this.#interceptedCaptionKind = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -321,21 +321,25 @@ class YouTubeCaptionProvider {
   }
 
   // todo: 优化逻辑
-  #findCaptionTrack(captionTracks, lang) {
+  #findCaptionTrack(captionTracks, lang, kind) {
     logger.debug("Youtube Provider: find caption track", {
       captionTracks,
       lang,
+      kind,
     });
 
     if (!captionTracks?.length) {
       return null;
     }
 
-    // 优先返回用户选择的字幕轨，同语言下优先手动字幕
-    let captionTrack =
-      captionTracks.find(
-        (item) => item.languageCode === lang && item.kind !== "asr"
-      ) || captionTracks.find((item) => item.languageCode === lang);
+    // 优先匹配用户选择的字幕轨（语言+kind完全一致）
+    let captionTrack = captionTracks.find(
+      (item) =>
+        item.languageCode === lang && (item.kind || null) === (kind || null)
+    );
+    if (!captionTrack) {
+      captionTrack = captionTracks.find((item) => item.languageCode === lang);
+    }
     if (!captionTrack) {
       const asrTrack = captionTracks.find((item) => item.kind === "asr");
       if (asrTrack) {
@@ -473,9 +477,13 @@ class YouTubeCaptionProvider {
     }
 
     const lang = potUrl.searchParams.get("lang");
+    const interceptedKind = potUrl.searchParams.get("kind") || null;
     const fromLang = this.#getFromLang(lang);
     if (this.#flatEvents.length) {
-      if (this.#isSameLang(lang, this.#fromLang)) {
+      if (
+        this.#isSameLang(lang, this.#fromLang) &&
+        interceptedKind === this.#interceptedCaptionKind
+      ) {
         logger.debug("Youtube Provider: video was processed:", videoId);
         return;
       }
@@ -494,12 +502,15 @@ class YouTubeCaptionProvider {
 
       const { toLang } = this.#setting;
       const captionTracks = await this.#getCaptionTracks(videoId);
-      const captionTrack = this.#findCaptionTrack(captionTracks, lang);
+      const captionTrack = this.#findCaptionTrack(
+        captionTracks,
+        lang,
+        interceptedKind
+      );
       if (!captionTrack) {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
-      this.#selectedCaptionTrack = captionTrack;
 
       const capUrl = new URL(captionTrack.baseUrl);
       const events = await this.#getSubtitleEvents(
@@ -530,6 +541,7 @@ class YouTubeCaptionProvider {
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
+      this.#interceptedCaptionKind = interceptedKind;
 
       this.#processEvents({
         videoId,
@@ -606,7 +618,7 @@ class YouTubeCaptionProvider {
     // 根据segSlug从transApis中查找对应的API设置
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
 
-    const isAutoCaption = this.#selectedCaptionTrack?.kind === "asr";
+    const isAutoCaption = this.#interceptedCaptionKind === "asr";
 
     // 仅自动字幕(kind=asr)启用AI断句，人工字幕直接使用原字幕分段
     if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -429,6 +429,10 @@ class YouTubeCaptionProvider {
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
       if (Array.isArray(subtitles)) {
+        // 断句服务和翻译服务不同时，清除断句的翻译，由翻译服务重新翻译
+        if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
+          return subtitles.map((sub) => ({ ...sub, translation: "" }));
+        }
         return subtitles;
       }
     } catch (err) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -662,10 +662,9 @@ class YouTubeCaptionProvider {
       }
     }
 
-    if (!isAutoCaption && segSlug && segSlug !== "-") {
-      logger.info(
-        "Youtube Provider: Skipping AI segmentation for manual captions."
-      );
+    if (!isAutoCaption) {
+      // 人工字幕已是句级分段，直接使用无需合并
+      return [flatEvents.filter((e) => e.text), 100];
     }
 
     return subtitlesFallback();
@@ -993,7 +992,10 @@ class YouTubeCaptionProvider {
 
     events.forEach(({ segs = [], tStartMs = 0, dDurationMs = 0 }) => {
       segs.forEach(({ utf8 = "", tOffsetMs = 0 }, j) => {
-        const text = utf8.trim().replace(/\s+/g, " ");
+        const text = utf8
+          .replace(/<[^>]+>/g, "")
+          .trim()
+          .replace(/\s+/g, " ");
         const start = tStartMs + tOffsetMs;
 
         if (buffer) {


### PR DESCRIPTION
这个PR是 #542 拆分出来的第3个PR，处理字幕轨道选择和人工字幕的差异化处理

## 背景

  之前 AI 智能断句不区分字幕来源，对所有字幕都做词级合并。但 YouTube 的人工字幕（作者上传）已是句级分段，再去做合并反而会破坏原有结构。同时这种字幕的词条里可能带有 `<i>` 等 HTML 标签，未做清理。

  字幕选择逻辑也没考虑用户实际点选的轨道。比如视频同时存在 `kind=asr` 自动字幕和作者手动字幕时，用户切换到自动字幕，插件却拿着手动字幕来翻译。

  断句服务和翻译服务用不同 API 时，断句服务返回的译文会被直接采用，跳过用户配置的翻译服务。

  ## 改动

  ### 1. 统一断句和翻译行为（ 70dfe22 ）

  断句服务和翻译服务不一致时，清空断句服务返回的译文字段，让翻译服务重新跑一遍。

  ### 2. 优先选择手动字幕（ ba3d215 ）

  `#findCaptionTrack` 同语言下优先返回非 `asr` 轨道，并新增 `isAutoCaption` 判断，仅 ASR 字幕走 AI 断句流程。引入 `#selectedCaptionTrack` 字段。

  ### 3. 按 kind 参数判断（ 24be736 ）

  读取 YouTube 拦截请求里的 `kind` 参数，识别用户实际点选的字幕类型。`kind=asr` 启用 AI 断句，否则跳过。同语言下也支持切换字幕类型重新处理。`#selectedCaptionTrack` 改为 `#interceptedCaptionKind`。

  ### 4. 人工字幕保持原始分段（ 6a79e81 ）

  非 ASR 字幕跳过 `#processSubtitles` 的逐词合并，直接使用原始事件作为字幕条目。同时在 `#genFlatEvents` 里剥离 YouTube json3 数据中的 HTML 内联格式标签（如 `<i>`）。

  ## 影响范围

  * **作者手动字幕用户**：保留原始分段，避免词条被异常合并
  * **自动字幕用户**：行为不变，仍走 AI 断句流程
  * **同语言切换字幕类型**：现在会触发重新处理，之前会被跳过

  ## 测试

  * 测试视频：[OSYmTw6_bjc](https://www.youtube.com/watch?v=OSYmTw6_bjc) 的英语作者字幕（之前会出现 70 多条字幕被合成 30 条的问题）
  * 同语言下切换 cc 字幕和作者字幕，验证重新处理生效