### PR TITLE
feat: per-rule toggle for subscribed rules

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2794,6 +2794,27 @@ export const I18N = {
     ja: `無効`,
     ko: `사용 안 함`,
   },
+  rule_disabled: {
+    zh: `规则已禁用`,
+    en: `Rule Disabled`,
+    zh_TW: `規則已禁用`,
+    ja: `ルールが無効になっています`,
+    ko: `규칙이 비활성화되었습니다`,
+  },
+  rule_enabled: {
+    zh: `规则已启用`,
+    en: `Rule Enabled`,
+    zh_TW: `規則已啟用`,
+    ja: `ルールが有効になっています`,
+    ko: `규칙이 활성화되었습니다`,
+  },
+  rule_toggle_failed: {
+    zh: `规则切换失败`,
+    en: `Failed to toggle rule`,
+    zh_TW: `規則切換失敗`,
+    ja: `ルールの切り替えに失敗しました`,
+    ko: `규칙 전환 실패`,
+  },
 };
 
 export const newI18n = (lang) => (key) => I18N[key]?.[lang] || "";

--- a/src/config/storage.js
+++ b/src/config/storage.js
@@ -19,6 +19,7 @@ export const STOKEY_FAB = `${APP_NAME}_fab`;
 export const STOKEY_TRANBOX = `${APP_NAME}_tranbox`;
 export const STOKEY_SEPARATE_WINDOW = `${APP_NAME}_separate_window`;
 export const STOKEY_RULESCACHE_PREFIX = `${APP_NAME}_rulescache_`;
+export const STOKEY_DISABLED_SUB_RULES = `${APP_NAME}_disabled_sub_rules`;
 
 export const CACHE_NAME = `${APP_NAME}_cache`;
 export const DEFAULT_CACHE_TIMEOUT = 3600 * 24 * 7; // 缓存超时时间(7天)

--- a/src/hooks/SubRules.js
+++ b/src/hooks/SubRules.js
@@ -15,7 +15,7 @@ export function useSubRules() {
   const list = setting?.subrulesList || DEFAULT_SUBRULES_LIST;
 
   const selectedSub = useMemo(() => list.find((item) => item.selected), [list]);
-  const selectedUrl = selectedSub.url;
+  const selectedUrl = selectedSub ? selectedSub.url : "";
 
   const selectSub = useCallback(
     (url) => {
@@ -62,6 +62,9 @@ export function useSubRules() {
         } finally {
           setLoading(false);
         }
+      } else {
+        // clear stale rules when no source selected
+        setSelectedRules([]);
       }
     })();
   }, [selectedUrl]);

--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -9,7 +9,7 @@ import {
   OPT_HIGHLIGHT_WORDS_ALL,
 } from "../config";
 import { loadOrFetchSubRules } from "./subRules";
-import { getRulesWithDefault, setRules } from "./storage";
+import { getRulesWithDefault, setRules, getDisabledSubRules } from "./storage";
 import { trySyncRules } from "./sync";
 import { kissLog } from "./log";
 
@@ -185,6 +185,15 @@ export const matchRule = async (href, { injectRules, subrulesList }) => {
       if (selectedSub?.url) {
         const subRules = await loadOrFetchSubRules(selectedSub.url);
         matchedSubRule = findMatchingRule(subRules, href);
+        // If the matched subscribed rule is disabled by user, ignore it
+        try {
+          const disabled = await getDisabledSubRules();
+          if (matchedSubRule && disabled.includes(matchedSubRule.pattern)) {
+            matchedSubRule = null;
+          }
+        } catch (err) {
+          kissLog("getDisabledSubRules", err);
+        }
       }
     } catch (err) {
       kissLog("load injectRules", err);

--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -185,9 +185,9 @@ export const matchRule = async (href, { injectRules, subrulesList }) => {
       if (selectedSub?.url) {
         const subRules = await loadOrFetchSubRules(selectedSub.url);
         matchedSubRule = findMatchingRule(subRules, href);
-        // If the matched subscribed rule is disabled by user, ignore it
+        // If the matched subscribed rule is disabled by user for this source, ignore it
         try {
-          const disabled = await getDisabledSubRules();
+          const disabled = await getDisabledSubRules(selectedSub.url);
           if (matchedSubRule && disabled.includes(matchedSubRule.pattern)) {
             matchedSubRule = null;
           }

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -10,6 +10,7 @@ import {
   STOKEY_MSAUTH,
   STOKEY_BDAUTH,
   STOKEY_RULESCACHE_PREFIX,
+  STOKEY_DISABLED_SUB_RULES,
   DEFAULT_SETTING,
   DEFAULT_RULES,
   DEFAULT_SYNC,
@@ -127,6 +128,13 @@ export const getSubRulesWithDefault = async () => (await getSubRules()) || [];
 export const delSubRules = (url) => del(STOKEY_RULESCACHE_PREFIX + url);
 export const setSubRules = (url, val) =>
   setObj(STOKEY_RULESCACHE_PREFIX + url, val);
+
+export const getDisabledSubRules = async () => {
+  const arr = await getObj(STOKEY_DISABLED_SUB_RULES);
+  return Array.isArray(arr) ? arr : [];
+};
+
+export const setDisabledSubRules = (val) => setObj(STOKEY_DISABLED_SUB_RULES, val);
 
 /**
  * fab位置

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -129,12 +129,38 @@ export const delSubRules = (url) => del(STOKEY_RULESCACHE_PREFIX + url);
 export const setSubRules = (url, val) =>
   setObj(STOKEY_RULESCACHE_PREFIX + url, val);
 
-export const getDisabledSubRules = async () => {
-  const arr = await getObj(STOKEY_DISABLED_SUB_RULES);
-  return Array.isArray(arr) ? arr : [];
+export const getDisabledSubRules = async (url) => {
+  if (!url) return [];
+  const raw = await getObj(STOKEY_DISABLED_SUB_RULES);
+  if (!raw) return [];
+  if (typeof raw === "object") {
+    const list = raw[url];
+    return Array.isArray(list) ? list : [];
+  }
+  return [];
 };
 
-export const setDisabledSubRules = (val) => setObj(STOKEY_DISABLED_SUB_RULES, val);
+export const setDisabledSubRules = async (url, patterns) => {
+  if (!url) return;
+  const map = (await getObj(STOKEY_DISABLED_SUB_RULES)) || {};
+  const arr = Array.isArray(patterns) ? [...new Set(patterns)] : [];
+  if (arr.length === 0) {
+    if (map[url]) delete map[url];
+  } else {
+    map[url] = arr;
+  }
+  await setObj(STOKEY_DISABLED_SUB_RULES, map);
+};
+
+export const removeDisabledSubRules = async (url) => {
+  if (!url) return;
+  const raw = await getObj(STOKEY_DISABLED_SUB_RULES);
+  if (!raw || typeof raw !== "object") return;
+  if (raw[url]) {
+    delete raw[url];
+    await setObj(STOKEY_DISABLED_SUB_RULES, raw);
+  }
+};
 
 /**
  * fab位置

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -50,6 +50,7 @@ import {
   getSyncWithDefault,
   getDisabledSubRules,
   setDisabledSubRules,
+  removeDisabledSubRules,
 } from "../../libs/storage";
 import ClearAllIcon from "@mui/icons-material/ClearAll";
 import HelpButton from "./HelpButton";
@@ -782,7 +783,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
   );
 }
 
-function RuleAccordion({ rule, rules, isExpanded = false }) {
+function RuleAccordion({ rule, rules, sourceUrl, isExpanded = false }) {
   const i18n = useI18n();
   const [expanded, setExpanded] = useState(isExpanded);
 
@@ -791,16 +792,17 @@ function RuleAccordion({ rule, rules, isExpanded = false }) {
 
   useEffect(() => {
     if (!rules) {
+      if (!sourceUrl) return;
       (async () => {
         try {
-          const list = await getDisabledSubRules();
+          const list = await getDisabledSubRules(sourceUrl);
           setDisabledByUser(Array.isArray(list) && list.includes(rule.pattern));
         } catch (err) {
           kissLog("getDisabledSubRules", err);
         }
       })();
     }
-  }, [rule, rules]);
+  }, [rule, rules, sourceUrl]);
 
   const handleChange = (e) => {
     setExpanded((pre) => !pre);
@@ -809,25 +811,31 @@ function RuleAccordion({ rule, rules, isExpanded = false }) {
   return (
     <Accordion expanded={expanded} onChange={handleChange}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Stack direction="row" alignItems="center" spacing={1} sx={{ width: "100%" }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{ width: "100%" }}
+        >
           {!rules && (
             <Switch
               size="small"
               checked={!disabledByUser}
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
-              onFocus={(e) => e.stopPropagation()}
               onChange={async (e) => {
-                // checked means enabled; we store disabled list, so invert
                 const enabled = e.target.checked;
                 const toDisable = !enabled;
                 try {
-                  const list = await getDisabledSubRules();
+                  const list = await getDisabledSubRules(sourceUrl);
                   const set = new Set(Array.isArray(list) ? list : []);
                   if (toDisable) set.add(rule.pattern);
                   else set.delete(rule.pattern);
-                  await setDisabledSubRules([...set]);
+                  await setDisabledSubRules(sourceUrl, [...set]);
                   setDisabledByUser(toDisable);
-                  alert.success(i18n(toDisable ? "rule_disabled" : "rule_enabled"));
+                  alert.success(
+                    i18n(toDisable ? "rule_disabled" : "rule_enabled")
+                  );
                 } catch (err) {
                   kissLog("toggle disabled sub rule", err);
                   alert.error(i18n("rule_toggle_failed"));
@@ -1028,7 +1036,11 @@ function UserRules({ subRules, rules }) {
                 rule.pattern.includes(keyword) || keyword.includes(rule.pattern)
             )
             .map((rule) => (
-              <RuleAccordion key={rule.pattern} rule={rule} />
+              <RuleAccordion
+                key={rule.pattern}
+                rule={rule}
+                sourceUrl={selectedUrl}
+              />
             ))}
         </Box>
       )}
@@ -1054,6 +1066,12 @@ function SubRulesItem({
       await delSub(url);
       await delSubRules(url);
       await deleteDataCache(url);
+      // remove any per-source disabled state
+      try {
+        await removeDisabledSubRules(url);
+      } catch (err) {
+        kissLog("removeDisabledSubRules", err);
+      }
     } catch (err) {
       kissLog("del subrules", err);
     }
@@ -1279,7 +1297,7 @@ function SubRules({ subRules }) {
           </center>
         ) : (
           selectedRules.map((rule) => (
-            <RuleAccordion key={rule.pattern} rule={rule} />
+            <RuleAccordion key={rule.pattern} rule={rule} sourceUrl={selectedUrl}/>
           ))
         )}
       </Box>

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -45,7 +45,12 @@ import { loadOrFetchSubRules } from "../../libs/subRules";
 import { useAlert } from "../../hooks/Alert";
 import { syncShareRules } from "../../libs/sync";
 import { debounce } from "../../libs/utils";
-import { delSubRules, getSyncWithDefault } from "../../libs/storage";
+import {
+  delSubRules,
+  getSyncWithDefault,
+  getDisabledSubRules,
+  setDisabledSubRules,
+} from "../../libs/storage";
 import ClearAllIcon from "@mui/icons-material/ClearAll";
 import HelpButton from "./HelpButton";
 import { useSyncCaches } from "../../hooks/Sync";
@@ -781,6 +786,22 @@ function RuleAccordion({ rule, rules, isExpanded = false }) {
   const i18n = useI18n();
   const [expanded, setExpanded] = useState(isExpanded);
 
+  const [disabledByUser, setDisabledByUser] = useState(false);
+  const alert = useAlert();
+
+  useEffect(() => {
+    if (!rules) {
+      (async () => {
+        try {
+          const list = await getDisabledSubRules();
+          setDisabledByUser(Array.isArray(list) && list.includes(rule.pattern));
+        } catch (err) {
+          kissLog("getDisabledSubRules", err);
+        }
+      })();
+    }
+  }, [rule, rules]);
+
   const handleChange = (e) => {
     setExpanded((pre) => !pre);
   };
@@ -788,16 +809,45 @@ function RuleAccordion({ rule, rules, isExpanded = false }) {
   return (
     <Accordion expanded={expanded} onChange={handleChange}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography
-          sx={{
-            opacity: rules ? 1 : 0.5,
-            overflowWrap: "anywhere",
-          }}
-        >
-          {rule.pattern === GLOBAL_KEY
-            ? `[${i18n("global_rule")}] ${rule.pattern}`
-            : rule.pattern}
-        </Typography>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ width: "100%" }}>
+          {!rules && (
+            <Switch
+              size="small"
+              checked={!disabledByUser}
+              onClick={(e) => e.stopPropagation()}
+              onFocus={(e) => e.stopPropagation()}
+              onChange={async (e) => {
+                // checked means enabled; we store disabled list, so invert
+                const enabled = e.target.checked;
+                const toDisable = !enabled;
+                try {
+                  const list = await getDisabledSubRules();
+                  const set = new Set(Array.isArray(list) ? list : []);
+                  if (toDisable) set.add(rule.pattern);
+                  else set.delete(rule.pattern);
+                  await setDisabledSubRules([...set]);
+                  setDisabledByUser(toDisable);
+                  alert.success(i18n(toDisable ? "rule_disabled" : "rule_enabled"));
+                } catch (err) {
+                  kissLog("toggle disabled sub rule", err);
+                  alert.error(i18n("rule_toggle_failed"));
+                }
+              }}
+            />
+          )}
+
+          <Typography
+            sx={{
+              opacity: rules ? 1 : 0.5,
+              overflowWrap: "anywhere",
+              flex: 1,
+            }}
+          >
+            {rule.pattern === GLOBAL_KEY
+              ? `[${i18n("global_rule")}] ${rule.pattern}`
+              : rule.pattern}
+          </Typography>
+        </Stack>
       </AccordionSummary>
       <AccordionDetails>
         {expanded && <RuleFields rule={rule} rules={rules} />}


### PR DESCRIPTION
Each subscribed rule now has a toggle ( #363 ). Disabled patterns are kept per source,
so switching subscriptions doesn’t mix state. Deleting a source removes its
disabled list.
Users can now turn off a bad rule (like Notion #426 #605 ) without losing the whole subscription.