### PR TITLE
fix: single subtitle too long error

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -1045,8 +1045,15 @@ class YouTubeCaptionProvider {
       bufferWordCount = 0;
     };
 
+    const MIN_WORDS_FOR_NEWLINE_SPLIT = 6;
+
     flatEvents.forEach((segment) => {
-      if (!segment.text) return;
+      if (!segment.text) {
+        if (currentBuffer.length > 0 && bufferWordCount >= MIN_WORDS_FOR_NEWLINE_SPLIT) {
+          flushBuffer();
+        }
+        return;
+      }
 
       const lastSegment = currentBuffer[currentBuffer.length - 1];
 
@@ -1065,12 +1072,15 @@ class YouTubeCaptionProvider {
           ) &&
           currentBuffer.length > 1;
 
+        const isHardWordLimitExceeded = bufferWordCount >= maxWords * 2;
+
         if (
           isEndOfSentence ||
           isTimeout ||
           isWordLimitExceeded ||
           startsWithSign ||
-          startsWithPauseWord
+          startsWithPauseWord ||
+          isHardWordLimitExceeded
         ) {
           flushBuffer();
         }
@@ -1117,6 +1127,12 @@ class YouTubeCaptionProvider {
     });
 
     segments.push(buffer);
+
+    for (let i = 0; i < segments.length - 1; i++) {
+      if (segments[i].end && segments[i].end > segments[i + 1].start) {
+        segments[i].end = segments[i + 1].start;
+      }
+    }
 
     return segments;
   }


### PR DESCRIPTION
问题原因，自动生成的英文字幕部分内容可能没有标点，同时由于原来的内置分句会直接丢掉停顿换行符，所以导致无法在这种情况下完成正常断句。

解决方法：保留换行标记，并将其作为最低优先级的手段，当某段字幕，大于150个字符，并且含有\n符号时，才会尝试进行利用换行符分句。由于换行符可能出现的比较密集，会将字幕拆的太碎，所以增加了短段落自动合并的机制，如果小于50个字符，那么就会尝试合并下一个字段，并且要满足合并后的字符数量小于120，才能完成合并。

大概解决了，不完美，但是至少应该不会出现糊一大坨字幕到脸上的问题了。

另一个小问题，部分带有twitch-chat字幕的视频，想要切换到正常英文字幕会有点小问题，比如字幕不加载，或者奇奇怪怪的问题，所以添加了剔除掉含有chat字段的字幕的功能。

@fishjar 