### PR TITLE
refactor: change subtitle loading notification style

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2598,6 +2598,13 @@ export const I18N = {
     ja: `字幕リストを表示`,
     ko: `자막 목록 표시`,
   },
+  subtitle_loading_notification: {
+    zh: `字幕加载通知`,
+    en: `Subtitle loading notification`,
+    zh_TW: `字幕載入通知`,
+    ja: `字幕読み込み通知`,
+    ko: `자막 로딩 알림`,
+  },
   default_styles_example: {
     zh: `默认样式参考：`,
     en: `Default styles reference:`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -137,6 +137,7 @@ export const DEFAULT_SUBTITLE_SETTING = {
   translationStyle: SUBTITLE_TRANSLATION_STYLE, // 译文样式
   enhanceMode: OPT_ENHANCE_MOBILE_OFF, // 增强功能：on/off/mobile_off
   showList: true, // 是否显示滚动字幕
+  showLoadNotification: true, // 是否显示字幕加载提示
   aiContextSlug: "-", // 增强智能上下文分析服务
 };
 

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -221,6 +221,8 @@ class YouTubeCaptionProvider {
       this.#toggleShowOrigin();
     } else if (name === "aiContextSlug") {
       this.#reProcessEventsWithContext();
+    } else if (name === "showLoadNotification" && value === false) {
+      this.#hideNotification();
     }
   }
 
@@ -1338,20 +1340,24 @@ class YouTubeCaptionProvider {
     notificationEl.className = "kiss-notification";
     Object.assign(notificationEl.style, {
       position: "absolute",
-      top: "40%",
+      top: "16px",
       left: "50%",
       transform: "translateX(-50%)",
-      background: "rgba(0,0,0,0.7)",
-      color: "red",
-      padding: "0.5em 1em",
-      borderRadius: "4px",
+      background: "rgba(0, 0, 0, 0.5)",
+      color: "#fff",
+      padding: "8px 12px",
+      borderRadius: "8px",
       zIndex: "2147483647",
       opacity: "0",
       transition: "opacity 0.3s ease-in-out",
       pointerEvents: "none",
-      fontSize: "2em",
-      width: "50%",
-      textAlign: "center",
+      fontSize: "16px",
+      lineHeight: "1.4",
+      width: "auto",
+      maxWidth: "min(360px, calc(100% - 32px))",
+      textAlign: "left",
+      boxSizing: "border-box",
+      boxShadow: "0 2px 8px rgba(0,0,0,0.25)",
     });
 
     const videoEl = this.#videoEl;
@@ -1362,13 +1368,27 @@ class YouTubeCaptionProvider {
     }
   }
 
+  #hideNotification() {
+    clearTimeout(this.#notificationTimeout);
+    if (this.#notificationEl) {
+      this.#notificationEl.style.opacity = "0";
+    }
+  }
+
   #showNotification(message, duration = 2000) {
+    if (this.#setting.showLoadNotification === false) {
+      this.#hideNotification();
+      return;
+    }
+
     if (!this.#notificationEl) this.#createNotificationElement();
+    if (!this.#notificationEl) return;
+
     this.#notificationEl.textContent = message;
     this.#notificationEl.style.opacity = "1";
     clearTimeout(this.#notificationTimeout);
     this.#notificationTimeout = setTimeout(() => {
-      this.#notificationEl.style.opacity = "0";
+      this.#hideNotification();
     }, duration);
   }
 }

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -265,6 +265,7 @@ export default function SubtitleSetting() {
     isBilingual,
     enhanceMode = OPT_ENHANCE_MOBILE_OFF,
     showList = true,
+    showLoadNotification = true,
     skipAd = false,
     aiContextSlug = "-",
     windowStyle,
@@ -679,6 +680,20 @@ export default function SubtitleSetting() {
               >
                 <MenuItem value={true}>{i18n("enable")}</MenuItem>
                 <MenuItem value={false}>{i18n("disable")}</MenuItem>
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                fullWidth
+                select
+                size="small"
+                name="showLoadNotification"
+                value={showLoadNotification}
+                label={i18n("subtitle_loading_notification")}
+                onChange={handleChange}
+              >
+                <MenuItem value={true}>{i18n("show")}</MenuItem>
+                <MenuItem value={false}>{i18n("hide")}</MenuItem>
               </TextField>
             </Grid>
           </Grid>


### PR DESCRIPTION
修改了字幕加载提示的样式，从惊悚的红色正中改为了顶部小字，并且在字幕设置界面增加了可以自行决定是否开启通知的开关

不过我个人觉得，这个加载通知其实可有可无，目前可以先降低一些存在感

<img width="2545" height="1269" alt="image" src="https://github.com/user-attachments/assets/61abb17b-f3b6-4e79-91a1-20a7b7579925" />

<img width="2560" height="1001" alt="image" src="https://github.com/user-attachments/assets/cc87c14e-d40d-4a2e-b69d-f7d282b47474" />
