### PR TITLE
fix: 修复 #639 合并时遗留的冲突标记

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -36,12 +36,9 @@ class YouTubeCaptionProvider {
   #flatEvents = [];
   #progressedNum = 0;
   #fromLang = "auto";
-<<<<<<< split/pr2-enhanced-smart-context
   #docInfo = {};
   #fullDescription = "";
-=======
   #interceptedCaptionKind = null;
->>>>>>> dev
 
   #processingId = null;
 
@@ -99,12 +96,9 @@ class YouTubeCaptionProvider {
       this.#flatEvents = [];
       this.#progressed = 0;
       this.#fromLang = "auto";
-<<<<<<< split/pr2-enhanced-smart-context
       this.#docInfo = {};
       this.#fullDescription = "";
-=======
       this.#interceptedCaptionKind = null;
->>>>>>> dev
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -528,19 +522,14 @@ class YouTubeCaptionProvider {
       this.#showNotification(this.#i18n("starting_to_process_subtitle"));
 
       const { toLang } = this.#setting;
-<<<<<<< split/pr2-enhanced-smart-context
       const { captionTracks, fullDescription } =
         await this.#getCaptionTracks(videoId);
       this.#fullDescription = fullDescription || "";
-      const captionTrack = this.#findCaptionTrack(captionTracks, lang);
-=======
-      const captionTracks = await this.#getCaptionTracks(videoId);
       const captionTrack = this.#findCaptionTrack(
         captionTracks,
         lang,
         interceptedKind
       );
->>>>>>> dev
       if (!captionTrack) {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
@@ -575,12 +564,9 @@ class YouTubeCaptionProvider {
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
-<<<<<<< split/pr2-enhanced-smart-context
       this.#docInfo = getDocInfo();
-      await this.#enrichDocInfoWithAI(flatEvents);
-=======
       this.#interceptedCaptionKind = interceptedKind;
->>>>>>> dev
+      await this.#enrichDocInfoWithAI(flatEvents);
 
       this.#processEvents({
         videoId,

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -348,6 +348,7 @@ class YouTubeCaptionProvider {
     }
 
     // 优先匹配用户选择的字幕轨（语言+kind完全一致）
+    // 手动字幕没有 kind 字段，统一转成 null，避免 undefined !== null 导致无法匹配
     let captionTrack = captionTracks.find(
       (item) =>
         item.languageCode === lang && (item.kind || null) === (kind || null)


### PR DESCRIPTION
#639 合并到 dev 时，src/subtitle/YouTubeCaptionProvider.js 遗留了 4 处未解决的冲突标记（`<<<<<<<` / `=======` / `>>>>>>>`），导致文件无法解析，当前 dev 跑不起来。

  ## 改动

  补上 4 处的正确合并版本，把 PR #639（增强智能上下文）和 PR #640（按用户选择的字幕轨决定 AI 断句）的字段都保留：

  - **行 39，class 字段声明**：保留 `#docInfo`、`#fullDescription`（来自 #639）和 `#interceptedCaptionKind`（来自 #640）
  - **行 96，popstate 回调中的状态重置**：同上保留全部三个字段
  - **行 522，字幕轨道获取**：用 #639 的对象解构语法 `{captionTracks, fullDescription}` 加上 #640 的 `findCaptionTrack(captionTracks, lang, interceptedKind)` 三参数签名
  - **行 564，拿到字幕事件后**：保留 `#docInfo = getDocInfo()`、`#interceptedCaptionKind = interceptedKind`、`await #enrichDocInfoWithAI(flatEvents)` 三句

  `#interceptedCaptionKind` 的赋值放在 `await` 之前，避免异步期间其他回调读到旧值。