### PR TITLE
fix: unescape HTML entities in subtitle translations

### DIFF
--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -5,6 +5,17 @@ import { apiMicrosoftDict } from "../apis/index.js";
 import { trustedTypesHelper } from "../libs/trustedTypes.js";
 import { isMobile } from "../libs/mobile.js";
 
+const decodeHTMLEntities = (str) => {
+  if (!str || typeof str !== "string") return str;
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'");
+};
+
 // 添加CSS样式用于高亮显示悬停的单词
 const addWordHoverStyles = () => {
   if (document.getElementById("kiss-word-hover-styles")) return;
@@ -830,7 +841,7 @@ export class BilingualSubtitleManager {
         apiSetting,
         docInfo,
       });
-      subtitle.translation = trText;
+      subtitle.translation = decodeHTMLEntities(trText);
     } catch (error) {
       logger.info("Translation failed for:", subtitle.text, error);
       subtitle.translation = "[Translation failed]";

--- a/src/subtitle/vtt.js
+++ b/src/subtitle/vtt.js
@@ -78,6 +78,17 @@ function formatMillisecondsToTimestamp(ms) {
  * @param {string} vttText - VTT文件的文本内容。
  * @returns {Array<Object>} 一个包含字幕对象的数组，每个对象包含 start, end, text, 和 translation.
  */
+const decodeHTMLEntities = (str) => {
+  if (!str || typeof str !== "string") return str;
+  return str
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'");
+};
+
 export function parseBilingualVtt(vttText) {
   const cleanText = vttText.replace(/^\uFEFF/, "").trim();
   if (!cleanText) {
@@ -102,8 +113,8 @@ export function parseBilingualVtt(vttText) {
     const textLines = lines.slice(timestampLineIndex + 1);
 
     if (startTimeString && endTimeString && textLines.length > 0) {
-      const originalText = textLines[0]?.trim() || "";
-      const translatedText = textLines[1]?.trim() || "";
+      const originalText = decodeHTMLEntities(textLines[0]?.trim() || "");
+      const translatedText = decodeHTMLEntities(textLines[1]?.trim() || "");
 
       result.push({
         start: parseTimestampToMilliseconds(startTimeString),


### PR DESCRIPTION
将被转义的符号替换回正常符号
这个问题存在挺久了，最常见的就是 “>>”翻译后变成 “&gt;&gt;”

解决方案，直接简单粗暴的replace即可