### PR TITLE
fix: 字幕轨道切换检测、Gemini截断处理与叠加层定位修复

### DIFF
--- a/src/apis/history.js
+++ b/src/apis/history.js
@@ -37,3 +37,7 @@ export const getMsgHistory = (apiSlug, maxSize) => {
   historyMap.set(apiSlug, msgHistory);
   return msgHistory;
 };
+
+export const clearMsgHistory = (apiSlug) => {
+  historyMap.delete(apiSlug);
+};

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -485,9 +485,13 @@ export const apiTranslate = async ({
   docInfo,
   useCache = true,
   usePool = true,
+  signal,
 }) => {
   if (!text) {
     throw new Error("The text cannot be empty.");
+  }
+  if (signal?.aborted) {
+    throw new DOMException("The operation was aborted.", "AbortError");
   }
 
   const { apiType, apiSlug, useBatchFetch } = apiSetting;
@@ -516,6 +520,9 @@ export const apiTranslate = async ({
     if (cache?.trText) {
       return cache;
     }
+  }
+  if (signal?.aborted) {
+    throw new DOMException("The operation was aborted.", "AbortError");
   }
 
   // 请求接口数据
@@ -549,6 +556,7 @@ export const apiTranslate = async ({
       usePool,
       onStreamChunk,
       docInfo,
+      signal,
     });
   } else {
     const { value } = await handleTranslate([text], {
@@ -561,6 +569,7 @@ export const apiTranslate = async ({
       apiSetting,
       usePool,
       docInfo,
+      signal,
     }).next();
     translation = value?.result;
   }

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -609,13 +609,17 @@ export const apiSubtitle = async ({
   events = [],
   apiSetting,
   docInfo,
+  prevContext = "",
+  nextContext = "",
 }) => {
+  if (!events?.length) return [];
   const cacheOpts = {
     apiSlug: apiSetting.apiSlug,
     videoId,
     chunkSign,
     fromLang,
     toLang,
+    segVer: 2,
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };
   const cacheInput = `${URL_CACHE_SUBTITLE}?${queryString.stringify(cacheOpts)}`;
@@ -630,6 +634,8 @@ export const apiSubtitle = async ({
     to: toLang,
     apiSetting,
     docInfo,
+    prevContext,
+    nextContext,
   });
   if (subtitles?.length) {
     putHttpCachePolyfill(cacheInput, null, subtitles);

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1201,8 +1201,11 @@ export async function* handleTranslate(
     apiSetting,
     usePool,
     docInfo,
+    signal,
   }
 ) {
+  if (signal?.aborted) return;
+
   let history = null;
   let hisMsgs = [];
   const {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -185,6 +185,36 @@ const genSubtitlePrompt = ({
     .replaceAll(INPUT_PLACE_TO_LANG, toLang);
 };
 
+const normalizeSubtitleContext = (text) =>
+  String(text ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 400);
+
+const buildSubtitleUserPrompt = ({
+  formattedEvents,
+  prevContext = "",
+  nextContext = "",
+}) => {
+  const mainInput = JSON.stringify(formattedEvents);
+  const prev = normalizeSubtitleContext(prevContext);
+  const next = normalizeSubtitleContext(nextContext);
+  if (!prev && !next) return mainInput;
+  const sections = [];
+  if (prev) {
+    sections.push(
+      `[Previous context (read-only, do NOT segment)]\n${JSON.stringify(prev)}`
+    );
+  }
+  sections.push(`[Main input]\n${mainInput}`);
+  if (next) {
+    sections.push(
+      `[Next context (read-only, do NOT segment)]\n${JSON.stringify(next)}`
+    );
+  }
+  return sections.join("\n\n");
+};
+
 const parseAIRes = (raw, useBatchFetch = true) => {
   if (!raw) {
     return [];
@@ -318,6 +348,8 @@ const parseIndexSubtitleRes = (raw, events) => {
         end: events[endIdx].end,
         text: String(seg.o ?? seg.original ?? ""),
         translation: String(seg.t ?? seg.translation ?? ""),
+        _si: s,
+        _ei: e,
       });
     }
     return result.length ? result : null;
@@ -972,6 +1004,8 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     customBody,
     events,
     tone,
+    prevContext,
+    nextContext,
     docInfo: externalDocInfo,
   } = args;
 
@@ -1036,7 +1070,13 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
-      ? JSON.stringify(events)
+      ? buildSubtitleUserPrompt({
+          formattedEvents: usesIndexSubtitleInput(subtitlePrompt)
+            ? formatIndexSubtitleEvents(events)
+            : events,
+          prevContext,
+          nextContext,
+        })
       : genUserPrompt({
           nobatchUserPrompt,
           useBatchFetch,
@@ -1534,6 +1574,8 @@ export const handleSubtitle = async ({
   to,
   apiSetting,
   docInfo,
+  prevContext = "",
+  nextContext = "",
 }) => {
   const { apiType, fetchInterval, fetchLimit, httpTimeout } = apiSetting;
 
@@ -1543,6 +1585,8 @@ export const handleSubtitle = async ({
     from,
     to,
     docInfo,
+    prevContext,
+    nextContext,
   });
 
   const res = await fetchData(input, init, {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -395,7 +395,13 @@ const parseSTRes = (raw, events = null) => {
   return [];
 };
 
-const siliconflowEffortMap = { max: 32768, high: 16384, medium: 8192, low: 4096, minimal: 2048 };
+const siliconflowEffortMap = {
+  max: 32768,
+  high: 16384,
+  medium: 8192,
+  low: 4096,
+  minimal: 2048,
+};
 
 const injectThinking = (body, { apiType, thinkingMode, thinkingEffort }) => {
   if (thinkingMode === "auto") return;
@@ -407,7 +413,9 @@ const injectThinking = (body, { apiType, thinkingMode, thinkingEffort }) => {
 
   switch (param.type) {
     case "deepseek":
-      body.thinking = { type: thinkingMode === "enabled" ? "enabled" : "disabled" };
+      body.thinking = {
+        type: thinkingMode === "enabled" ? "enabled" : "disabled",
+      };
       if (thinkingMode === "enabled" && hasEffort) {
         body.reasoning_effort = thinkingEffort;
       }
@@ -648,23 +656,7 @@ const genGemini = ({
 
   const userMsg = { role: "user", parts: [{ text: userPrompt }] };
 
-  const modelLower = String(model || "").toLowerCase();
-  const geminiMajor = Number(modelLower.match(/gemini[- ]?(\d+)/)?.[1]);
-  const isPro = modelLower.includes("pro");
-  const thinkingConfig = isPro
-    ? null
-    : Number.isFinite(geminiMajor) && geminiMajor >= 3
-      ? { thinkingLevel: "MINIMAL" }
-      : modelLower.includes("gemini-2.5")
-        ? { thinkingBudget: 0 }
-        : null;
-
   const body = {
-    // system_instruction: {
-    //   parts: {
-    //     text: systemPrompt,
-    //   },
-    // },
     contents: [
       {
         role: "model",
@@ -676,15 +668,14 @@ const genGemini = ({
     generationConfig: {
       maxOutputTokens: maxTokens,
       temperature,
-      ...(thinkingConfig ? { thinkingConfig } : {}),
     },
   };
 
-  if (thinkingMode && thinkingMode !== "auto") {
-    if (thinkingMode === "disabled") {
-      body.thinkingConfig = { thinkingLevel: "minimal" };
-    } else if (thinkingEffort && thinkingEffort !== "_default") {
-      body.thinkingConfig = { thinkingLevel: thinkingEffort };
+  if (thinkingMode === "disabled") {
+    body.generationConfig.thinkingConfig = { thinkingBudget: 0 };
+  } else if (thinkingMode && thinkingMode !== "auto") {
+    if (thinkingEffort && thinkingEffort !== "_default") {
+      body.generationConfig.thinkingConfig = { thinkingLevel: thinkingEffort };
     }
   }
 
@@ -836,7 +827,11 @@ const genOpenRouter = ({
     stream: useStream,
   };
 
-  injectThinking(body, { apiType: OPT_TRANS_OPENROUTER, thinkingMode, thinkingEffort });
+  injectThinking(body, {
+    apiType: OPT_TRANS_OPENROUTER,
+    thinkingMode,
+    thinkingEffort,
+  });
 
   const headers = {
     "Content-type": "application/json",
@@ -877,7 +872,11 @@ const genOllama = ({
     max_tokens: maxTokens,
   };
 
-  injectThinking(body, { apiType: OPT_TRANS_OLLAMA, thinkingMode, thinkingEffort });
+  injectThinking(body, {
+    apiType: OPT_TRANS_OLLAMA,
+    thinkingMode,
+    thinkingEffort,
+  });
   body.stream = useStream;
 
   const headers = {
@@ -1427,7 +1426,16 @@ async function* handleTranslateStreamInternal(
   texts,
   input,
   init,
-  { apiType, history, userMsg, usePool, fetchInterval, fetchLimit, httpTimeout, streamRenderMode }
+  {
+    apiType,
+    history,
+    userMsg,
+    usePool,
+    fetchInterval,
+    fetchLimit,
+    httpTimeout,
+    streamRenderMode,
+  }
 ) {
   const results = new Array(texts.length).fill(null);
   let fullContent = "";
@@ -1606,14 +1614,41 @@ export const handleSubtitle = async ({
     case OPT_TRANS_GEMINI_2:
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
-      return parseSTRes(res?.choices?.[0]?.message?.content ?? "");
-    case OPT_TRANS_GEMINI:
-      return parseSTRes(
-        geminiText(res?.candidates?.[0]?.content?.parts),
-        events
-      );
+      return parseSTRes(res?.choices?.[0]?.message?.content ?? "", events);
+    case OPT_TRANS_GEMINI: {
+      const candidate = res?.candidates?.[0];
+      const { thinkingMode } = apiSetting;
+      const thinkingWasOn =
+        thinkingMode && thinkingMode !== "auto" && thinkingMode !== "disabled";
+      if (candidate?.finishReason === "MAX_TOKENS" && thinkingWasOn) {
+        const [retryInput, retryInit] = await genTransReq({
+          ...apiSetting,
+          thinkingMode: "disabled",
+          events,
+          from,
+          to,
+          docInfo,
+          prevContext,
+          nextContext,
+        });
+        const retryRes = await fetchData(retryInput, retryInit, {
+          useCache: false,
+          usePool: true,
+          fetchInterval,
+          fetchLimit,
+          httpTimeout,
+        });
+        if (retryRes?.candidates?.[0]?.content?.parts) {
+          return parseSTRes(
+            geminiText(retryRes.candidates[0].content.parts),
+            events
+          );
+        }
+      }
+      return parseSTRes(geminiText(candidate?.content?.parts), events);
+    }
     case OPT_TRANS_CLAUDE:
-      return parseSTRes(res?.content?.[0]?.text ?? "");
+      return parseSTRes(res?.content?.[0]?.text ?? "", events);
     case OPT_TRANS_CUSTOMIZE:
       return res;
     default:

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -271,14 +271,87 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
-const parseSTRes = (raw) => {
+const getPauseLevel = (gapMs) => {
+  if (!Number.isFinite(gapMs) || gapMs <= 300) return 0;
+  if (gapMs <= 600) return 1;
+  if (gapMs <= 1200) return 2;
+  return 3;
+};
+
+const formatIndexSubtitleEvents = (events) =>
+  events.map((e, i) => {
+    const item = { id: i, text: e.text };
+    if (i > 0) {
+      const p = getPauseLevel(e.start - events[i - 1].end);
+      if (p) item.p = p;
+    }
+    return item;
+  });
+
+const usesIndexSubtitleInput = (prompt = "") => {
+  if (/\{\s*["']?s["']?\s*:/.test(prompt) && /\bid\b/i.test(prompt))
+    return true;
+  if (/WEBVTT|MM:SS\.mmm|-->/i.test(prompt)) return false;
+  return false;
+};
+
+const geminiText = (parts) =>
+  Array.isArray(parts)
+    ? parts
+        .filter((p) => !p.thought && p.text)
+        .map((p) => p.text)
+        .join("")
+    : "";
+
+const parseIndexSubtitleRes = (raw, events) => {
+  const buildResult = (data) => {
+    if (!Array.isArray(data) || !data.length) return null;
+    const result = [];
+    for (const seg of data) {
+      const s = Number(seg.s ?? seg.start_id);
+      const e = Number(seg.e ?? seg.end_id);
+      if (!Number.isInteger(s) || !Number.isInteger(e)) continue;
+      const startIdx = Math.max(0, Math.min(s, events.length - 1));
+      const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
+      result.push({
+        start: events[startIdx].start,
+        end: events[endIdx].end,
+        text: String(seg.o ?? seg.original ?? ""),
+        translation: String(seg.t ?? seg.translation ?? ""),
+      });
+    }
+    return result.length ? result : null;
+  };
+
+  try {
+    return buildResult(JSON.parse(raw));
+  } catch {
+    try {
+      const str = String(raw ?? "");
+      const last = Math.max(
+        str.lastIndexOf("},"),
+        str.lastIndexOf("}\n"),
+        str.lastIndexOf("}\r")
+      );
+      if (last < 0) return null;
+      return buildResult(JSON.parse(str.slice(0, last + 1) + "]"));
+    } catch {
+      return null;
+    }
+  }
+};
+
+const parseSTRes = (raw, events = null) => {
   if (!raw) {
     return [];
   }
 
+  if (events?.length) {
+    const indexed = parseIndexSubtitleRes(raw, events);
+    if (indexed) return indexed;
+  }
+
   try {
-    // const jsonString = extractJson(raw);
-    // const data = JSON.parse(jsonString);
     const data = parseBilingualVtt(raw);
     if (Array.isArray(data)) {
       return data;
@@ -542,6 +615,18 @@ const genGemini = ({
   }
 
   const userMsg = { role: "user", parts: [{ text: userPrompt }] };
+
+  const modelLower = String(model || "").toLowerCase();
+  const geminiMajor = Number(modelLower.match(/gemini[- ]?(\d+)/)?.[1]);
+  const isPro = modelLower.includes("pro");
+  const thinkingConfig = isPro
+    ? null
+    : Number.isFinite(geminiMajor) && geminiMajor >= 3
+      ? { thinkingLevel: "MINIMAL" }
+      : modelLower.includes("gemini-2.5")
+        ? { thinkingBudget: 0 }
+        : null;
+
   const body = {
     // system_instruction: {
     //   parts: {
@@ -559,8 +644,7 @@ const genGemini = ({
     generationConfig: {
       maxOutputTokens: maxTokens,
       temperature,
-      // topP: 0.8,
-      // topK: 10,
+      ...(thinkingConfig ? { thinkingConfig } : {}),
     },
   };
 
@@ -976,6 +1060,10 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     method = "POST",
   } = genReqFuncs[apiType](args);
 
+  if (events && apiType === OPT_TRANS_GEMINI && body?.generationConfig) {
+    body.generationConfig.responseMimeType = "application/json";
+  }
+
   // 合并用户自定义headers和body
   if (customHeader?.trim()) {
     Object.assign(headers, parseJsonObj(customHeader));
@@ -1141,7 +1229,7 @@ export const parseTransRes = async (
       if (history && userMsg && modelMsg) {
         history.add(userMsg, modelMsg);
       }
-      return parseAIRes(modelMsg?.parts?.[0]?.text ?? "", useBatchFetch);
+      return parseAIRes(geminiText(modelMsg?.parts), useBatchFetch);
     case OPT_TRANS_CLAUDE:
       modelMsg = { role: res?.role, content: res?.content?.text };
       if (history && userMsg && modelMsg) {
@@ -1476,7 +1564,10 @@ export const handleSubtitle = async ({
     case OPT_TRANS_OLLAMA:
       return parseSTRes(res?.choices?.[0]?.message?.content ?? "");
     case OPT_TRANS_GEMINI:
-      return parseSTRes(res?.candidates?.[0]?.content?.parts?.[0]?.text ?? "");
+      return parseSTRes(
+        geminiText(res?.candidates?.[0]?.content?.parts),
+        events
+      );
     case OPT_TRANS_CLAUDE:
       return parseSTRes(res?.content?.[0]?.text ?? "");
     case OPT_TRANS_CUSTOMIZE:
@@ -1548,14 +1639,14 @@ export const handleSummarize = async ({
     case OPT_TRANS_OLLAMA:
       return res?.choices?.[0]?.message?.content?.trim() || "";
     case OPT_TRANS_GEMINI:
-      return res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "";
+      return geminiText(res?.candidates?.[0]?.content?.parts).trim() || "";
     case OPT_TRANS_CLAUDE:
       return res?.content?.[0]?.text?.trim() || "";
     case OPT_TRANS_CUSTOMIZE:
       if (typeof res === "string") return res.trim();
       return (
         res?.choices?.[0]?.message?.content?.trim() ||
-        res?.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ||
+        geminiText(res?.candidates?.[0]?.content?.parts).trim() ||
         res?.content?.[0]?.text?.trim() ||
         ""
       );

--- a/src/injectors/xmlhttp.js
+++ b/src/injectors/xmlhttp.js
@@ -1,21 +1,41 @@
 export const XMLHttpRequestInjector = () => {
   try {
+    const emitTimedtext = (url, response) => {
+      if (url && typeof response === "string") {
+        window.postMessage(
+          { type: "KISS_XHR_DATA_YOUTUBE", url, response },
+          window.location.origin
+        );
+      }
+    };
+
     const originalOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (...args) {
       const url = args[1];
       if (typeof url === "string" && url.includes("timedtext")) {
         this.addEventListener("load", function () {
-          window.postMessage(
-            {
-              type: "KISS_XHR_DATA_YOUTUBE",
-              url: this.responseURL,
-              response: this.responseText,
-            },
-            window.location.origin
-          );
+          emitTimedtext(this.responseURL, this.responseText);
         });
       }
       return originalOpen.apply(this, args);
+    };
+
+    const originalFetch = window.fetch;
+    window.fetch = async function (...args) {
+      const response = await originalFetch.apply(this, args);
+      try {
+        const input = args[0];
+        const inputUrl = typeof input === "string" ? input : input?.url || "";
+        const responseUrl = response?.url || inputUrl;
+        if (responseUrl.includes("timedtext")) {
+          response
+            .clone()
+            .text()
+            .then((text) => emitTimedtext(responseUrl, text))
+            .catch(() => {});
+        }
+      } catch (_) {}
+      return response;
     };
   } catch (err) {
     console.log("XMLHttpRequestInjector", err);

--- a/src/injectors/xmlhttp.js
+++ b/src/injectors/xmlhttp.js
@@ -1,41 +1,21 @@
 export const XMLHttpRequestInjector = () => {
   try {
-    const emitTimedtext = (url, response) => {
-      if (url && typeof response === "string") {
-        window.postMessage(
-          { type: "KISS_XHR_DATA_YOUTUBE", url, response },
-          window.location.origin
-        );
-      }
-    };
-
     const originalOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (...args) {
       const url = args[1];
       if (typeof url === "string" && url.includes("timedtext")) {
         this.addEventListener("load", function () {
-          emitTimedtext(this.responseURL, this.responseText);
+          window.postMessage(
+            {
+              type: "KISS_XHR_DATA_YOUTUBE",
+              url: this.responseURL,
+              response: this.responseText,
+            },
+            window.location.origin
+          );
         });
       }
       return originalOpen.apply(this, args);
-    };
-
-    const originalFetch = window.fetch;
-    window.fetch = async function (...args) {
-      const response = await originalFetch.apply(this, args);
-      try {
-        const input = args[0];
-        const inputUrl = typeof input === "string" ? input : input?.url || "";
-        const responseUrl = response?.url || inputUrl;
-        if (responseUrl.includes("timedtext")) {
-          response
-            .clone()
-            .text()
-            .then((text) => emitTimedtext(responseUrl, text))
-            .catch(() => {});
-        }
-      } catch (_) {}
-      return response;
     };
   } catch (err) {
     console.log("XMLHttpRequestInjector", err);

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -104,8 +104,13 @@ export function getStreamDelta(json, apiType) {
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
       return json.choices?.[0]?.delta?.content || "";
-    case OPT_TRANS_GEMINI:
-      return json.candidates?.[0]?.content?.parts?.[0]?.text || "";
+    case OPT_TRANS_GEMINI: {
+      const parts = json.candidates?.[0]?.content?.parts;
+      return (
+        (Array.isArray(parts) ? parts.find((p) => !p.thought) : undefined)
+          ?.text || ""
+      );
+    }
     case OPT_TRANS_CLAUDE:
       if (json.type === "content_block_delta") {
         return json.delta?.text || "";

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -128,6 +128,8 @@ export class BilingualSubtitleManager {
   #tooltipEl = null;
   #hoverTimeout = null; // 用于延迟显示/隐藏tooltip
   #seekSyncRafId = null;
+  #translationSessionId = 0;
+  #abortController = null;
   #wasPlayingBeforeHover = false; //记录hover单词前视频是否处于播放状态
   #hoverTarget = null;
 
@@ -141,6 +143,7 @@ export class BilingualSubtitleManager {
     this.#setting = setting;
     this.#videoEl = videoEl;
     this.#formattedSubtitles = formattedSubtitles;
+    this.#abortController = new AbortController();
 
     this.onTimeUpdate = this.onTimeUpdate.bind(this);
     this.onSeeking = this.onSeeking.bind(this);
@@ -183,6 +186,10 @@ export class BilingualSubtitleManager {
    */
   destroy() {
     logger.info("Bilingual Subtitle Manager: Destroying...");
+    this.#translationSessionId += 1;
+    this.#abortController?.abort();
+    this.#abortController = null;
+    this.onSubtitleUpdate = null;
     this.#removeEventListeners();
     this.#throttledTriggerTranslations?.cancel();
     if (this.#seekSyncRafId !== null) {
@@ -864,6 +871,10 @@ export class BilingualSubtitleManager {
    * @param {object} subtitle - 需要翻译的字幕对象。
    */
   async #translateAndStore(subtitle) {
+    const sessionId = this.#translationSessionId;
+    const signal = this.#abortController?.signal;
+    if (signal?.aborted) return;
+
     subtitle.isTranslating = true;
     try {
       const { fromLang, toLang, apiSetting, docInfo } = this.#setting;
@@ -873,12 +884,17 @@ export class BilingualSubtitleManager {
         toLang,
         apiSetting,
         docInfo,
+        signal,
       });
+      if (sessionId !== this.#translationSessionId) return;
       subtitle.translation = decodeHTMLEntities(trText);
     } catch (error) {
+      if (sessionId !== this.#translationSessionId) return;
+      if (error?.name === "AbortError") return;
       logger.info("Translation failed for:", subtitle.text, error);
       subtitle.translation = "[Translation failed]";
     } finally {
+      if (sessionId !== this.#translationSessionId) return;
       subtitle.isTranslating = false;
 
       const currentSubtitleIndexNow = this.#findSubtitleIndexForTime(

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -220,50 +220,6 @@ export class BilingualSubtitleManager {
   }
 
   /**
-   * 监听播放器控制条的显示状态，隐藏时将字幕下移
-   */
-  #observePlayerControlBar() {
-    const player = this.#videoEl.closest(".html5-video-player");
-    if (!player) return;
-
-    const controlBar = player.querySelector(".ytp-left-controls");
-    if (!controlBar) return;
-    const controlBarHeight = parseFloat(getComputedStyle(controlBar).height);
-
-    const getCurrentPaperElBottom = () => {
-      const bottom = getComputedStyle(this.#paperEl).bottom;
-      return parseFloat(bottom) || 0;
-    };
-
-    // 默认视字幕初始化完成时控制条为显示状态
-    let lastControlBarHiddenState = false;
-
-    const updatePaperElBottom = () => {
-      const isHidden = player.classList.contains("ytp-autohide");
-      if (isHidden === lastControlBarHiddenState) return;
-      lastControlBarHiddenState = isHidden;
-
-      const currentPaperElBottom = getCurrentPaperElBottom();
-      if (currentPaperElBottom === 0) return;
-
-      if (isHidden) {
-        this.#paperEl.style.bottom = `${currentPaperElBottom - controlBarHeight}px`;
-      } else {
-        this.#paperEl.style.bottom = `${currentPaperElBottom + controlBarHeight}px`;
-      }
-    };
-
-    const observer = new MutationObserver(() => {
-      if (!this.#captionDragged) updatePaperElBottom();
-    });
-
-    observer.observe(player, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-  }
-
-  /**
    * 创建并配置用于显示字幕的 DOM 元素。
    */
   #createCaptionWindow() {
@@ -346,7 +302,6 @@ export class BilingualSubtitleManager {
         }
       });
     }
-    this.#observePlayerControlBar();
   }
 
   // 处理单词悬停事件
@@ -788,6 +743,7 @@ export class BilingualSubtitleManager {
       // 创建带有单词标记的字幕内容
       const p1 = document.createElement("p");
       p1.style.cssText = this.#setting.originStyle;
+      p1.style.margin = "0";
 
       const isHoverLookupEnabled = this.#isHoverLookupEnabled();
 
@@ -801,6 +757,7 @@ export class BilingualSubtitleManager {
 
       const p2 = document.createElement("p");
       p2.style.cssText = this.#setting.translationStyle;
+      p2.style.margin = "0";
       if (isHoverLookupEnabled) {
         p2.innerHTML = trustedTypesHelper.createHTML(
           this.#wrapWordsWithSpans(subtitle.translation || "...")

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -20,6 +20,7 @@ import { buildBilingualVtt } from "./vtt.js";
 import { getDocInfo } from "../libs/docInfo.js";
 import { intelligentSentenceBreak } from "./sentenceBreaker.js";
 import { isSubtitleModeEnabled } from "./modes.js";
+import { clearMsgHistory } from "../apis/history.js";
 
 const VIDEO_SELECT = "#container video";
 const CONTORLS_SELECT = ".ytp-right-controls";
@@ -40,6 +41,8 @@ class YouTubeCaptionProvider {
   #interceptedCaptionKind = null;
 
   #processingId = null;
+  #processingVersion = 0;
+  #activeTrackKey = null;
 
   #managerInstance = null;
   #toggleButton = null;
@@ -89,6 +92,7 @@ class YouTubeCaptionProvider {
       logger.debug("Youtube Provider: yt-navigate-finish", this.#videoId);
 
       this.#destroyManager();
+      clearMsgHistory(this.#setting.apiSlug);
 
       this.#subtitles = [];
       this.#events = [];
@@ -98,6 +102,9 @@ class YouTubeCaptionProvider {
       this.#docInfo = {};
       this.#fullDescription = "";
       this.#interceptedCaptionKind = null;
+      this.#processingId = null;
+      this.#processingVersion += 1;
+      this.#activeTrackKey = null;
       this.#updateMenuProps(); // 更新菜单 props
     });
 
@@ -333,6 +340,7 @@ class YouTubeCaptionProvider {
   }
 
   #isSameLang(lang1, lang2) {
+    if (!lang1 || !lang2) return false;
     return lang1.slice(0, 2) === lang2.slice(0, 2);
   }
 
@@ -340,6 +348,21 @@ class YouTubeCaptionProvider {
     if (!track) return false;
     const name = track.name?.simpleText || track.name?.runs?.[0]?.text || "";
     return /chat/i.test(name);
+  }
+
+  #buildTrackKey(potUrl) {
+    const p = potUrl.searchParams;
+    return [
+      p.get("v") || "",
+      p.get("lang") || "",
+      p.get("kind") || "",
+      p.get("name") || "",
+      p.get("tlang") || "",
+    ].join("|");
+  }
+
+  #isStaleProcessing(version) {
+    return version !== this.#processingVersion;
   }
 
   // todo: 优化逻辑
@@ -570,26 +593,38 @@ class YouTubeCaptionProvider {
     }
 
     const lang = potUrl.searchParams.get("lang");
-    const interceptedKind = potUrl.searchParams.get("kind") || null;
-    const interceptedName = potUrl.searchParams.get("name");
-    const fromLang = this.#getFromLang(lang);
-    if (this.#flatEvents.length) {
-      if (
-        this.#isSameLang(lang, this.#fromLang) &&
-        interceptedKind === this.#interceptedCaptionKind
-      ) {
-        logger.debug("Youtube Provider: video was processed:", videoId);
-        return;
-      }
-      this.#destroyManager();
-    }
-
-    if (videoId === this.#processingId) {
-      logger.debug("Youtube Provider: video is processing:", videoId);
+    if (!lang) {
+      logger.debug("Youtube Provider: timedtext lang not found:", url);
       return;
     }
 
-    this.#processingId = videoId;
+    const interceptedKind = potUrl.searchParams.get("kind") || null;
+    const trackKey = this.#buildTrackKey(potUrl);
+    const fromLang = this.#getFromLang(lang);
+
+    if (this.#flatEvents.length && trackKey === this.#activeTrackKey) {
+      logger.debug("Youtube Provider: track was processed:", trackKey);
+      return;
+    }
+
+    if (this.#processingId === trackKey) {
+      logger.debug("Youtube Provider: track is processing:", trackKey);
+      return;
+    }
+
+    const processingVersion = (this.#processingVersion += 1);
+    this.#processingId = trackKey;
+
+    if (this.#flatEvents.length) {
+      this.#destroyManager();
+      clearMsgHistory(this.#setting.apiSlug);
+      this.#subtitles = [];
+      this.#events = [];
+      this.#flatEvents = [];
+      this.#progressed = 0;
+      this.#activeTrackKey = null;
+      this.#interceptedCaptionKind = null;
+    }
 
     try {
       this.#showNotification(this.#i18n("starting_to_process_subtitle"));
@@ -597,6 +632,8 @@ class YouTubeCaptionProvider {
       const { toLang } = this.#setting;
       const { captionTracks, fullDescription } =
         await this.#getCaptionTracks(videoId);
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       this.#fullDescription = fullDescription || "";
       const captionTrack = this.#findCaptionTrack(
         captionTracks,
@@ -614,6 +651,8 @@ class YouTubeCaptionProvider {
         potUrl,
         responseText
       );
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       if (!events?.length) {
         logger.debug("Youtube Provider: events not got:", videoId);
         return;
@@ -633,35 +672,47 @@ class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: flatEvents not got:", videoId);
         return;
       }
+      if (this.#isStaleProcessing(processingVersion)) return;
 
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
-      this.#docInfo = getDocInfo();
       this.#interceptedCaptionKind = interceptedKind;
-      await this.#enrichDocInfoWithAI(flatEvents);
+      this.#activeTrackKey = trackKey;
+      this.#docInfo = getDocInfo();
+      await this.#enrichDocInfoWithAI(flatEvents, processingVersion);
+      if (this.#isStaleProcessing(processingVersion)) return;
 
       this.#processEvents({
         videoId,
         flatEvents,
         fromLang,
+        processingVersion,
       });
     } catch (error) {
       logger.warn("Youtube Provider: handle subtitle", error);
       this.#showNotification(this.#i18n("subtitle_load_failed"));
     } finally {
-      this.#processingId = null;
+      if (
+        !this.#isStaleProcessing(processingVersion) &&
+        this.#processingId === trackKey
+      ) {
+        this.#processingId = null;
+      }
     }
   }
 
-  async #processEvents({ videoId, flatEvents, fromLang }) {
+  async #processEvents({ videoId, flatEvents, fromLang, processingVersion }) {
     try {
       const [subtitles, progressed] = await this.#eventsToSubtitles({
         videoId,
         events: this.#events,
         flatEvents,
         fromLang,
+        processingVersion,
       });
+      if (this.#isStaleProcessing(processingVersion)) return;
+
       if (!subtitles?.length) {
         logger.debug(
           "Youtube Provider: events to subtitles got empty",
@@ -702,15 +753,18 @@ class YouTubeCaptionProvider {
 
     this.#showNotification(this.#i18n("starting_reprocess_events"));
 
+    const processingVersion = (this.#processingVersion += 1);
     this.#destroyManager();
+    clearMsgHistory(this.#setting.apiSlug);
 
-    this.#processEvents({ videoId, flatEvents, fromLang });
+    this.#processEvents({ videoId, flatEvents, fromLang, processingVersion });
   }
 
-  async #enrichDocInfoWithAI(flatEvents) {
+  async #enrichDocInfoWithAI(flatEvents, processingVersion) {
     const { aiContextSlug, transApis } = this.#setting;
 
     if (!aiContextSlug || aiContextSlug === "-") return;
+    if (this.#isStaleProcessing(processingVersion)) return;
 
     const contextApiSetting = transApis?.find(
       (api) => api.apiSlug === aiContextSlug
@@ -741,7 +795,11 @@ class YouTubeCaptionProvider {
         apiSetting: contextApiSetting,
       });
 
-      if (summary && videoId === this.#videoId) {
+      if (
+        summary &&
+        videoId === this.#videoId &&
+        !this.#isStaleProcessing(processingVersion)
+      ) {
         docInfo.summary = summary;
       }
     } catch (err) {
@@ -757,19 +815,28 @@ class YouTubeCaptionProvider {
     const flatEvents = this.#flatEvents;
     if (!videoId || !flatEvents.length) return;
 
+    const processingVersion = (this.#processingVersion += 1);
     this.#destroyManager();
+    clearMsgHistory(this.#setting.apiSlug);
     this.#docInfo = getDocInfo();
-    await this.#enrichDocInfoWithAI(flatEvents);
-    this.#processEvents({ videoId, flatEvents, fromLang: this.#fromLang });
+    await this.#enrichDocInfoWithAI(flatEvents, processingVersion);
+    if (this.#isStaleProcessing(processingVersion)) return;
+    this.#processEvents({
+      videoId,
+      flatEvents,
+      fromLang: this.#fromLang,
+      processingVersion,
+    });
   }
 
-  async #eventsToSubtitles({ videoId, events, flatEvents, fromLang }) {
+  async #eventsToSubtitles({ videoId, events, flatEvents, fromLang, processingVersion }) {
     const { segSlug, transApis, chunkLength, toLang } = this.#setting;
 
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
     const isAutoCaption = this.#interceptedCaptionKind === "asr";
 
     if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
+      if (this.#isStaleProcessing(processingVersion)) return [[], 0];
       logger.info("Youtube Provider: Starting AI segmentation...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
 
@@ -788,6 +855,7 @@ class YouTubeCaptionProvider {
         toLang,
         segApiSetting,
       });
+      if (this.#isStaleProcessing(processingVersion)) return [[], 0];
 
       if (!firstBatchSubtitles?.length) {
         logger.info("Youtube Provider: AI failed, falling back to built-in");
@@ -803,6 +871,7 @@ class YouTubeCaptionProvider {
           fromLang,
           toLang,
           segApiSetting,
+          processingVersion,
         });
 
         const processed = Math.floor(100 / eventChunks.length);
@@ -929,6 +998,7 @@ class YouTubeCaptionProvider {
 
     logger.info("Youtube Provider: Destroying manager...");
 
+    this.#managerInstance.onSubtitleUpdate = null;
     this.#managerInstance.destroy();
     this.#managerInstance = null;
 
@@ -1295,10 +1365,16 @@ class YouTubeCaptionProvider {
     fromLang,
     toLang,
     segApiSetting,
+    processingVersion,
   }) {
     logger.info(`Youtube Provider: Starting for ${chunks.length} chunks.`);
 
     for (let i = 0; i < chunks.length; i++) {
+      if (this.#isStaleProcessing(processingVersion)) {
+        logger.info("Youtube Provider: Skip stale chunk processing.");
+        break;
+      }
+
       const chunkEvents = chunks[i];
       const chunkNum = i + 2;
       logger.debug(
@@ -1315,6 +1391,7 @@ class YouTubeCaptionProvider {
           toLang,
           segApiSetting,
         });
+        if (this.#isStaleProcessing(processingVersion)) break;
 
         if (aiSubtitles?.length > 0) {
           subtitlesForThisChunk = aiSubtitles;
@@ -1328,9 +1405,12 @@ class YouTubeCaptionProvider {
         subtitlesForThisChunk = this.#formatSubtitles(chunkEvents, fromLang);
       }
 
-      if (videoId !== this.#videoId) {
+      if (
+        videoId !== this.#videoId ||
+        this.#isStaleProcessing(processingVersion)
+      ) {
         logger.info(
-          "Youtube Provider: videoId changed!!",
+          "Youtube Provider: videoId changed or track replaced!",
           videoId,
           this.#videoId
         );

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -495,7 +495,31 @@ class YouTubeCaptionProvider {
     }
   }
 
-  async #aiSegment({ videoId, fromLang, toLang, chunkEvents, segApiSetting }) {
+  #getChunkContext(chunks, chunkIndex, side, maxEvents = 3, maxChars = 240) {
+    const NON_SPEECH_RE = /^\[.+\]$/i;
+    const adj =
+      side === "prev" ? chunks[chunkIndex - 1] : chunks[chunkIndex + 1];
+    if (!adj?.length) return "";
+    const picked =
+      side === "prev" ? adj.slice(-maxEvents) : adj.slice(0, maxEvents);
+    return picked
+      .map((e) => String(e?.text ?? "").trim())
+      .filter((t) => t && !NON_SPEECH_RE.test(t))
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, maxChars);
+  }
+
+  async #aiSegment({
+    videoId,
+    fromLang,
+    toLang,
+    chunkEvents,
+    segApiSetting,
+    prevContext = "",
+    nextContext = "",
+  }) {
     const NON_SPEECH_RE = /^\[.+\]$/i;
     const speechEvents = [];
     const nonSpeechEvents = [];
@@ -535,26 +559,67 @@ class YouTubeCaptionProvider {
         events: speechEvents,
         apiSetting: segApiSetting,
         docInfo: this.#docInfo,
+        prevContext,
+        nextContext,
       });
       logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
-      if (Array.isArray(subtitles)) {
+      if (Array.isArray(subtitles) && subtitles.length) {
         // 断句服务和翻译服务不同时，清除断句的翻译，由翻译服务重新翻译
-        const speechSubtitles =
-          segApiSetting.apiSlug !== this.#setting.apiSlug
-            ? subtitles.map((sub) => ({ ...sub, translation: "" }))
-            : subtitles;
+        let result = subtitles;
+        if (segApiSetting.apiSlug !== this.#setting.apiSlug) {
+          result = subtitles.map((sub) => ({ ...sub, translation: "" }));
+        }
+
+        // 截断重试：检测 AI 是否覆盖了全部 speechEvents
+        const maxEi = Math.max(...result.map((s) => s._ei ?? -1));
+        if (maxEi >= 0 && maxEi < speechEvents.length - 1) {
+          const tailEvents = speechEvents.slice(maxEi + 1);
+          // 仅当尾部不超过原始的 50% 时重试（否则视为整体失败）
+          if (tailEvents.length <= speechEvents.length * 0.5) {
+            try {
+              const tailSign = `${tailEvents[0].start} --> ${tailEvents[tailEvents.length - 1].end}`;
+              const lastResultText = result[result.length - 1]?.text || "";
+              const tailSubs = await apiSubtitle({
+                videoId,
+                chunkSign: tailSign,
+                fromLang,
+                toLang,
+                events: tailEvents,
+                apiSetting: segApiSetting,
+                docInfo: this.#docInfo,
+                prevContext: [prevContext, lastResultText]
+                  .filter(Boolean)
+                  .join(" "),
+                nextContext,
+              });
+              if (tailSubs?.length) {
+                result = [...result, ...tailSubs];
+              } else {
+                result = [
+                  ...result,
+                  ...this.#formatSubtitles(tailEvents, fromLang),
+                ];
+              }
+            } catch {
+              result = [
+                ...result,
+                ...this.#formatSubtitles(tailEvents, fromLang),
+              ];
+            }
+          }
+        }
 
         // 仅保留落在语音字幕间隙中的非语音条目，丢弃与语音重叠的
         const gapCues = nonSpeechEvents
           .filter(
             (ns) =>
-              !speechSubtitles.some(
+              !result.some(
                 (sub) => ns.start < sub.end && ns.end > sub.start
               )
           )
           .map(toStandaloneSub);
 
-        return [...speechSubtitles, ...gapCues].sort(
+        return [...result, ...gapCues].sort(
           (a, b) => a.start - b.start
         );
       }
@@ -854,6 +919,8 @@ class YouTubeCaptionProvider {
         fromLang,
         toLang,
         segApiSetting,
+        prevContext: "",
+        nextContext: this.#getChunkContext(eventChunks, 0, "next"),
       });
       if (this.#isStaleProcessing(processingVersion)) return [[], 0];
 
@@ -864,9 +931,9 @@ class YouTubeCaptionProvider {
 
       logger.info("Youtube Provider: Sentence break mode: AI");
       if (eventChunks.length > 1) {
-        const remainingChunks = eventChunks.slice(1);
         this.#processRemainingChunksAsync({
-          chunks: remainingChunks,
+          chunks: eventChunks,
+          startIndex: 1,
           videoId,
           fromLang,
           toLang,
@@ -1361,24 +1428,27 @@ class YouTubeCaptionProvider {
 
   async #processRemainingChunksAsync({
     chunks,
+    startIndex = 0,
     videoId,
     fromLang,
     toLang,
     segApiSetting,
     processingVersion,
   }) {
-    logger.info(`Youtube Provider: Starting for ${chunks.length} chunks.`);
+    logger.info(
+      `Youtube Provider: Starting async from chunk ${startIndex + 1}/${chunks.length}.`
+    );
 
-    for (let i = 0; i < chunks.length; i++) {
+    for (let i = startIndex; i < chunks.length; i++) {
       if (this.#isStaleProcessing(processingVersion)) {
         logger.info("Youtube Provider: Skip stale chunk processing.");
         break;
       }
 
       const chunkEvents = chunks[i];
-      const chunkNum = i + 2;
+      const chunkNum = i + 1;
       logger.debug(
-        `Youtube Provider: Processing subtitle chunk ${chunkNum}/${chunks.length + 1}: ${chunkEvents[0]?.start} --> ${chunkEvents[chunkEvents.length - 1]?.start}`
+        `Youtube Provider: Processing subtitle chunk ${chunkNum}/${chunks.length}: ${chunkEvents[0]?.start} --> ${chunkEvents[chunkEvents.length - 1]?.start}`
       );
 
       let subtitlesForThisChunk = [];
@@ -1390,6 +1460,8 @@ class YouTubeCaptionProvider {
           fromLang,
           toLang,
           segApiSetting,
+          prevContext: this.#getChunkContext(chunks, i, "prev"),
+          nextContext: this.#getChunkContext(chunks, i, "next"),
         });
         if (this.#isStaleProcessing(processingVersion)) break;
 
@@ -1418,7 +1490,7 @@ class YouTubeCaptionProvider {
       }
 
       if (subtitlesForThisChunk.length > 0) {
-        const progressed = Math.floor((chunkNum * 100) / (chunks.length + 1));
+        const progressed = Math.floor((chunkNum * 100) / chunks.length);
         this.#subtitles.push(...subtitlesForThisChunk);
         this.#subtitles.sort((a, b) => a.start - b.start);
         this.#progressed = progressed;


### PR DESCRIPTION
这个PR是 #542 拆分出来的最后一个PR

## 背景

用户在同一视频内切换字幕轨道（如自动字幕 → 手动字幕）时，旧的翻译任务不会终止，新旧翻译结果交叉写入。AI 断句的上下文历史也不会清理，可能影响新轨道的翻译质量。

Gemini 2.5/3.x 的思考模型默认启用 thinking，字幕请求的输出可能包含思考内容或被截断，解析失败后字幕全空。

AI 断句在长 chunk 末尾可能截断（AI 没有覆盖全部输入词），尾部字幕静默丢失。多 chunk 之间也缺少上下文衔接，边界处容易断句不自然。

双语字幕叠加层会随 YouTube 控制栏的显隐上下跳动，控制栏隐藏时译文可能溢出视频下方。

## 改动

### 1. 字幕轨道切换自动检测（ 4b638df ）

拦截 fetch API 补充 XHR，用 trackKey（v|lang|kind|name|tlang）识别轨道切换。processingVersion 递增使异步路径自动失效，AbortController 终止旧翻译，translationSessionId 防止过期结果写回，clearMsgHistory 清除AI 上下文历史。

### 2. Gemini 思考模型兼容（ 421dc52 ）

按模型族智能注入 thinkingConfig（Flash 用 MINIMAL，Pro 跳过，非思考模型不添加）。字幕请求启用 responseMimeType 确保输出为合法 JSON。parseIndexSubtitleRes 增加截断 JSON 容错，恢复部分结果。geminiText 过滤thought part。

### 3. AI 断句截断重试与上下文重叠（ c87b5b1 ）

parseIndexSubtitleRes 返回 `_si`/`_ei` 词 ID，`#aiSegment` 检测覆盖度不足时截出尾部重新请求，重试失败则规则分句兜底。多chunk 断句时注入相邻 chunk 的前后文本上下文。缓存键增加 segVer 版本位。

### 4. 字幕叠加层定位修复（ c936ce1 ）

删除控制栏显隐观察器（MutationObserver on ytp-autohide），字幕固定在 bottom:10% 不再跳动。重置 `<p>` 默认 margin 消除双语字幕额外高度溢出。

## 影响范围

* **轨道切换用户**：旧翻译自动终止，不再出现结果混写
* **Gemini 用户**：思考模型不再导致字幕全空
* **长视频用户**：尾部字幕不再静默丢失，chunk 边界断句更自然
* **所有字幕用户**：叠加层位置稳定，不随控制栏跳动
