### PR TITLE
refactor: rewrite the builtin sentence segmentation logic

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2759,6 +2759,13 @@ export const I18N = {
     ja: `スタイルコード`,
     ko: `스타일 코드`,
   },
+  long_sentence_threshold: {
+    zh: `内置断句阈值 (20-300字符)`,
+    en: `Built-in sentence segmentation threshold (20-300 chars)`,
+    zh_TW: `內建斷句閾值 (20-300字符)`,
+    ja: `内蔵文分割閾値 (20-300文字)`,
+    ko: `내장 문장 분할 임계값 (20-300자)`,
+  },
   pre_trans_seconds: {
     zh: `提前翻译时长 (10-36000s)`,
     en: `Pre translation seconds (10-36000s)`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -125,6 +125,7 @@ export const DEFAULT_SUBTITLE_SETTING = {
   apiSlug: OPT_TRANS_MICROSOFT,
   segSlug: "-", // AI智能断句
   chunkLength: 1000, // AI处理切割长度
+  longSentenceThreshold: 120, // 规则断句超长句阈值
   preTrans: 90, // 提前翻译时长
   throttleTrans: 30, // 节流翻译间隔
   // fromLang: "en",

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -335,6 +335,13 @@ class YouTubeCaptionProvider {
     return lang1.slice(0, 2) === lang2.slice(0, 2);
   }
 
+  #isChatCaptionTrack(track) {
+    if (!track) return false;
+    const name =
+      track.name?.simpleText || track.name?.runs?.[0]?.text || "";
+    return /chat/i.test(name);
+  }
+
   // todo: 优化逻辑
   #findCaptionTrack(captionTracks, lang, kind) {
     logger.debug("Youtube Provider: find caption track", {
@@ -372,6 +379,30 @@ class YouTubeCaptionProvider {
 
     if (!captionTrack) {
       captionTrack = captionTracks.pop();
+    }
+
+    // Chat/弹幕字幕轨道自动降级为正常字幕轨道
+    if (captionTrack && this.#isChatCaptionTrack(captionTrack)) {
+      logger.debug("Youtube Provider: detected chat subtitle track, switching to normal subtitle");
+
+      const nonChatSameLang = captionTracks.find(
+        (item) =>
+          this.#isSameLang(item.languageCode, lang) &&
+          !this.#isChatCaptionTrack(item)
+      );
+
+      if (nonChatSameLang) {
+        logger.debug("Youtube Provider: switched to same-language non-chat track");
+        captionTrack = nonChatSameLang;
+      } else {
+        const anyNonChat = captionTracks.find(
+          (item) => !this.#isChatCaptionTrack(item)
+        );
+        if (anyNonChat) {
+          logger.debug("Youtube Provider: switched to fallback non-chat track");
+          captionTrack = anyNonChat;
+        }
+      }
     }
 
     return captionTrack;
@@ -415,6 +446,7 @@ class YouTubeCaptionProvider {
 
     try {
       potUrl.searchParams.delete("tlang");
+      potUrl.searchParams.delete("name");
       potUrl.searchParams.set("lang", capUrl.searchParams.get("lang"));
       potUrl.searchParams.set("fmt", "json3");
       if (capUrl.searchParams.get("kind")) {
@@ -500,6 +532,7 @@ class YouTubeCaptionProvider {
 
     const lang = potUrl.searchParams.get("lang");
     const interceptedKind = potUrl.searchParams.get("kind") || null;
+    const interceptedName = potUrl.searchParams.get("name");
     const fromLang = this.#getFromLang(lang);
     if (this.#flatEvents.length) {
       if (
@@ -908,11 +941,32 @@ class YouTubeCaptionProvider {
     }
 
     let subtitles = this.#processSubtitles({ flatEvents });
-    const isPoor = this.#isQualityPoor(subtitles);
-    logger.debug("Youtube Provider: isQualityPoor", { isPoor, subtitles });
-    if (isPoor) {
-      subtitles = this.#processSubtitles({ flatEvents, usePause: true });
+
+    const longSentenceThreshold = this.#setting.longSentenceThreshold ?? 120;
+    const result = [];
+    for (const sub of subtitles) {
+      if (sub.text.length > longSentenceThreshold) {
+        const subEvents = flatEvents.filter(
+          (e) => e.start >= sub.start && e.start < sub.end
+        );
+        if (subEvents.length > 1) {
+          logger.debug("Youtube Provider: re-processing long sentence with pause", {
+            length: sub.text.length,
+            text: sub.text.slice(0, 50) + "...",
+          });
+          const reProcessed = this.#processSubtitles({
+            flatEvents: subEvents,
+            usePause: true,
+          });
+          result.push(...reProcessed);
+        } else {
+          result.push(sub);
+        }
+      } else {
+        result.push(sub);
+      }
     }
+    subtitles = result;
 
     return subtitles;
   }

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -457,6 +457,7 @@ export default function SubtitleSetting() {
     apiSlug,
     segSlug,
     chunkLength,
+    longSentenceThreshold = 120,
     preTrans = 90,
     throttleTrans = 30,
     toLang,
@@ -562,6 +563,19 @@ export default function SubtitleSetting() {
                 onChange={handleChange}
                 min={200}
                 max={20000}
+              />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <ValidationInput
+                fullWidth
+                size="small"
+                label={i18n("long_sentence_threshold")}
+                type="number"
+                name="longSentenceThreshold"
+                value={longSentenceThreshold}
+                onChange={handleChange}
+                min={20}
+                max={500}
               />
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>


### PR DESCRIPTION
弃用基于长句全文占比来决定是否使用Pause词汇拆分句子的逻辑，这会两种结果，要么全部被二次拆分，要么完全不进入二次拆分。
现在对所有超过阈值长度的句子采取二次拆分的操作，这将使字幕的长度更加均匀。
在字幕翻译设置页面增加长度阈值的设置项。