### PR TITLE
refactor: move trigger mode into each api setting

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -683,6 +683,7 @@ const defaultApi = {
   useStream: false, // 是否启用流式传输
   streamRenderMode: "disabled", // 流式渲染模式：disabled/realtime/segment
   transAllnow: false, // 是否立即全部翻译
+  rootMargin: 500, // 滚动加载提前触发距离
   useContext: false, // 是否启用智能上下文
   contextSize: DEFAULT_CONTEXT_SIZE, // 智能上下文保留会话数
   temperature: 0.0,

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -682,6 +682,7 @@ const defaultApi = {
   useBatchFetch: false, // 是否启用聚合发送请求
   useStream: false, // 是否启用流式传输
   streamRenderMode: "disabled", // 流式渲染模式：disabled/realtime/segment
+  transAllnow: false, // 是否立即全部翻译
   useContext: false, // 是否启用智能上下文
   contextSize: DEFAULT_CONTEXT_SIZE, // 智能上下文保留会话数
   temperature: 0.0,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -203,6 +203,6 @@ export const DEFAULT_SETTING = {
   transAllnow: false, // 旧版全局触发方式，仅用于迁移接口配置
   subtitleSetting: DEFAULT_SUBTITLE_SETTING, // 字幕设置
   logLevel: LogLevel.INFO.value, // 日志级别
-  rootMargin: 500, // 提前触发翻译
+  rootMargin: 500, // 旧版全局滚动提前触发距离，仅用于迁移接口配置
   customStyles: DEFAULT_CUSTOM_STYLES, // 自定义样式列表
 };

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -200,9 +200,9 @@ export const DEFAULT_SETTING = {
   langDetector: "-", // 远程语言识别服务
   mouseHoverSetting: DEFAULT_MOUSE_HOVER_SETTING, // 鼠标悬停翻译
   preInit: true, // 是否预加载脚本
-  transAllnow: false, // 旧版全局触发方式，仅用于迁移接口配置
+  transAllnow: false, // 旧版全局触发方式，供未设置接口配置时回退
   subtitleSetting: DEFAULT_SUBTITLE_SETTING, // 字幕设置
   logLevel: LogLevel.INFO.value, // 日志级别
-  rootMargin: 500, // 旧版全局滚动提前触发距离，仅用于迁移接口配置
+  rootMargin: 500, // 旧版全局滚动提前触发距离，供未设置接口配置时回退
   customStyles: DEFAULT_CUSTOM_STYLES, // 自定义样式列表
 };

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -200,7 +200,7 @@ export const DEFAULT_SETTING = {
   langDetector: "-", // 远程语言识别服务
   mouseHoverSetting: DEFAULT_MOUSE_HOVER_SETTING, // 鼠标悬停翻译
   preInit: true, // 是否预加载脚本
-  transAllnow: false, // 是否立即全部翻译
+  transAllnow: false, // 旧版全局触发方式，仅用于迁移接口配置
   subtitleSetting: DEFAULT_SUBTITLE_SETTING, // 字幕设置
   logLevel: LogLevel.INFO.value, // 日志级别
   rootMargin: 500, // 提前触发翻译

--- a/src/hooks/Setting.js
+++ b/src/hooks/Setting.js
@@ -13,7 +13,7 @@ import {
   MSG_SET_LOGLEVEL,
 } from "../config";
 import { useStorage } from "./Storage";
-import { debounceSyncMeta, normalizeSetting } from "../libs/storage";
+import { debounceSyncMeta } from "../libs/storage";
 import Loading from "./Loading";
 import { logger } from "../libs/log";
 import { sendBgMsg } from "../libs/msg";
@@ -29,16 +29,11 @@ export function SettingProvider({ children, context }) {
   const isOptionsPage = useMemo(() => context === "options", [context]);
 
   const {
-    data: storedSetting,
+    data: setting,
     isLoading,
     update,
     reload,
   } = useStorage(STOKEY_SETTING, DEFAULT_SETTING, KV_SETTING_KEY);
-
-  const setting = useMemo(
-    () => normalizeSetting(storedSetting || DEFAULT_SETTING),
-    [storedSetting]
-  );
 
   useEffect(() => {
     if (typeof setting?.darkMode === "boolean") {

--- a/src/hooks/Setting.js
+++ b/src/hooks/Setting.js
@@ -13,7 +13,7 @@ import {
   MSG_SET_LOGLEVEL,
 } from "../config";
 import { useStorage } from "./Storage";
-import { debounceSyncMeta } from "../libs/storage";
+import { debounceSyncMeta, normalizeSetting } from "../libs/storage";
 import Loading from "./Loading";
 import { logger } from "../libs/log";
 import { sendBgMsg } from "../libs/msg";
@@ -29,11 +29,16 @@ export function SettingProvider({ children, context }) {
   const isOptionsPage = useMemo(() => context === "options", [context]);
 
   const {
-    data: setting,
+    data: storedSetting,
     isLoading,
     update,
     reload,
   } = useStorage(STOKEY_SETTING, DEFAULT_SETTING, KV_SETTING_KEY);
+
+  const setting = useMemo(
+    () => normalizeSetting(storedSetting || DEFAULT_SETTING),
+    [storedSetting]
+  );
 
   useEffect(() => {
     if (typeof setting?.darkMode === "boolean") {

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -12,7 +12,6 @@ import {
   STOKEY_RULESCACHE_PREFIX,
   STOKEY_DISABLED_SUB_RULES,
   DEFAULT_SETTING,
-  DEFAULT_API_LIST,
   DEFAULT_RULES,
   DEFAULT_SYNC,
   BUILTIN_RULES,
@@ -93,50 +92,12 @@ export const storage = {
   // onChanged,
 };
 
-/**
- * 设置信息
- */
-export const normalizeSetting = (setting = {}) => {
-  const normalizedSetting = {
-    ...DEFAULT_SETTING,
-    ...(setting || {}),
-  };
-  const legacyTransAllnow =
-    normalizedSetting.transAllnow ?? DEFAULT_SETTING.transAllnow;
-  const legacyRootMargin =
-    normalizedSetting.rootMargin ?? DEFAULT_SETTING.rootMargin;
-  const defaultApisBySlug = new Map(
-    DEFAULT_API_LIST.map((api) => [api.apiSlug, api])
-  );
-  const defaultApisByType = new Map(
-    DEFAULT_API_LIST.map((api) => [api.apiType, api])
-  );
-  const transApis = Array.isArray(normalizedSetting.transApis)
-    ? normalizedSetting.transApis
-    : DEFAULT_SETTING.transApis;
-
-  return {
-    ...normalizedSetting,
-    transApis: transApis.map((api) => {
-      const defaultApi =
-        defaultApisBySlug.get(api.apiSlug) ||
-        defaultApisByType.get(api.apiType) ||
-        {};
-
-      return {
-        ...defaultApi,
-        ...api,
-        transAllnow: api.transAllnow ?? legacyTransAllnow,
-        rootMargin: api.rootMargin ?? legacyRootMargin,
-      };
-    }),
-  };
-};
-
 export const getSetting = () => getObj(STOKEY_SETTING);
 export const getSettingOld = () => getObj(STOKEY_SETTING_OLD);
-export const getSettingWithDefault = async () =>
-  normalizeSetting((await getSetting()) || {});
+export const getSettingWithDefault = async () => ({
+  ...DEFAULT_SETTING,
+  ...((await getSetting()) || {}),
+});
 export const setSetting = (val) => setObj(STOKEY_SETTING, val);
 export const putSetting = (obj) => putObj(STOKEY_SETTING, obj);
 

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -103,6 +103,8 @@ export const normalizeSetting = (setting = {}) => {
   };
   const legacyTransAllnow =
     normalizedSetting.transAllnow ?? DEFAULT_SETTING.transAllnow;
+  const legacyRootMargin =
+    normalizedSetting.rootMargin ?? DEFAULT_SETTING.rootMargin;
   const defaultApisBySlug = new Map(
     DEFAULT_API_LIST.map((api) => [api.apiSlug, api])
   );
@@ -125,6 +127,7 @@ export const normalizeSetting = (setting = {}) => {
         ...defaultApi,
         ...api,
         transAllnow: api.transAllnow ?? legacyTransAllnow,
+        rootMargin: api.rootMargin ?? legacyRootMargin,
       };
     }),
   };

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -12,6 +12,7 @@ import {
   STOKEY_RULESCACHE_PREFIX,
   STOKEY_DISABLED_SUB_RULES,
   DEFAULT_SETTING,
+  DEFAULT_API_LIST,
   DEFAULT_RULES,
   DEFAULT_SYNC,
   BUILTIN_RULES,
@@ -95,12 +96,44 @@ export const storage = {
 /**
  * 设置信息
  */
+export const normalizeSetting = (setting = {}) => {
+  const normalizedSetting = {
+    ...DEFAULT_SETTING,
+    ...(setting || {}),
+  };
+  const legacyTransAllnow =
+    normalizedSetting.transAllnow ?? DEFAULT_SETTING.transAllnow;
+  const defaultApisBySlug = new Map(
+    DEFAULT_API_LIST.map((api) => [api.apiSlug, api])
+  );
+  const defaultApisByType = new Map(
+    DEFAULT_API_LIST.map((api) => [api.apiType, api])
+  );
+  const transApis = Array.isArray(normalizedSetting.transApis)
+    ? normalizedSetting.transApis
+    : DEFAULT_SETTING.transApis;
+
+  return {
+    ...normalizedSetting,
+    transApis: transApis.map((api) => {
+      const defaultApi =
+        defaultApisBySlug.get(api.apiSlug) ||
+        defaultApisByType.get(api.apiType) ||
+        {};
+
+      return {
+        ...defaultApi,
+        ...api,
+        transAllnow: api.transAllnow ?? legacyTransAllnow,
+      };
+    }),
+  };
+};
+
 export const getSetting = () => getObj(STOKEY_SETTING);
 export const getSettingOld = () => getObj(STOKEY_SETTING_OLD);
-export const getSettingWithDefault = async () => ({
-  ...DEFAULT_SETTING,
-  ...((await getSetting()) || {}),
-});
+export const getSettingWithDefault = async () =>
+  normalizeSetting((await getSetting()) || {});
 export const setSetting = (val) => setObj(STOKEY_SETTING, val);
 export const putSetting = (obj) => putObj(STOKEY_SETTING, obj);
 

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -440,11 +440,16 @@ export class Translator {
 
   get #rootMargin() {
     const apiValue = this.#apisMap.get(this.#rule.apiSlug)?.rootMargin;
-    if (apiValue !== undefined && apiValue !== "") {
-      return apiValue;
-    }
+    const legacyValue = this.#setting.rootMargin;
+    const value =
+      apiValue !== undefined && apiValue !== ""
+        ? apiValue
+        : legacyValue !== undefined && legacyValue !== ""
+          ? legacyValue
+          : 500;
+    const rootMargin = Number(value);
 
-    return this.#setting.rootMargin ?? 500;
+    return Number.isFinite(rootMargin) ? rootMargin : 500;
   }
 
   // 占位符配置（包含正则）
@@ -1941,6 +1946,7 @@ export class Translator {
     this.#observedNodes = new WeakSet();
     this.#translationNodes = new WeakMap();
     this.#processedNodes = new WeakMap();
+    this.#io = this.#createIntersectionObserver();
   }
 
   // 开启鼠标悬停翻译

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -427,6 +427,17 @@ export class Translator {
     return this.#apisMap.get(this.#rule.apiSlug) || DEFAULT_API_SETTING;
   }
 
+  get #transAllnow() {
+    const apiValue = this.#apisMap.get(this.#rule.apiSlug)?.transAllnow;
+    if (apiValue !== undefined) {
+      return apiValue === true || apiValue === "true";
+    }
+
+    return (
+      this.#setting.transAllnow === true || this.#setting.transAllnow === "true"
+    );
+  }
+
   // 占位符配置（包含正则）
   get #placeholderConfig() {
     if (this.#placeholderCache) {
@@ -946,11 +957,7 @@ export class Translator {
       this.#highlightWordsDeeply(node);
     }
 
-    if (
-      !this.#observedNodes.has(node) &&
-      this.#enabled &&
-      this.#setting.transAllnow
-    ) {
+    if (!this.#observedNodes.has(node) && this.#enabled && this.#transAllnow) {
       this.#observedNodes.add(node);
       this.#processNode(node);
       return;
@@ -1377,7 +1384,10 @@ export class Translator {
 
       // 流式渲染模式
       const streamRenderMode = this.#apiSetting.streamRenderMode || "disabled";
-      const isStreamRender = streamRenderMode !== "disabled" && this.#apiSetting.useStream && this.#apiSetting.useBatchFetch;
+      const isStreamRender =
+        streamRenderMode !== "disabled" &&
+        this.#apiSetting.useStream &&
+        this.#apiSetting.useBatchFetch;
 
       // RAF 缓冲
       let rafId = null;
@@ -1956,17 +1966,14 @@ export class Translator {
     this.#transOnlyRevertEnabled = true;
 
     this.#boundTransOnlyMouseOver = (e) => {
-      const wrapper = e.target.closest?.(
-        `.${Translator.KISS_CLASS.warpper}`
-      );
+      const wrapper = e.target.closest?.(`.${Translator.KISS_CLASS.warpper}`);
       if (wrapper) {
         const data = this.#translationNodes.get(wrapper);
         if (!data || !data.isHide) return;
         if (this.#transOnlyRevertTarget === wrapper) return;
 
         this.#clearTransOnlyRevertTimer();
-        const delay =
-          parseFloat(this.#rule.transOnlyRevertDelay) || 0.5;
+        const delay = parseFloat(this.#rule.transOnlyRevertDelay) || 0.5;
         this.#transOnlyRevertTimer = setTimeout(() => {
           this.#showOriginalTemporarily(wrapper, data);
         }, delay * 1000);
@@ -1986,9 +1993,7 @@ export class Translator {
 
     this.#boundTransOnlyMouseOut = (e) => {
       if (!this.#transOnlyRevertTarget) {
-        const wrapper = e.target.closest?.(
-          `.${Translator.KISS_CLASS.warpper}`
-        );
+        const wrapper = e.target.closest?.(`.${Translator.KISS_CLASS.warpper}`);
         if (wrapper) this.#clearTransOnlyRevertTimer();
         return;
       }
@@ -2134,7 +2139,7 @@ export class Translator {
     this.#runId++;
 
     if (this.#isInitialized) {
-      if (this.#setting.transAllnow) {
+      if (this.#transAllnow) {
         this.rescan();
       } else {
         this.#reIOViewNodes();
@@ -2264,7 +2269,7 @@ export class Translator {
     // 配置变更时清空正则缓存
     this.#placeholderCache = null;
 
-    if (needsRescan || (this.#enabled && this.#setting.transAllnow)) {
+    if (needsRescan || (this.#enabled && this.#transAllnow)) {
       this.rescan();
       this.#syncTransOnlyRevert();
       return;
@@ -2278,8 +2283,7 @@ export class Translator {
 
   #syncTransOnlyRevert() {
     const shouldEnable =
-      this.#rule.transOnly === "true" &&
-      this.#rule.transOnlyRevert === "true";
+      this.#rule.transOnly === "true" && this.#rule.transOnlyRevert === "true";
     if (shouldEnable && !this.#transOnlyRevertEnabled) {
       this.#enableTransOnlyRevert();
     } else if (!shouldEnable && this.#transOnlyRevertEnabled) {

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -438,6 +438,15 @@ export class Translator {
     );
   }
 
+  get #rootMargin() {
+    const apiValue = this.#apisMap.get(this.#rule.apiSlug)?.rootMargin;
+    if (apiValue !== undefined && apiValue !== "") {
+      return apiValue;
+    }
+
+    return this.#setting.rootMargin ?? 500;
+  }
+
   // 占位符配置（包含正则）
   get #placeholderConfig() {
     if (this.#placeholderCache) {
@@ -704,7 +713,8 @@ export class Translator {
 
   // 监控翻译单元的可见性
   #createIntersectionObserver() {
-    const { transInterval, rootMargin = 500 } = this.#setting;
+    const { transInterval } = this.#setting;
+    const rootMargin = this.#rootMargin;
 
     const pending = new Set();
     const flush = debounce(() => {
@@ -2247,6 +2257,8 @@ export class Translator {
   updateRule(newRule) {
     let hasChanged = false;
     let needsRescan = false;
+    const oldTransAllnow = this.#transAllnow;
+    const oldRootMargin = this.#rootMargin;
     for (const key in newRule) {
       if (
         Object.prototype.hasOwnProperty.call(this.#rule, key) &&
@@ -2269,7 +2281,16 @@ export class Translator {
     // 配置变更时清空正则缓存
     this.#placeholderCache = null;
 
-    if (needsRescan || (this.#enabled && this.#transAllnow)) {
+    const needsTriggerRescan =
+      this.#enabled &&
+      (oldTransAllnow !== this.#transAllnow ||
+        String(oldRootMargin) !== String(this.#rootMargin));
+
+    if (
+      needsRescan ||
+      needsTriggerRescan ||
+      (this.#enabled && this.#transAllnow)
+    ) {
       this.rescan();
       this.#syncTransOnlyRevert();
       return;

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -228,6 +228,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
     useBatchFetch = false,
     useStream = false,
     streamRenderMode = "disabled",
+    transAllnow = false,
     batchInterval = DEFAULT_BATCH_INTERVAL,
     batchSize = DEFAULT_BATCH_SIZE,
     batchLength = DEFAULT_BATCH_LENGTH,
@@ -262,7 +263,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
     <Stack spacing={3}>
       <Box>
         <Grid container spacing={2} columns={12}>
-          <Grid item xs={12} sm={12} md={6} lg={6}>
+          <Grid item xs={12} sm={12} md={6} lg={4}>
             <TextField
               size="small"
               fullWidth
@@ -272,7 +273,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               onChange={handleChange}
             />
           </Grid>
-          <Grid item xs={12} sm={12} md={6} lg={6}>
+          <Grid item xs={12} sm={12} md={6} lg={4}>
             <TextField
               size="small"
               fullWidth
@@ -283,6 +284,20 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               onChange={handleChange}
               helperText={i18n("sort_order_help") || "数值越小越靠前"}
             />
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={4}>
+            <TextField
+              select
+              fullWidth
+              size="small"
+              name="transAllnow"
+              value={transAllnow}
+              label={i18n("trigger_mode")}
+              onChange={handleChange}
+            >
+              <MenuItem value={false}>{i18n("mk_pagescroll")}</MenuItem>
+              <MenuItem value={true}>{i18n("mk_pageopen")}</MenuItem>
+            </TextField>
           </Grid>
         </Grid>
       </Box>
@@ -397,7 +412,6 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               <Grid item xs={12} sm={12} md={6} lg={3}></Grid>
             </Grid>
           </Box>
-
         </>
       )}
 
@@ -542,23 +556,29 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
             </Grid>
           )}
 
-          {API_SPE_TYPES.stream.has(api.apiType) && useBatchFetch && useStream && (
-            <Grid item xs={12} sm={12} md={6} lg={3}>
-              <TextField
-                select
-                fullWidth
-                size="small"
-                name="streamRenderMode"
-                value={streamRenderMode}
-                label={i18n("stream_render_mode")}
-                onChange={handleChange}
-              >
-                <MenuItem value="disabled">{i18n("disable")}</MenuItem>
-                <MenuItem value="realtime">{i18n("stream_render_realtime")}</MenuItem>
-                <MenuItem value="segment">{i18n("stream_render_segment")}</MenuItem>
-              </TextField>
-            </Grid>
-          )}
+          {API_SPE_TYPES.stream.has(api.apiType) &&
+            useBatchFetch &&
+            useStream && (
+              <Grid item xs={12} sm={12} md={6} lg={3}>
+                <TextField
+                  select
+                  fullWidth
+                  size="small"
+                  name="streamRenderMode"
+                  value={streamRenderMode}
+                  label={i18n("stream_render_mode")}
+                  onChange={handleChange}
+                >
+                  <MenuItem value="disabled">{i18n("disable")}</MenuItem>
+                  <MenuItem value="realtime">
+                    {i18n("stream_render_realtime")}
+                  </MenuItem>
+                  <MenuItem value="segment">
+                    {i18n("stream_render_segment")}
+                  </MenuItem>
+                </TextField>
+              </Grid>
+            )}
 
           {API_SPE_TYPES.context.has(api.apiType) && (
             <>
@@ -655,10 +675,16 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
                 onChange={handleChange}
                 helperText={i18n("thinking_mode_helper")}
               >
-                <MenuItem value="auto">{i18n("thinking_mode_default")}</MenuItem>
-                <MenuItem value="enabled">{i18n("thinking_mode_enabled")}</MenuItem>
+                <MenuItem value="auto">
+                  {i18n("thinking_mode_default")}
+                </MenuItem>
+                <MenuItem value="enabled">
+                  {i18n("thinking_mode_enabled")}
+                </MenuItem>
                 {thinkingParam.disableSupported !== false && (
-                  <MenuItem value="disabled">{i18n("thinking_mode_disabled")}</MenuItem>
+                  <MenuItem value="disabled">
+                    {i18n("thinking_mode_disabled")}
+                  </MenuItem>
                 )}
               </TextField>
             </Grid>
@@ -678,7 +704,9 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
                       {e.label}
                     </MenuItem>
                   ))}
-                  <MenuItem value="_default">{i18n("thinking_effort_default")}</MenuItem>
+                  <MenuItem value="_default">
+                    {i18n("thinking_effort_default")}
+                  </MenuItem>
                 </TextField>
               </Grid>
             )}

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -229,6 +229,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
     useStream = false,
     streamRenderMode = "disabled",
     transAllnow = false,
+    rootMargin = 500,
     batchInterval = DEFAULT_BATCH_INTERVAL,
     batchSize = DEFAULT_BATCH_SIZE,
     batchLength = DEFAULT_BATCH_LENGTH,
@@ -263,7 +264,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
     <Stack spacing={3}>
       <Box>
         <Grid container spacing={2} columns={12}>
-          <Grid item xs={12} sm={12} md={6} lg={4}>
+          <Grid item xs={12} sm={12} md={6} lg={3}>
             <TextField
               size="small"
               fullWidth
@@ -273,7 +274,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               onChange={handleChange}
             />
           </Grid>
-          <Grid item xs={12} sm={12} md={6} lg={4}>
+          <Grid item xs={12} sm={12} md={6} lg={3}>
             <TextField
               size="small"
               fullWidth
@@ -285,7 +286,7 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               helperText={i18n("sort_order_help") || "数值越小越靠前"}
             />
           </Grid>
-          <Grid item xs={12} sm={12} md={6} lg={4}>
+          <Grid item xs={12} sm={12} md={6} lg={3}>
             <TextField
               select
               fullWidth
@@ -298,6 +299,19 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               <MenuItem value={false}>{i18n("mk_pagescroll")}</MenuItem>
               <MenuItem value={true}>{i18n("mk_pageopen")}</MenuItem>
             </TextField>
+          </Grid>
+          <Grid item xs={12} sm={12} md={6} lg={3}>
+            <ValidationInput
+              fullWidth
+              size="small"
+              label={i18n("pagescroll_root_margin")}
+              type="number"
+              name="rootMargin"
+              value={rootMargin}
+              onChange={handleChange}
+              min={0}
+              max={10000}
+            />
           </Grid>
         </Grid>
       </Box>

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -104,7 +104,6 @@ export default function Settings() {
     preInit = true,
     skipLangs = [],
     // detectRemote = true,
-    rootMargin = 500,
   } = setting;
   const { isHide = false, fabClickAction = 0 } = fab || {};
 
@@ -308,19 +307,6 @@ export default function Settings() {
                   </MenuItem>
                 ))}
               </TextField>
-            </Grid>
-            <Grid item xs={12} sm={12} md={6} lg={3}>
-              <ValidationInput
-                fullWidth
-                size="small"
-                label={i18n("pagescroll_root_margin")}
-                type="number"
-                name="rootMargin"
-                value={rootMargin}
-                onChange={handleChange}
-                min={0}
-                max={10000}
-              />
             </Grid>
             {/* <Grid item xs={12} sm={12} md={6} lg={3}>
               <TextField

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -104,7 +104,6 @@ export default function Settings() {
     preInit = true,
     skipLangs = [],
     // detectRemote = true,
-    transAllnow = false,
     rootMargin = 500,
   } = setting;
   const { isHide = false, fabClickAction = 0 } = fab || {};
@@ -308,20 +307,6 @@ export default function Settings() {
                     {item}
                   </MenuItem>
                 ))}
-              </TextField>
-            </Grid>
-            <Grid item xs={12} sm={12} md={6} lg={3}>
-              <TextField
-                select
-                size="small"
-                fullWidth
-                name="transAllnow"
-                value={transAllnow}
-                label={i18n("trigger_mode")}
-                onChange={handleChange}
-              >
-                <MenuItem value={false}>{i18n("mk_pagescroll")}</MenuItem>
-                <MenuItem value={true}>{i18n("mk_pageopen")}</MenuItem>
               </TextField>
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>


### PR DESCRIPTION
将“滚动加载翻译”和“立刻加载翻译”的设置项移动到了接口设置中

LLM翻译效果比较好，但是速度慢，如果使用滚动加载方式，虽然能够节省token，但是比较限制阅读速度
原先的逻辑是一个全局设定，不能基于接口灵活的调整
