### PR TITLE
fix: fallback caused single-word subtitle

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -777,11 +777,6 @@ class YouTubeCaptionProvider {
       }
     }
 
-    if (!isAutoCaption) {
-      // 人工字幕已是句级分段，直接使用无需合并
-      return [flatEvents.filter((e) => e.text), 100];
-    }
-
     return subtitlesFallback();
   }
 


### PR DESCRIPTION
fallback会导致切换后出现单个词汇组成的字幕列表，无法阅读，也极度影响字幕列表性能。

可以通过 https://www.youtube.com/watch?v=1wkUyzUPo6Q 复现。