### PR TITLE
fix: 跳过嵌套 script 节点的翻译序列化

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -416,6 +416,13 @@ export class Translator {
     return selectors.join(", ");
   }
 
+  #isIgnoredElement(node) {
+    return (
+      node?.nodeType === Node.ELEMENT_NODE &&
+      node.matches?.(this.#ignoreSelector)
+    );
+  }
+
   // 接口参数
   // todo: 不用频繁查找计算
   get #apiSetting() {
@@ -1594,6 +1601,10 @@ export class Translator {
 
       // 元素节点
       if (node.nodeType === Node.ELEMENT_NODE) {
+        if (this.#isIgnoredElement(node)) {
+          return "";
+        }
+
         if (
           (this.#rule.hasRichText === "true" &&
             Translator.TAGS.REPLACE.has(node.tagName)) ||


### PR DESCRIPTION
## 背景

修复 #676

在部分页面中，如果 `<script>` 嵌套在可翻译文本容器内，例如 `div > span > script`，翻译流程会把脚本内容一并序列化进翻译请求，导致脚本源码被翻译并显示到页面上。即使规则里的“不翻译节点选择器”添加了 `script` 也无法避免

## 修改内容

- 在翻译序列化阶段增加忽略节点判断
- 当递归处理富文本节点时，如果元素命中内置或用户配置的忽略选择器，直接跳过该元素及其子树

## 验证

#676 中的复现示例

<img width="415" height="93" alt="屏幕截图 2026-05-12 232905" src="https://github.com/user-attachments/assets/7643d25f-1ddc-4f88-8931-ed40be113cf4" />

网页 https://activitywatch.net/

<img width="1440" height="415" alt="屏幕截图 2026-05-12 232916" src="https://github.com/user-attachments/assets/b561a84e-9373-4c13-9876-f83dba8185d7" />

## 影响范围

该修改只影响翻译前的 DOM 序列化过滤逻辑，忽略节点的内容不会再被发送给翻译接口，也不会作为译文插入页面