### PR TITLE
refactor: 划词翻译按钮跟随选中文本

### DIFF
--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -1,4 +1,4 @@
-import { LogLevel } from "../libs/log";
+﻿import { LogLevel } from "../libs/log";
 import {
   OPT_DICT_BING,
   OPT_SUG_YOUDAO,
@@ -91,8 +91,8 @@ export const DEFAULT_TRANBOX_SETTING = {
   toLang: "zh-CN",
   toLang2: "en",
   tranboxShortcut: DEFAULT_TRANBOX_SHORTCUT,
-  btnOffsetX: 10,
-  btnOffsetY: 10,
+  btnOffsetX: 0,
+  btnOffsetY: 0,
   boxOffsetX: 0,
   boxOffsetY: 10,
   hideTranBtn: false, // 是否隐藏翻译按钮

--- a/src/hooks/useAutoHideTranBtn.js
+++ b/src/hooks/useAutoHideTranBtn.js
@@ -1,35 +1,8 @@
-import { useEffect, useRef } from "react";
+﻿import { useEffect } from "react";
 
-export default function useAutoHideTranBtn(
-  showBtn,
-  setShowBtn,
-  position,
-  options = {}
-) {
-  const { delay = 5000, distance = 100 } = options;
-
-  const timerRef = useRef(null);
-  const originRef = useRef({ x: 0, y: 0 });
-
+export default function useAutoHideTranBtn(showBtn, setShowBtn) {
   useEffect(() => {
     if (!showBtn) return;
-
-    originRef.current = position;
-
-    /*等待5 秒自动隐藏翻译按钮*/
-    timerRef.current = setTimeout(() => {
-      setShowBtn(false);
-    }, delay);
-
-    /*鼠标移出 100px 自动隐藏翻译按钮*/
-    const handleMouseMove = (e) => {
-      const { x, y } = originRef.current;
-      const dx = e.clientX - x;
-      const dy = e.clientY - y;
-      if (dx * dx + dy * dy > distance * distance) {
-        setShowBtn(false);
-      }
-    };
 
     /*点击右键,隐藏翻译按钮*/
     const handleMouseDown = (e) => {
@@ -38,14 +11,17 @@ export default function useAutoHideTranBtn(
       }
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
+    const handleSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) setShowBtn(false);
+    };
 
     window.addEventListener("mousedown", handleMouseDown, true);
+    document.addEventListener("selectionchange", handleSelectionChange);
 
     return () => {
-      clearTimeout(timerRef.current);
-      window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mousedown", handleMouseDown, true);
+      document.removeEventListener("selectionchange", handleSelectionChange);
     };
-  }, [showBtn, position, delay, distance, setShowBtn]);
+  }, [showBtn, setShowBtn]);
 }

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+﻿import { useState, useCallback, useMemo, useEffect } from "react";
 import { sleep, limitNumber } from "../libs/utils";
 import { isMobile } from "../libs/mobile";
 import useAutoHideTranBtn from "./useAutoHideTranBtn";
@@ -6,6 +6,23 @@ import {
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
 } from "../config";
+
+function getSelectionPosition() {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) return null;
+  try {
+    const range = selection.getRangeAt(0);
+    const rects = range.getClientRects();
+    if (rects.length === 0) return null;
+    const lastRect = rects[rects.length - 1];
+    return {
+      x: lastRect.right + window.scrollX,
+      y: lastRect.bottom + window.scrollY,
+    };
+  } catch {
+    return null;
+  }
+}
 
 export default function useSelectionController({
   tranboxSetting,
@@ -25,7 +42,7 @@ export default function useSelectionController({
   const [position, setPosition] = useState({ x: 0, y: 0 }); // 划词按钮位置
 
   // 划词按钮自动隐藏
-  useAutoHideTranBtn(showBtn, setShowBtn, position);
+  useAutoHideTranBtn(showBtn, setShowBtn);
 
   // 打开翻译框
   const handleOpenTranbox = useCallback(
@@ -79,7 +96,6 @@ export default function useSelectionController({
     const eventName = isMobile ? "touchend" : "mouseup";
 
     async function handleMouseup(e) {
-      // e.stopPropagation();
       if (e.button === 2) return;
 
       await sleep(200);
@@ -108,12 +124,19 @@ export default function useSelectionController({
         return;
       }
 
-      const { clientX, clientY } = isMobile ? e.changedTouches[0] : e;
-      setShowBtn(!hideTranBtn);
-      setPosition({ x: clientX, y: clientY });
+      if (!hideTranBtn) {
+        const selectionPos = getSelectionPosition();
+        if (selectionPos) {
+          setShowBtn(true);
+          setPosition(selectionPos);
+        } else {
+          setShowBtn(false);
+        }
+      } else {
+        setShowBtn(false);
+      }
     }
 
-    // window.addEventListener("mouseup", handleMouseup);
     window.addEventListener(eventName, handleMouseup);
     return () => {
       window.removeEventListener(eventName, handleMouseup);

--- a/src/views/Selection/TranBtn.js
+++ b/src/views/Selection/TranBtn.js
@@ -1,5 +1,5 @@
+﻿import { createPortal } from "react-dom";
 import { isMobile } from "../../libs/mobile";
-import { limitNumber } from "../../libs/utils";
 
 export default function TranBtn({
   onTrigger,
@@ -8,20 +8,21 @@ export default function TranBtn({
   btnOffsetX,
   btnOffsetY,
 }) {
-  const left = limitNumber(position.x + btnOffsetX, 0, window.innerWidth - 32);
-  const top = limitNumber(position.y + btnOffsetY, 0, window.innerHeight - 32);
+  const left = position.x + btnOffsetX;
+  const top = position.y + btnOffsetY;
 
-  return (
+  const buttonElement = (
     <div
       className="KT-tranbtn"
       style={{
         cursor: "pointer",
-        // position: "absolute",
-        position: "fixed",
+        position: "absolute",
         left,
         top,
         zIndex: 2147483647,
       }}
+      // 阻止点击按钮时清除文本选区，防止 Hook 立刻隐藏按钮
+      onMouseDown={(e) => e.preventDefault()}
       {...{ [btnEvent]: onTrigger }}
     >
       <svg
@@ -44,4 +45,6 @@ export default function TranBtn({
       </svg>
     </div>
   );
+
+  return createPortal(buttonElement, document.body);
 }


### PR DESCRIPTION
1.修改按钮显示在选中文本右下角并跟随文本
2.添加选区消失时隐藏按钮
3.仅保留右键点击隐藏按钮