### PR TITLE
refactor: split enhanceMode

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2598,6 +2598,13 @@ export const I18N = {
     ja: `字幕リストを表示`,
     ko: `자막 목록 표시`,
   },
+  subtitle_hover_lookup: {
+    zh: `悬停查词`,
+    en: `Hover Word Lookup`,
+    zh_TW: `懸停查詞`,
+    ja: `ホバー辞書検索`,
+    ko: `호버 단어 조회`,
+  },
   default_styles_example: {
     zh: `默认样式参考：`,
     en: `Default styles reference:`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -135,8 +135,8 @@ export const DEFAULT_SUBTITLE_SETTING = {
   windowStyle: SUBTITLE_WINDOW_STYLE, // 背景样式
   originStyle: SUBTITLE_ORIGIN_STYLE, // 原文样式
   translationStyle: SUBTITLE_TRANSLATION_STYLE, // 译文样式
-  enhanceMode: OPT_ENHANCE_MOBILE_OFF, // 增强功能：on/off/mobile_off
-  showList: true, // 是否显示滚动字幕
+  hoverLookupMode: OPT_ENHANCE_MOBILE_OFF, // 悬停查词：on/off/mobile_off
+  showList: OPT_ENHANCE_MOBILE_OFF, // 是否显示滚动字幕：on/off/mobile_off
   aiContextSlug: "-", // 增强智能上下文分析服务
 };
 

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -3,7 +3,7 @@ import { truncateWords, throttle } from "../libs/utils.js";
 import { apiTranslate } from "../apis/index.js";
 import { apiMicrosoftDict } from "../apis/index.js";
 import { trustedTypesHelper } from "../libs/trustedTypes.js";
-import { isMobile } from "../libs/mobile.js";
+import { isSubtitleModeEnabled } from "./modes.js";
 
 const decodeHTMLEntities = (str) => {
   if (!str || typeof str !== "string") return str;
@@ -162,14 +162,16 @@ export class BilingualSubtitleManager {
       (setting.throttleTrans ?? 30) * 1000
     );
 
-    // todo: 使用 @emotion/css
-    const enhanceMode = this.#setting.enhanceMode ?? "mobile_off";
-    const isEnhance =
-      enhanceMode === "on" || (enhanceMode === "mobile_off" && !isMobile);
-
-    if (isEnhance) {
+    if (this.#isHoverLookupEnabled()) {
       addWordHoverStyles();
     }
+  }
+
+  #isHoverLookupEnabled() {
+    return isSubtitleModeEnabled(
+      this.#setting.hoverLookupMode,
+      this.#setting.enhanceMode
+    );
   }
 
   /**
@@ -315,9 +317,7 @@ export class BilingualSubtitleManager {
     videoContainer.style.position = "relative";
     videoContainer.appendChild(container);
 
-    const enhanceMode = this.#setting.enhanceMode ?? "mobile_off";
-    const isEnhance =
-      enhanceMode === "on" || (enhanceMode === "mobile_off" && !isMobile);
+    const isHoverLookupEnabled = this.#isHoverLookupEnabled();
 
     this.#enableDragging(
       this.#paperEl,
@@ -326,7 +326,7 @@ export class BilingualSubtitleManager {
       () => (this.#captionDragged = true)
     );
 
-    if (isEnhance) {
+    if (isHoverLookupEnabled) {
       this.#captionWindowEl.addEventListener("pointerenter", (e) => {
         if (e.target === this.#captionWindowEl) {
           this.#wasPlayingBeforeHover = this.#videoEl && !this.#videoEl.paused;
@@ -793,11 +793,9 @@ export class BilingualSubtitleManager {
       const p1 = document.createElement("p");
       p1.style.cssText = this.#setting.originStyle;
 
-      const enhanceMode = this.#setting.enhanceMode ?? "mobile_off";
-      const isEnhance =
-        enhanceMode === "on" || (enhanceMode === "mobile_off" && !isMobile);
+      const isHoverLookupEnabled = this.#isHoverLookupEnabled();
 
-      if (isEnhance) {
+      if (isHoverLookupEnabled) {
         p1.innerHTML = trustedTypesHelper.createHTML(
           this.#wrapWordsWithSpans(subtitle.text)
         );
@@ -807,7 +805,7 @@ export class BilingualSubtitleManager {
 
       const p2 = document.createElement("p");
       p2.style.cssText = this.#setting.translationStyle;
-      if (isEnhance) {
+      if (isHoverLookupEnabled) {
         p2.innerHTML = trustedTypesHelper.createHTML(
           this.#wrapWordsWithSpans(subtitle.translation || "...")
         );
@@ -821,7 +819,7 @@ export class BilingualSubtitleManager {
         this.#captionWindowEl.replaceChildren(p2);
       }
 
-      if (isEnhance) {
+      if (isHoverLookupEnabled) {
         this.#attachSpanListeners();
       }
 

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -8,8 +8,6 @@ import {
   OPT_LANGS_TO_CODE,
   OPT_TRANS_MICROSOFT,
   OPT_LANGS_SPEC_DEFAULT,
-  OPT_ENHANCE_ON,
-  OPT_ENHANCE_MOBILE_OFF,
   API_SPE_TYPES,
 } from "../config";
 import { sleep, downloadBlobFile } from "../libs/utils.js";
@@ -19,8 +17,8 @@ import { newI18n } from "../config";
 import DomManager from "../libs/domManager.js";
 import { Menus } from "./Menus.js";
 import { buildBilingualVtt } from "./vtt.js";
-import { isMobile } from "../libs/mobile.js";
 import { getDocInfo } from "../libs/docInfo.js";
+import { isSubtitleModeEnabled } from "./modes.js";
 
 const VIDEO_SELECT = "#container video";
 const CONTORLS_SELECT = ".ytp-right-controls";
@@ -337,8 +335,7 @@ class YouTubeCaptionProvider {
 
   #isChatCaptionTrack(track) {
     if (!track) return false;
-    const name =
-      track.name?.simpleText || track.name?.runs?.[0]?.text || "";
+    const name = track.name?.simpleText || track.name?.runs?.[0]?.text || "";
     return /chat/i.test(name);
   }
 
@@ -383,7 +380,9 @@ class YouTubeCaptionProvider {
 
     // Chat/弹幕字幕轨道自动降级为正常字幕轨道
     if (captionTrack && this.#isChatCaptionTrack(captionTrack)) {
-      logger.debug("Youtube Provider: detected chat subtitle track, switching to normal subtitle");
+      logger.debug(
+        "Youtube Provider: detected chat subtitle track, switching to normal subtitle"
+      );
 
       const nonChatSameLang = captionTracks.find(
         (item) =>
@@ -392,7 +391,9 @@ class YouTubeCaptionProvider {
       );
 
       if (nonChatSameLang) {
-        logger.debug("Youtube Provider: switched to same-language non-chat track");
+        logger.debug(
+          "Youtube Provider: switched to same-language non-chat track"
+        );
         captionTrack = nonChatSameLang;
       } else {
         const anyNonChat = captionTracks.find(
@@ -852,15 +853,13 @@ class YouTubeCaptionProvider {
       },
     });
 
-    // todo 移到菜单切换
     // 监听字幕更新事件，将翻译后的字幕传递给字幕列表
-    const enhanceMode = this.#setting.enhanceMode ?? "mobile_off";
-    const isEnhance =
-      enhanceMode === OPT_ENHANCE_ON ||
-      (enhanceMode === OPT_ENHANCE_MOBILE_OFF && !isMobile);
-    const showList = this.#setting.showList ?? true;
+    const showList = isSubtitleModeEnabled(
+      this.#setting.showList,
+      this.#setting.enhanceMode
+    );
 
-    if (isEnhance && showList && !this.#subtitleListManager) {
+    if (showList && !this.#subtitleListManager) {
       // 初始化字幕列表管理器
       this.#subtitleListManager = new YouTubeSubtitleList(videoEl);
       this.#subtitleListManager.initialize(this.#subtitles);
@@ -985,10 +984,13 @@ class YouTubeCaptionProvider {
           (e) => e.start >= sub.start && e.start < sub.end
         );
         if (subEvents.length > 1) {
-          logger.debug("Youtube Provider: re-processing long sentence with pause", {
-            length: sub.text.length,
-            text: sub.text.slice(0, 50) + "...",
-          });
+          logger.debug(
+            "Youtube Provider: re-processing long sentence with pause",
+            {
+              length: sub.text.length,
+              text: sub.text.slice(0, 50) + "...",
+            }
+          );
           const reProcessed = this.#processSubtitles({
             flatEvents: subEvents,
             usePause: true,

--- a/src/subtitle/modes.js
+++ b/src/subtitle/modes.js
@@ -1,0 +1,31 @@
+import {
+  OPT_ENHANCE_MOBILE_OFF,
+  OPT_ENHANCE_OFF,
+  OPT_ENHANCE_ON,
+} from "../config";
+import { isMobile } from "../libs/mobile.js";
+
+export function normalizeSubtitleMode(
+  value,
+  fallback = OPT_ENHANCE_MOBILE_OFF
+) {
+  if (value === true) return normalizeSubtitleMode(fallback);
+  if (value === false) return OPT_ENHANCE_OFF;
+
+  if (
+    value === OPT_ENHANCE_ON ||
+    value === OPT_ENHANCE_OFF ||
+    value === OPT_ENHANCE_MOBILE_OFF
+  ) {
+    return value;
+  }
+
+  return OPT_ENHANCE_MOBILE_OFF;
+}
+
+export function isSubtitleModeEnabled(value, fallback) {
+  const mode = normalizeSubtitleMode(value, fallback);
+  return (
+    mode === OPT_ENHANCE_ON || (mode === OPT_ENHANCE_MOBILE_OFF && !isMobile)
+  );
+}

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -24,6 +24,7 @@ import { useSubtitle } from "../../hooks/Subtitle";
 import { useApiList } from "../../hooks/Api";
 import ValidationInput from "../../hooks/ValidationInput";
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { normalizeSubtitleMode } from "../../subtitle/modes";
 
 const parseCssToObject = (cssString) => {
   const result = {};
@@ -176,14 +177,8 @@ const YOUTUBE_CAPTION_CONTAINER_WIDTH = 640;
 function SubtitleStylePreview({ windowStyle, originStyle, translationStyle }) {
   const i18n = useI18n();
 
-  const windowCss = useMemo(
-    () => parseCssToObject(windowStyle),
-    [windowStyle]
-  );
-  const originCss = useMemo(
-    () => parseCssToObject(originStyle),
-    [originStyle]
-  );
+  const windowCss = useMemo(() => parseCssToObject(windowStyle), [windowStyle]);
+  const originCss = useMemo(() => parseCssToObject(originStyle), [originStyle]);
   const transCss = useMemo(
     () => parseCssToObject(translationStyle),
     [translationStyle]
@@ -220,9 +215,7 @@ function SubtitleStylePreview({ windowStyle, originStyle, translationStyle }) {
             <p style={{ ...originCss, margin: 0 }}>
               This is an example subtitle
             </p>
-            <p style={{ ...transCss, margin: 0 }}>
-              这是示例字幕文本
-            </p>
+            <p style={{ ...transCss, margin: 0 }}>这是示例字幕文本</p>
           </div>
         </Box>
       </Box>
@@ -263,14 +256,23 @@ export default function SubtitleSetting() {
     throttleTrans = 30,
     toLang,
     isBilingual,
-    enhanceMode = OPT_ENHANCE_MOBILE_OFF,
-    showList = true,
+    enhanceMode,
+    hoverLookupMode,
+    showList = OPT_ENHANCE_MOBILE_OFF,
     skipAd = false,
     aiContextSlug = "-",
     windowStyle,
     originStyle,
     translationStyle,
   } = subtitleSetting;
+  const hoverLookupModeValue = normalizeSubtitleMode(
+    hoverLookupMode,
+    enhanceMode || OPT_ENHANCE_MOBILE_OFF
+  );
+  const showListValue = normalizeSubtitleMode(
+    showList,
+    enhanceMode || OPT_ENHANCE_MOBILE_OFF
+  );
 
   const [localOriginStyle, setLocalOriginStyle] = useState(originStyle);
   const [localTransStyle, setLocalTransStyle] = useState(translationStyle);
@@ -297,7 +299,9 @@ export default function SubtitleSetting() {
     return () => {
       Object.values(debounceTimers.current).forEach(clearTimeout);
       debounceTimers.current = {};
-      Object.values(rafIds.current).forEach((id) => id && cancelAnimationFrame(id));
+      Object.values(rafIds.current).forEach(
+        (id) => id && cancelAnimationFrame(id)
+      );
       rafIds.current = { origin: 0, trans: 0, window: 0 };
     };
   }, []);
@@ -315,7 +319,11 @@ export default function SubtitleSetting() {
   );
 
   const scheduleRafUpdate = useCallback((name, setter, cssString) => {
-    const rafKey = { originStyle: "origin", translationStyle: "trans", windowStyle: "window" }[name];
+    const rafKey = {
+      originStyle: "origin",
+      translationStyle: "trans",
+      windowStyle: "window",
+    }[name];
     if (rafIds.current[rafKey]) {
       cancelAnimationFrame(rafIds.current[rafKey]);
     }
@@ -395,8 +403,7 @@ export default function SubtitleSetting() {
     windowCssObj["background-color"] || "rgba(0, 0, 0, 0.5)"
   ) || { r: 0, g: 0, b: 0, a: 0.5 };
   const windowBgHex = rgbToHex(windowBgRgba.r, windowBgRgba.g, windowBgRgba.b);
-  const windowLineHeight =
-    parseFloat(windowCssObj["line-height"]) || 1.3;
+  const windowLineHeight = parseFloat(windowCssObj["line-height"]) || 1.3;
   const windowHasTextShadow = !!windowCssObj["text-shadow"];
 
   const textStyleControls = useCallback(
@@ -425,13 +432,16 @@ export default function SubtitleSetting() {
                 const minRatio = fontSize.min / p;
                 const maxRatio = fontSize.max / p;
                 updateCss(
-                    "font-size",
-                    `clamp(${(val * minRatio).toFixed(2)}${fontSize.unit}, ${val}cqw, ${(val * maxRatio).toFixed(2)}${fontSize.unit})`
-                  );
+                  "font-size",
+                  `clamp(${(val * minRatio).toFixed(2)}${fontSize.unit}, ${val}cqw, ${(val * maxRatio).toFixed(2)}${fontSize.unit})`
+                );
               }}
               sx={{ flex: 1 }}
             />
-            <Typography variant="body2" sx={{ minWidth: 28, textAlign: "right" }}>
+            <Typography
+              variant="body2"
+              sx={{ minWidth: 28, textAlign: "right" }}
+            >
               {fontSize.preferred}
             </Typography>
           </Box>
@@ -655,9 +665,9 @@ export default function SubtitleSetting() {
                 fullWidth
                 select
                 size="small"
-                name="enhanceMode"
-                value={enhanceMode}
-                label={i18n("is_enable_enhance")}
+                name="hoverLookupMode"
+                value={hoverLookupModeValue}
+                label={i18n("subtitle_hover_lookup")}
                 onChange={handleChange}
               >
                 <MenuItem value={OPT_ENHANCE_ON}>{i18n("enable")}</MenuItem>
@@ -673,12 +683,15 @@ export default function SubtitleSetting() {
                 select
                 size="small"
                 name="showList"
-                value={showList}
+                value={showListValue}
                 label={i18n("show_subtitle_list") || "显示字幕列表"}
                 onChange={handleChange}
               >
-                <MenuItem value={true}>{i18n("enable")}</MenuItem>
-                <MenuItem value={false}>{i18n("disable")}</MenuItem>
+                <MenuItem value={OPT_ENHANCE_ON}>{i18n("enable")}</MenuItem>
+                <MenuItem value={OPT_ENHANCE_OFF}>{i18n("disable")}</MenuItem>
+                <MenuItem value={OPT_ENHANCE_MOBILE_OFF}>
+                  {i18n("disable_on_mobile")}
+                </MenuItem>
               </TextField>
             </Grid>
           </Grid>
@@ -773,7 +786,10 @@ export default function SubtitleSetting() {
                       }}
                       sx={{ flex: 1 }}
                     />
-                    <Typography variant="body2" sx={{ minWidth: 36, textAlign: "right" }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ minWidth: 36, textAlign: "right" }}
+                    >
                       {Math.round(windowBgRgba.a * 100)}%
                     </Typography>
                   </Box>
@@ -798,7 +814,10 @@ export default function SubtitleSetting() {
                       }
                       sx={{ flex: 1 }}
                     />
-                    <Typography variant="body2" sx={{ minWidth: 28, textAlign: "right" }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ minWidth: 28, textAlign: "right" }}
+                    >
                       {windowLineHeight}
                     </Typography>
                   </Box>
@@ -856,10 +875,7 @@ export default function SubtitleSetting() {
                         checked={windowHasTextShadow}
                         onChange={(e) => {
                           if (e.target.checked) {
-                            updateWindowCss(
-                              "text-shadow",
-                              "1px 1px 2px black"
-                            );
+                            updateWindowCss("text-shadow", "1px 1px 2px black");
                           } else {
                             const newObj = { ...windowCssRef.current };
                             delete newObj["text-shadow"];


### PR DESCRIPTION
拆分了增强模式对应的功能

现在为两个设置，并且默认为“移动端禁用”
1、悬停查词功能，包含了选词查词，悬浮暂停视频的功能
2、双语字幕列表，不再收到增强模式的限制

保留了enhanceMode作为兼容回退，但是移除了主控开关
新增了modes.js用于统一处理on/off/mobile_off以及boolean设置，避免代码重复

目前不确定这个解决方案是否合适，等大佬看看 @fishjar 

<img width="2314" height="358" alt="image" src="https://github.com/user-attachments/assets/f611087b-8140-4bfe-a1a3-4fc1871bb941" />
