### PR TITLE
feat: 增加调试日志以增强 API 调用和翻译过程的可追踪性

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -30,6 +30,7 @@ import { isBuiltinAIAvailable } from "../libs/browser";
 import { chromeDetect, chromeTranslate } from "../libs/builtinAI";
 import { fnPolyfill } from "../libs/fetch";
 import { getFetchPool } from "../libs/pool";
+import { logger } from "../libs/log";
 
 /**
  * 同步数据
@@ -491,6 +492,18 @@ export const apiTranslate = async ({
   }
 
   const { apiType, apiSlug, useBatchFetch } = apiSetting;
+
+  logger.debug("apiTranslate start", {
+    apiType,
+    apiSlug,
+    fromLang,
+    toLang,
+    textLen: text.length,
+    useBatchFetch,
+    useCache,
+    usePool,
+    textPreview: text.slice(0, 80) + (text.length > 80 ? "..." : ""),
+  });
   const langMap = OPT_LANGS_TO_SPEC[apiType] || OPT_LANGS_SPEC_DEFAULT;
   const from = langMap.get(fromLang);
   const to = langMap.get(toLang);
@@ -514,8 +527,10 @@ export const apiTranslate = async ({
   if (useCache) {
     const cache = await getHttpCachePolyfill(cacheInput);
     if (cache?.trText) {
+      logger.debug("apiTranslate cache hit", { apiSlug, trText: cache.trText?.slice(0, 60) });
       return cache;
     }
+    logger.debug("apiTranslate cache miss", { apiSlug });
   }
 
   // 请求接口数据
@@ -528,6 +543,7 @@ export const apiTranslate = async ({
       apiSetting,
     });
   } else if (useBatchFetch && API_SPE_TYPES.batch.has(apiType)) {
+    logger.debug("apiTranslate using batch queue", { apiType, apiSlug });
     const { apiSlug, batchInterval, batchSize, batchLength, useStream } =
       apiSetting;
     const enableStream = useStream && API_SPE_TYPES.stream.has(apiType);
@@ -551,6 +567,7 @@ export const apiTranslate = async ({
       docInfo,
     });
   } else {
+    logger.debug("apiTranslate using direct call", { apiType, apiSlug });
     const { value } = await handleTranslate([text], {
       from,
       to,
@@ -587,6 +604,11 @@ export const apiTranslate = async ({
   if (useCache) {
     putHttpCachePolyfill(cacheInput, null, { trText, isSame, srLang, srCode });
   }
+
+  logger.debug("apiTranslate done", {
+    apiType, trTextLen: trText.length, srLang, srCode, isSame,
+    trTextPreview: trText.slice(0, 60),
+  });
 
   return { trText, srLang, srCode, isSame };
 };

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -64,7 +64,7 @@ import {
   detectStreamFormat,
   getStreamDelta,
 } from "../libs/stream";
-import { kissLog } from "../libs/log";
+import { kissLog, logger } from "../libs/log";
 import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
 import { parseBilingualVtt } from "../subtitle/vtt";
@@ -186,10 +186,14 @@ const genSubtitlePrompt = ({
 
 const parseAIRes = (raw, useBatchFetch = true) => {
   if (!raw) {
+    logger.debug("parseAIRes: empty input");
     return [];
   }
 
+  logger.debug("parseAIRes start", { rawLength: raw.length, useBatchFetch, rawPreview: raw.slice(0, 120) });
+
   if (!useBatchFetch) {
+    logger.debug("parseAIRes: non-batch mode, return as-is");
     return [[raw]];
   }
 
@@ -890,6 +894,13 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     docInfo: externalDocInfo,
   } = args;
 
+  logger.debug("genTransReq", {
+    apiType, apiSlug,
+    fromLang, toLang, textCount: texts?.length,
+    useBatchFetch, hasEvents: !!events,
+    textPreview: texts?.[0]?.slice(0, 80) + (texts?.[0]?.length > 80 ? "..." : ""),
+  });
+
   if (API_SPE_TYPES.mulkeys.has(apiType)) {
     args.key = keyPick(apiSlug, key, keyMap);
   }
@@ -909,26 +920,26 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     let baseSystemPrompt = events
       ? genSubtitlePrompt({
-          subtitlePrompt,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo,
-          tone,
-          aiTerms,
-        })
+        subtitlePrompt,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo,
+        tone,
+        aiTerms,
+      })
       : genSystemPrompt({
-          systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo,
-          tone,
-        });
+        systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo,
+        tone,
+      });
 
     // 上下文回退：当 prompt 模板缺少占位符时，追加 # Context 块
     if (hasExternalDocInfo) {
@@ -953,18 +964,18 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     args.userPrompt = events
       ? JSON.stringify(events)
       : genUserPrompt({
-          nobatchUserPrompt,
-          useBatchFetch,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo: userDocInfo,
-          tone,
-          glossary,
-          aiTerms,
-        });
+        nobatchUserPrompt,
+        useBatchFetch,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo: userDocInfo,
+        tone,
+        glossary,
+        aiTerms,
+      });
   }
 
   const {
@@ -1008,6 +1019,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
         req
       );
       if (hookResult && hookResult.url) {
+        logger.debug("genTransReq hook override", { url: hookResult.url });
         return genInit(hookResult);
       }
     } catch (err) {
@@ -1016,7 +1028,9 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     }
   }
 
-  return genInit({ url, body, headers, userMsg, method });
+  const [resultUrl, resultInit] = genInit({ url, body, headers, userMsg, method });
+  logger.debug("genTransReq result", { url: resultUrl, method: resultInit.method, bodySize: resultInit.body?.length || 0 });
+  return [resultUrl, resultInit, userMsg];
 };
 
 /**
@@ -1244,7 +1258,13 @@ export async function* handleTranslate(
     docInfo,
   });
 
+  logger.debug("handleTranslate sending", {
+    apiType, textCount: texts.length, enableStream,
+    useContext, contextMessages: hisMsgs.length,
+  });
+
   if (enableStream) {
+    logger.debug("handleTranslate using stream mode");
     yield* handleTranslateStreamInternal(texts, input, init, {
       apiType,
       history,
@@ -1256,6 +1276,7 @@ export async function* handleTranslate(
       streamRenderMode: apiSetting.streamRenderMode || "disabled",
     });
   } else {
+    logger.debug("handleTranslate using non-stream mode");
     const response = await fetchData(input, init, {
       useCache: false,
       usePool,
@@ -1267,6 +1288,7 @@ export async function* handleTranslate(
       throw new Error("translate got empty response");
     }
 
+    logger.debug("handleTranslate got response", { apiType, responseType: typeof response });
     const result = await parseTransRes(response, {
       texts,
       from,
@@ -1282,6 +1304,7 @@ export async function* handleTranslate(
       throw new Error("translate got an unexpected result");
     }
 
+    logger.debug("handleTranslate parsed result", { resultCount: result.length, firstResult: result[0]?.[0]?.slice(0, 60) });
     for (let i = 0; i < result.length; i++) {
       yield { id: i, result: result[i] };
     }
@@ -1300,6 +1323,12 @@ async function* handleTranslateStreamInternal(
   const results = new Array(texts.length).fill(null);
   let fullContent = "";
   const processedIds = new Set();
+  let chunkCount = 0;
+
+  logger.debug("handleTranslateStream start", {
+    apiType, textCount: texts.length,
+    streamRenderMode,
+  });
 
   const jsonParser = createStreamingJsonParser();
   const realtimeParser =
@@ -1400,6 +1429,14 @@ async function* handleTranslateStreamInternal(
       });
     }
   }
+
+  logger.debug("handleTranslateStream done", {
+    apiType, totalChunks: chunkCount,
+    fullContentLength: fullContent.length,
+    resultsFilled: results.filter(Boolean).length,
+    hasEmpty,
+    contentPreview: fullContent.slice(0, 100),
+  });
 }
 
 /**
@@ -1445,6 +1482,8 @@ export const handleSubtitle = async ({
 }) => {
   const { apiType, fetchInterval, fetchLimit, httpTimeout } = apiSetting;
 
+  logger.debug("handleSubtitle start", { apiType, eventCount: events?.length, from, to });
+
   const [input, init] = await genTransReq({
     ...apiSetting,
     events,
@@ -1464,6 +1503,8 @@ export const handleSubtitle = async ({
     kissLog("subtitle got empty response");
     return [];
   }
+
+  logger.debug("handleSubtitle got response", { apiType, responseLen: JSON.stringify(res || "").length });
 
   switch (apiType) {
     case OPT_TRANS_OPENAI:

--- a/src/libs/fetch.js
+++ b/src/libs/fetch.js
@@ -3,7 +3,7 @@ import { sendBgMsg } from "./msg";
 import { getSettingWithDefault } from "./storage";
 import { MSG_FETCH, DEFAULT_HTTP_TIMEOUT, PORT_STREAM_FETCH } from "../config";
 import { isBg } from "./browser";
-import { kissLog } from "./log";
+import { kissLog, logger } from "./log";
 import { getFetchPool } from "./pool";
 import { getHttpCachePolyfill, parseResponse } from "./cache";
 import { createSSEParser, createAsyncQueue } from "./stream";
@@ -66,6 +66,7 @@ export const fetchGM = async (
  * @returns
  */
 export const fetchPatcher = async (input, init = {}, opts) => {
+  logger.debug("fetchPatcher start", { url: input, method: init.method, env: isGm ? "GM" : isExt ? "Extension" : "Web" });
   let timeout = opts?.httpTimeout;
   if (!timeout) {
     try {
@@ -106,8 +107,12 @@ export const fetchPatcher = async (input, init = {}, opts) => {
  * @returns
  */
 export const fetchHandle = async ({ input, init, opts }) => {
+  const startTime = Date.now();
   const res = await fetchPatcher(input, init, opts);
-  return parseResponse(res, opts.expect);
+  const duration = Date.now() - startTime;
+  const parsed = await parseResponse(res, opts.expect);
+  logger.debug("fetchHandle done", { url: input, status: res.status, duration: `${duration}ms`, bodySize: typeof parsed === "string" ? parsed.length : JSON.stringify(parsed || "").length });
+  return parsed;
 };
 
 /**
@@ -141,21 +146,27 @@ export const fetchData = async (
     throw new Error("URL is empty");
   }
 
+  logger.debug("fetchData called", { url: input, method: init?.method, useCache, usePool, timeout: opts?.httpTimeout });
+
   // 使用缓存数据
   if (useCache) {
     const resCache = await getHttpCachePolyfill(input, init);
     if (resCache) {
+      logger.debug("fetchData cache hit", { url: input });
       return resCache;
     }
+    logger.debug("fetchData cache miss", { url: input });
   }
 
   // 通过任务池发送请求
   if (usePool) {
+    logger.debug("fetchData using pool", { url: input, fetchInterval, fetchLimit });
     const fetchPool = getFetchPool(fetchInterval, fetchLimit);
     return fetchPool.push(fnPolyfill, { fn: fetchHandle, input, init, opts });
   }
 
   // 直接请求
+  logger.debug("fetchData direct request", { url: input });
   return fnPolyfill({ fn: fetchHandle, input, init, opts });
 };
 
@@ -219,12 +230,16 @@ async function* fetchStreamGM(
  * @returns {AsyncGenerator<string>}
  */
 export async function* fetchStreamNative(input, init, timeout) {
+  logger.debug("fetchStreamNative start", { url: input });
   const signal = AbortSignal?.timeout?.(timeout);
+  const startTime = Date.now();
   const response = await fetch(input, { ...init, signal });
 
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
+
+  logger.debug("fetchStreamNative response", { url: input, status: response.status, duration: `${Date.now() - startTime}ms` });
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
@@ -337,23 +352,30 @@ export async function* fetchStream(
     throw new Error("URL is empty");
   }
 
+  logger.debug("fetchStream start", { url: input, method: init?.method, usePool, timeout: opts?.httpTimeout });
+
   // 使用缓存数据
   if (useCache) {
     const resCache = await getHttpCachePolyfill(input, init);
     if (resCache) {
+      logger.debug("fetchStream cache hit", { url: input });
       yield resCache;
       return;
     }
   }
 
+  let chunkCount = 0;
+
   // 通过任务池发送请求
   if (usePool) {
+    logger.debug("fetchStream using pool", { url: input, fetchInterval, fetchLimit });
     const fetchPool = getFetchPool(fetchInterval, fetchLimit);
     const asyncQueue = createAsyncQueue();
 
     const streamPromise = fetchPool.push(async () => {
       try {
         for await (const chunk of fnPolyfillStream(input, init, opts)) {
+          chunkCount++;
           asyncQueue.push(chunk);
         }
         asyncQueue.finish();
@@ -365,9 +387,14 @@ export async function* fetchStream(
 
     yield* asyncQueue.iterate();
     await streamPromise;
+    logger.debug("fetchStream done", { url: input, totalChunks: chunkCount });
     return;
   }
 
   // 直接请求
-  yield* fnPolyfillStream(input, init, opts);
+  for await (const chunk of fnPolyfillStream(input, init, opts)) {
+    chunkCount++;
+    yield chunk;
+  }
+  logger.debug("fetchStream done", { url: input, totalChunks: chunkCount });
 }

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -26,7 +26,7 @@ import {
   parseAITerms,
 } from "./utils";
 import { apiTranslate } from "../apis";
-import { kissLog } from "./log";
+import { kissLog, logger } from "./log";
 import { clearAllBatchQueue } from "./batchQueue";
 import { genTextClass } from "./style";
 import { createLoadingSVG, createRetrySVG } from "./svg";
@@ -539,10 +539,10 @@ export class Translator {
         .querySelectorAll("pre")
         .forEach(
           (pre) =>
-            (pre.innerHTML = pre.innerHTML?.replace(
-              /(?:\r\n|\r|\n)/g,
-              "<br />"
-            ))
+          (pre.innerHTML = pre.innerHTML?.replace(
+            /(?:\r\n|\r|\n)/g,
+            "<br />"
+          ))
         );
     }
 
@@ -710,7 +710,7 @@ export class Translator {
         if (
           this.#skipMoNodes.has(mutation.target) ||
           mutation.nextSibling?.tagName?.toLowerCase() ===
-            this.#translationTagName
+          this.#translationTagName
         ) {
           continue;
         }
@@ -1336,7 +1336,17 @@ export class Translator {
         nodes,
         termsStyle
       );
-      if (this.#isInvalidText(processedString)) return;
+
+      logger.debug("translateNodeGroup serialized", {
+        nodeCount: nodes.length,
+        textLen: processedString.length,
+        textPreview: processedString.slice(0, 80) + (processedString.length > 80 ? "..." : ""),
+      });
+
+      if (this.#isInvalidText(processedString)) {
+        logger.debug("translateNodeGroup skipped invalid text");
+        return;
+      }
 
       const wrapper = document.createElement(this.#translationTagName);
       wrapper.className = `${Translator.KISS_CLASS.warpper} notranslate`;
@@ -1387,28 +1397,34 @@ export class Translator {
 
       const onStreamChunk = isStreamRender
         ? (chunk) => {
-            if (this.#runId !== currentRunId) return;
-            const { text, isComplete } = chunk;
-            if (!text) return;
+          if (this.#runId !== currentRunId) return;
+          const { text, isComplete } = chunk;
+          if (!text) return;
 
-            if (isComplete) {
-              pendingText = Array.isArray(text) ? text[0] : text;
-              if (rafId) {
-                cancelAnimationFrame(rafId);
-                rafId = null;
-              }
-              flushPendingText();
-            } else {
-              pendingText = text;
-              if (!rafId) {
-                rafId = requestAnimationFrame(flushPendingText);
-              }
+          if (isComplete) {
+            pendingText = Array.isArray(text) ? text[0] : text;
+            if (rafId) {
+              cancelAnimationFrame(rafId);
+              rafId = null;
+            }
+            flushPendingText();
+          } else {
+            pendingText = text;
+            if (!rafId) {
+              rafId = requestAnimationFrame(flushPendingText);
             }
           }
+        }
         : null;
 
       const { trText: translatedText, isSame: isSameLang } =
         await this.#translateFetch(processedString, deLang, onStreamChunk);
+
+      logger.debug("translateNodeGroup got translation", {
+        trTextLen: translatedText?.length || 0,
+        isSameLang,
+        trTextPreview: translatedText?.slice(0, 60),
+      });
 
       // 清理 RAF 缓冲
       if (rafId) {
@@ -1725,6 +1741,13 @@ export class Translator {
       onStreamChunk,
     };
 
+    logger.debug("translateFetch", {
+      apiType: apiSetting.apiType,
+      fromLang, toLang,
+      textLen: text.length,
+      hasStreamChunk: !!onStreamChunk,
+    });
+
     // 翻译开始钩子函数
     if (transStartHook?.trim()) {
       try {
@@ -2006,6 +2029,8 @@ export class Translator {
     this.#rule.transOpen = "true";
     this.#runId++;
 
+    logger.debug("Translator enabled", { rule: this.#rule.apiSlug, transAllnow: this.#setting.transAllnow });
+
     if (this.#isInitialized) {
       if (this.#setting.transAllnow) {
         this.rescan();
@@ -2061,6 +2086,8 @@ export class Translator {
   rescan() {
     if (!this.#isInitialized) return;
     this.#runId++;
+
+    logger.debug("Translator rescan");
 
     this.#cleanupAllNodes();
     this.#resetOptions();


### PR DESCRIPTION
此拉取请求在整个翻译、API及网络代码中新增了大量调试日志，以提升可观测性与故障排查能力。新增日志在关键步骤（如API调用、缓存使用、流式操作及翻译处理）提供了详细上下文信息。这些改动不影响功能，但能帮助开发者更高效地追踪执行流程与诊断问题。

**调试日志增强：**

* 在 `src/apis/index.js`、`src/apis/trans.js`、`src/libs/fetch.js` 和 `src/libs/translator.js` 的主要函数中添加了 `logger.debug` 调用，用于记录API参数、缓存命中/未命中、流式传输进度及翻译结果。[[1]](diffhunk://#diff-0d6dfab09c06908612a28d65e8ade1facc03513ed414076dbb61119ba0e0f7c2R495-R506) [[2]](diffhunk://#diff-5947210954ec971c113b5654c67c808ffc1d95106afa19372c6f5de0c9540a66R189-R196) [[3]](diffhunk://#diff-2f3cd5050a8a415f908016ab919867c5c6511d4f0253a883bb67ef51c5c12370R110-R115) [[4]](diffhunk://#diff-243cc70f1db612d1a8cac716c10bae7bba31a995a22250498d080cf1a454a5bbL1339-R1349)

**API及翻译流程日志记录：**

* 在翻译与字幕生成管线中，新增了追踪开始、完成及重要决策分支（如批量翻译与直接翻译、流式与非流式）的日志。[[1]](diffhunk://#diff-0d6dfab09c06908612a28d65e8ade1facc03513ed414076dbb61119ba0e0f7c2R546) [[2]](diffhunk://#diff-5947210954ec971c113b5654c67c808ffc1d95106afa19372c6f5de0c9540a66R1261-R1267) [[3]](diffhunk://#diff-5947210954ec971c113b5654c67c808ffc1d95106afa19372c6f5de0c9540a66R1485-R1486) [[4]](diffhunk://#diff-243cc70f1db612d1a8cac716c10bae7bba31a995a22250498d080cf1a454a5bbR1744-R1750)

**缓存与连接池使用日志记录：**

* 为 `fetchData`、`fetchStream` 和 `apiTranslate` 新增了缓存命中/未命中，以及fetch请求使用连接池或直接方法的日志。[[1]](diffhunk://#diff-2f3cd5050a8a415f908016ab919867c5c6511d4f0253a883bb67ef51c5c12370R149-R169) [[2]](diffhunk://#diff-2f3cd5050a8a415f908016ab919867c5c6511d4f0253a883bb67ef51c5c12370R355-R378) [[3]](diffhunk://#diff-0d6dfab09c06908612a28d65e8ade1facc03513ed414076dbb61119ba0e0f7c2R530-R533)

**流式传输与分块追踪：**

* 流式fetch与翻译现在会在开始和完成时记录分块数量与耗时，以便进行性能诊断。[[1]](diffhunk://#diff-2f3cd5050a8a415f908016ab919867c5c6511d4f0253a883bb67ef51c5c12370R233-R243) [[2]](diffhunk://#diff-2f3cd5050a8a415f908016ab919867c5c6511d4f0253a883bb67ef51c5c12370R390-R399) [[3]](diffhunk://#diff-5947210954ec971c113b5654c67c808ffc1d95106afa19372c6f5de0c9540a66R1326-R1331) [[4]](diffhunk://#diff-5947210954ec971c113b5654c67c808ffc1d95106afa19372c6f5de0c9540a66R1432-R1439)

**翻译器类生命周期日志记录：**

* `Translator` 类现在会记录翻译启用、重新扫描的事件，以及已处理文本节点与翻译结果的详情。[[1]](diffhunk://#diff-243cc70f1db612d1a8cac716c10bae7bba31a995a22250498d080cf1a454a5bbR2032-R2033) [[2]](diffhunk://#diff-243cc70f1db612d1a8cac716c10bae7bba31a995a22250498d080cf1a454a5bbR2090-R2091) [[3]](diffhunk://#diff-243cc70f1db612d1a8cac716c10bae7bba31a995a22250498d080cf1a454a5bbR1423-R1428)

这些改动将帮助开发者与维护者快速定位问题发生的位置，并理解应用运行时的行为。