### PR TITLE
feat: 于 "仅译文模式" 下提供 "鼠标悬浮展示原文" 功能及相关配置

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1880,6 +1880,20 @@ export const I18N = {
     ja: `完全な実装ではなく、一部のページでスタイルの問題が発生する可能性があります。`,
     ko: `완벽한 구현이 아니며 일부 페이지에서 스타일 문제가 발생할 수 있습니다.`,
   },
+  transonly_revert: {
+    zh: `悬浮显示原文`,
+    en: `Hover to Show Original`,
+    zh_TW: `懸浮顯示原文`,
+    ja: `ホバーで原文を表示`,
+    ko: `호버 시 원문 표시`,
+  },
+  transonly_revert_delay: {
+    zh: `悬浮延迟(秒)`,
+    en: `Hover Delay (seconds)`,
+    zh_TW: `懸浮延遲(秒)`,
+    ja: `ホバー遅延(秒)`,
+    ko: `호버 지연(초)`,
+  },
   translate_page_title: {
     zh: `是否翻译页面标题`,
     en: `Translate Page Title`,

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -71,6 +71,8 @@ export const DEFAULT_RULE = {
   injectJs: "", // 注入JS
   // injectCss: "", // 注入CSS (作废)
   transOnly: GLOBAL_KEY, // 是否仅显示译文
+  transOnlyRevert: GLOBAL_KEY, // 悬浮恢复原文
+  transOnlyRevertDelay: GLOBAL_KEY, // 悬浮恢复延迟(秒)
   // transTiming: GLOBAL_KEY, // 翻译时机/鼠标悬停翻译  (暂时作废)
   transTag: GLOBAL_KEY, // 译文元素标签
   transTitle: GLOBAL_KEY, // 是否同时翻译页面标题
@@ -116,6 +118,8 @@ export const GLOBLA_RULE = {
   injectJs: "", // 注入JS
   injectCss: "", // 注入CSS
   transOnly: "false", // 是否仅显示译文
+  transOnlyRevert: "false", // 悬浮恢复原文
+  transOnlyRevertDelay: "0.5", // 悬浮恢复延迟(秒)
   // transTiming: OPT_TIMING_PAGESCROLL, // 翻译时机/鼠标悬停翻译 (暂时作废)
   transTag: DEFAULT_TRANS_TAG, // 译文元素标签
   transTitle: "false", // 是否同时翻译页面标题

--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -126,6 +126,7 @@ const mergeRules = (baseRule, overrideRule) => {
     "toLang",
     "transOpen",
     "transOnly",
+    "transOnlyRevert",
     "autoScan",
     "hasRichText",
     "hasShadowroot",
@@ -142,8 +143,8 @@ const mergeRules = (baseRule, overrideRule) => {
   });
 
   // 数字类型的属性
-  ["splitLength"].forEach((key) => {
-    if (overrideRule[key]) {
+  ["splitLength", "transOnlyRevertDelay"].forEach((key) => {
+    if (overrideRule[key] && overrideRule[key] !== GLOBAL_KEY) {
       merged[key] = overrideRule[key];
     }
   });
@@ -262,6 +263,8 @@ export const checkRules = (rules) => {
         textStyle,
         transOpen,
         transOnly,
+        transOnlyRevert,
+        transOnlyRevertDelay,
         autoScan,
         hasRichText,
         hasShadowroot,
@@ -303,6 +306,11 @@ export const checkRules = (rules) => {
             : GLOBAL_KEY,
         transOpen: matchValue([GLOBAL_KEY, "true", "false"], transOpen),
         transOnly: matchValue([GLOBAL_KEY, "true", "false"], transOnly),
+        transOnlyRevert: matchValue([GLOBAL_KEY, "true", "false"], transOnlyRevert),
+        transOnlyRevertDelay:
+          type(transOnlyRevertDelay) === "string" && !isNaN(parseFloat(transOnlyRevertDelay))
+            ? transOnlyRevertDelay
+            : GLOBAL_KEY,
         autoScan: matchValue([GLOBAL_KEY, "true", "false"], autoScan),
         hasRichText: matchValue([GLOBAL_KEY, "true", "false"], hasRichText),
         hasShadowroot: matchValue([GLOBAL_KEY, "true", "false"], hasShadowroot),

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -297,6 +297,12 @@ export class Translator {
   #mouseHoverEnabled = false; // 鼠标悬停翻译
   #enabled = false; // 全局默认状态
   #runId = 0; // 用于中止过期的异步请求
+
+  #transOnlyRevertTimer = null;
+  #transOnlyRevertTarget = null;
+  #transOnlyRevertEnabled = false;
+  #boundTransOnlyMouseOver = null;
+  #boundTransOnlyMouseOut = null;
   #termValues = []; // 按顺序存储术语的替换值
   #combinedTermsRegex; // 专业术语正则表达式
   #combinedSkipsRegex; // 跳过文本正则表达式
@@ -508,6 +514,14 @@ export class Translator {
     // 鼠标悬停翻译
     if (this.#setting.mouseHoverSetting.useMouseHover) {
       this.#enableMouseHover();
+    }
+
+    // 仅显示译文模式下悬浮恢复原文
+    if (
+      this.#rule.transOnly === "true" &&
+      this.#rule.transOnlyRevert === "true"
+    ) {
+      this.#enableTransOnlyRevert();
     }
 
     if (document.readyState === "loading") {
@@ -1937,6 +1951,119 @@ export class Translator {
     this.#removeKeydownHandler?.();
   }
 
+  #enableTransOnlyRevert() {
+    if (this.#transOnlyRevertEnabled) return;
+    this.#transOnlyRevertEnabled = true;
+
+    this.#boundTransOnlyMouseOver = (e) => {
+      const wrapper = e.target.closest?.(
+        `.${Translator.KISS_CLASS.warpper}`
+      );
+      if (wrapper) {
+        const data = this.#translationNodes.get(wrapper);
+        if (!data || !data.isHide) return;
+        if (this.#transOnlyRevertTarget === wrapper) return;
+
+        this.#clearTransOnlyRevertTimer();
+        const delay =
+          parseFloat(this.#rule.transOnlyRevertDelay) || 0.5;
+        this.#transOnlyRevertTimer = setTimeout(() => {
+          this.#showOriginalTemporarily(wrapper, data);
+        }, delay * 1000);
+        return;
+      }
+
+      if (this.#transOnlyRevertTarget) {
+        const data = this.#translationNodes.get(this.#transOnlyRevertTarget);
+        if (data) {
+          const origNodes = data.nodes || [];
+          for (const node of origNodes) {
+            if (node === e.target || node.contains?.(e.target)) return;
+          }
+        }
+      }
+    };
+
+    this.#boundTransOnlyMouseOut = (e) => {
+      if (!this.#transOnlyRevertTarget) {
+        const wrapper = e.target.closest?.(
+          `.${Translator.KISS_CLASS.warpper}`
+        );
+        if (wrapper) this.#clearTransOnlyRevertTimer();
+        return;
+      }
+
+      const wrapper = this.#transOnlyRevertTarget;
+      const related = e.relatedTarget;
+
+      if (related && (wrapper.contains(related) || related === wrapper)) return;
+
+      const data = this.#translationNodes.get(wrapper);
+      if (data && related) {
+        const origNodes = data.nodes || [];
+        for (const node of origNodes) {
+          if (node === related || node.contains?.(related)) return;
+        }
+      }
+
+      this.#clearTransOnlyRevertTimer();
+      this.#hideOriginalTemporarily(wrapper);
+    };
+
+    document.addEventListener("mouseover", this.#boundTransOnlyMouseOver);
+    document.addEventListener("mouseout", this.#boundTransOnlyMouseOut);
+  }
+
+  #disableTransOnlyRevert() {
+    if (!this.#transOnlyRevertEnabled) return;
+    this.#transOnlyRevertEnabled = false;
+
+    this.#clearTransOnlyRevertTimer();
+    if (this.#transOnlyRevertTarget) {
+      this.#hideOriginalTemporarily(this.#transOnlyRevertTarget);
+    }
+
+    document.removeEventListener("mouseover", this.#boundTransOnlyMouseOver);
+    document.removeEventListener("mouseout", this.#boundTransOnlyMouseOut);
+    this.#boundTransOnlyMouseOver = null;
+    this.#boundTransOnlyMouseOut = null;
+  }
+
+  #clearTransOnlyRevertTimer() {
+    if (this.#transOnlyRevertTimer) {
+      clearTimeout(this.#transOnlyRevertTimer);
+      this.#transOnlyRevertTimer = null;
+    }
+  }
+
+  #showOriginalTemporarily(wrapper, data) {
+    const { nodes } = data;
+    this.#withViewportAnchor(() => {
+      this.#restoreOriginal(wrapper, nodes);
+      const inner = wrapper.querySelector(
+        `:scope > .${Translator.KISS_CLASS.inner}`
+      );
+      if (inner) inner.style.display = "none";
+      const br = wrapper.querySelector(":scope > br");
+      if (br) br.hidden = true;
+    });
+    this.#transOnlyRevertTarget = wrapper;
+  }
+
+  #hideOriginalTemporarily(wrapper) {
+    const data = this.#translationNodes.get(wrapper);
+    if (!data) return;
+    const { nodes } = data;
+    this.#withViewportAnchor(() => {
+      this.#removeNodes(nodes);
+      const inner = wrapper.querySelector(
+        `:scope > .${Translator.KISS_CLASS.inner}`
+      );
+      if (inner) inner.style.display = "";
+    });
+    this.#transOnlyRevertTarget = null;
+  }
+
   // 注入JS/CSS
   #initInjector() {
     if (this.#isJsInjected) {
@@ -2106,6 +2233,7 @@ export class Translator {
     this.disable();
     this.#resetOptions();
     this.#disableMouseHover();
+    this.#disableTransOnlyRevert();
     this.#removeInjector();
     this.#isInitialized = false;
   }
@@ -2138,11 +2266,24 @@ export class Translator {
 
     if (needsRescan || (this.#enabled && this.#setting.transAllnow)) {
       this.rescan();
+      this.#syncTransOnlyRevert();
       return;
     }
 
     if (hasChanged) {
       this.#reIOViewNodes();
+      this.#syncTransOnlyRevert();
+    }
+  }
+
+  #syncTransOnlyRevert() {
+    const shouldEnable =
+      this.#rule.transOnly === "true" &&
+      this.#rule.transOnlyRevert === "true";
+    if (shouldEnable && !this.#transOnlyRevertEnabled) {
+      this.#enableTransOnlyRevert();
+    } else if (!shouldEnable && this.#transOnlyRevertEnabled) {
+      this.#disableTransOnlyRevert();
     }
   }
 

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -117,6 +117,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
     // bgColor,
     // textDiyStyle,
     transOnly = "false",
+    transOnlyRevert = "false",
+    transOnlyRevertDelay = "0.5",
     autoScan = "true",
     hasRichText = "true",
     hasShadowroot = "false",
@@ -440,6 +442,37 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
                 <MenuItem value={"false"}>{i18n("disable")}</MenuItem>
                 <MenuItem value={"true"}>{i18n("enable")}</MenuItem>
               </TextField>
+            </Grid>
+
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                select
+                size="small"
+                fullWidth
+                name="transOnlyRevert"
+                value={transOnlyRevert}
+                label={i18n("transonly_revert")}
+                disabled={disabled}
+                onChange={handleChange}
+              >
+                {GlobalItem}
+                <MenuItem value={"false"}>{i18n("disable")}</MenuItem>
+                <MenuItem value={"true"}>{i18n("enable")}</MenuItem>
+              </TextField>
+            </Grid>
+
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                size="small"
+                fullWidth
+                name="transOnlyRevertDelay"
+                value={transOnlyRevertDelay}
+                label={i18n("transonly_revert_delay")}
+                disabled={disabled}
+                onChange={handleChange}
+                type="number"
+                inputProps={{ min: 0, step: 0.1 }}
+              />
             </Grid>
 
             <Grid item xs={12} sm={12} md={6} lg={3}>


### PR DESCRIPTION
在需要快速阅读一些专业性较强的文本时, 我经常会直接打开仅译文模式阅读页面, 但当我发现翻译的不通顺之处时, 我又时时需要查看原文对照. 若直接关闭仅译文模式, 大段原文又占据了太多页面空间 (AI 在 99% 的情况下翻译没有问题, 绝大部分原文我本来也不会阅读). 为了快速便捷地查看小段原文, 我就想如果有一个功能可以和 "悬浮翻译" 一样, 但是功能 "相反", 变成 "悬浮展示原文" 就好了, 于是我让 Claude Opus 为我实现了这个功能.

声明: 本人具有专业编程经验, 但并不熟悉本项目的代码和开发过程. 本 PR 中的代码完全由 Claude Opus 编写, 我只对其进行了项目无关的基于通用编程经验和 JS 知识的审阅. 本 PR 内提出的改动本人已在且仅在本机 chromium 上进行了试用, 确实实现了 AI 所声称其实现的功能. 如干扰了本项目的正常贡献过程, 在此道歉并欢迎维护者直接关闭本 PR; 您亦可关闭 PR 后以您觉得合理的方式以相同思路自行实现本功能, 本人放弃对此贡献的署名要求.

所使用的 prompt:
```
我想要扩展这个 chrome 扩展在 "仅显示译文" 模式下的功能, 我想添加一个选项, "鼠标悬浮时显示原文", 当鼠标在给定元素上悬浮超过 x 秒 (用户可配) 之后, 可以显示原始元素, 鼠标移开之后恢复.
```

---
以下为 AI 总结:
 - 在"仅显示译文"模式下新增"悬浮显示原文"功能：鼠标悬停在译文元素上超过可配置的延迟时间后，隐藏译文并显示原文；鼠标移开后恢复显示译文
 - 新增两个 rule 级别配置项：transOnlyRevert（开关）和 transOnlyRevertDelay（延迟秒数，默认 0.5s），支持按站点独立配置
 - 在 Options > Rules 设置页中添加了对应 UI 控件