### PR TITLE
refactor: optimize subtitle list performance

### DIFF
--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -700,13 +700,34 @@ export class BilingualSubtitleManager {
 
   /**
    * 根据时间（毫秒）查找对应的字幕索引。
+   * 使用二分查找，复杂度 O(log n)，替代原 findIndex 的 O(n)。
    * @param {number} currentTimeMs
    * @returns {number} 找到的字幕索引，-1 表示没找到。
    */
   #findSubtitleIndexForTime(currentTimeMs) {
-    return this.#formattedSubtitles.findIndex(
-      (sub) => currentTimeMs >= sub.start && currentTimeMs <= sub.end
-    );
+    const arr = this.#formattedSubtitles;
+    const len = arr.length;
+    if (len === 0) return -1;
+
+    if (currentTimeMs < arr[0].start || currentTimeMs > arr[len - 1].end) {
+      return -1;
+    }
+
+    let left = 0;
+    let right = len - 1;
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2);
+      const sub = arr[mid];
+      if (currentTimeMs >= sub.start && currentTimeMs <= sub.end) {
+        return mid;
+      } else if (currentTimeMs < sub.start) {
+        right = mid - 1;
+      } else {
+        left = mid + 1;
+      }
+    }
+
+    return -1;
   }
 
   /**

--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -36,6 +36,7 @@ export class YouTubeSubtitleList {
     this.activeTab = "subtitles"; // 当前激活的 Tab: 'subtitles' 或 'vocabulary'
     this._lastActiveIndex = -1; // 上一次高亮的字幕索引
     this._vocabularyDirty = false; // 生词本是否需要重新渲染
+    this._chunkRenderCancel = null; // 分块渲染的取消函数，用于中止进行中的渲染
 
     // --- 事件绑定 ---
     this.handleWordAdded = this.handleWordAdded.bind(this);
@@ -87,6 +88,7 @@ export class YouTubeSubtitleList {
    */
   destroy() {
     this.turnOffAutoSub();
+    this._cancelChunkRender();
     document.removeEventListener("kiss-add-word", this.handleWordAdded);
     if (this.container) {
       this.container.remove();
@@ -97,6 +99,63 @@ export class YouTubeSubtitleList {
     this.bilingualSubtitles = [];
     this._cachedSubtitleItems = [];
     this.vocabulary = [];
+  }
+
+  // ==================================================================================
+  // Chunk Rendering: 分块渲染工具方法
+  // ==================================================================================
+
+  /**
+   * 取消正在进行的分块渲染
+   */
+  _cancelChunkRender() {
+    if (this._chunkRenderCancel) {
+      this._chunkRenderCancel();
+      this._chunkRenderCancel = null;
+    }
+  }
+
+  /**
+   * 在空闲时调度回调，兼容不支持 requestIdleCallback 的浏览器
+   */
+  _scheduleIdle(callback) {
+    if (typeof requestIdleCallback === "function") {
+      const id = requestIdleCallback(callback, { timeout: 100 });
+      this._chunkRenderCancel = () => cancelIdleCallback(id);
+    } else {
+      const id = setTimeout(callback, 0);
+      this._chunkRenderCancel = () => clearTimeout(id);
+    }
+  }
+
+  /**
+   * 分块异步渲染字幕列表，避免大量 DOM 节点同步创建导致主线程阻塞
+   * @param {HTMLUListElement} ul 字幕列表的 ul 元素
+   */
+  _renderSubtitlesInChunks(ul) {
+    const CHUNK_SIZE = 100;
+    const subtitles = this.bilingualSubtitles;
+
+    this._cachedSubtitleItems = new Array(subtitles.length);
+
+    const renderNextChunk = (startIndex) => {
+      if (startIndex >= subtitles.length || !this.subtitleListEl) return;
+
+      const end = Math.min(startIndex + CHUNK_SIZE, subtitles.length);
+      const fragment = document.createDocumentFragment();
+      for (let i = startIndex; i < end; i++) {
+        const li = this._createSubtitleListItem(subtitles[i], i);
+        this._cachedSubtitleItems[i] = li;
+        fragment.appendChild(li);
+      }
+      ul.appendChild(fragment);
+
+      if (end < subtitles.length && this.subtitleListEl) {
+        this._scheduleIdle(() => renderNextChunk(end));
+      }
+    };
+
+    renderNextChunk(0);
   }
 
   // ==================================================================================
@@ -206,21 +265,15 @@ export class YouTubeSubtitleList {
       this._renderTabsAndStructure();
     }
 
-    // 3. 渲染字幕列表内容
+    // 3. 取消之前可能正在进行的渲染
+    this._cancelChunkRender();
+
+    // 4. 清空列表并启动分块异步渲染，避免大量字幕导致主线程卡死
     const ul = this.subtitleListEl.querySelector("ul");
     ul.replaceChildren();
-    this._cachedSubtitleItems = []; // 重置缓存
+    this._renderSubtitlesInChunks(ul);
 
-    // 使用 DocumentFragment 批量插入，减少重排
-    const fragment = document.createDocumentFragment();
-    this.bilingualSubtitles.forEach((sub, i) => {
-      const li = this._createSubtitleListItem(sub, i);
-      this._cachedSubtitleItems.push(li);
-      fragment.appendChild(li);
-    });
-    ul.appendChild(fragment);
-
-    // 4. 渲染生词本（初始为空或已有数据）
+    // 5. 渲染生词本（初始为空或已有数据）
     this._renderVocabulary();
   }
 
@@ -512,6 +565,7 @@ export class YouTubeSubtitleList {
 
     // 1. 增量追加模式：只添加新增的条目，不全量重建
     if (this.bilingualSubtitles.length > this._cachedSubtitleItems.length) {
+      this._cancelChunkRender();
       const ul = this.subtitleListEl.querySelector("ul");
       if (ul) {
         const fragment = document.createDocumentFragment();
@@ -524,18 +578,12 @@ export class YouTubeSubtitleList {
         ul.appendChild(fragment);
       }
     } else if (this.bilingualSubtitles.length < this._cachedSubtitleItems.length) {
-      // 数据源变少了（如切换视频后重建），全量重建
+      // 数据源变少了（如切换视频后重建），全量分块渲染
       const ul = this.subtitleListEl.querySelector("ul");
       if (ul) {
+        this._cancelChunkRender();
         ul.replaceChildren();
-        this._cachedSubtitleItems = [];
-        const fragment = document.createDocumentFragment();
-        this.bilingualSubtitles.forEach((sub, i) => {
-          const li = this._createSubtitleListItem(sub, i);
-          this._cachedSubtitleItems.push(li);
-          fragment.appendChild(li);
-        });
-        ul.appendChild(fragment);
+        this._renderSubtitlesInChunks(ul);
       }
       return;
     }


### PR DESCRIPTION
首次打开字幕会造成一次峰值卡顿，因为会一次性加载所有字幕，大量的DOM操作会阻塞主线程
将其修改为分区块异步加载，不影响使用，性能提升明显。

#findSubtitleIndexForTime使用了findIndex，这将遍历整个字幕列表，不必要的性能消耗。
修改为二分查找，对比遍历，显著降低查询次数。