### PR TITLE
feat: add quick blacklist button to popup menu

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1789,6 +1789,20 @@ export const I18N = {
     ja: `ブラックリスト`,
     ko: `블랙리스트`,
   },
+  add_to_blacklist: {
+    zh: `加入黑名单`,
+    en: `Add to Blacklist`,
+    zh_TW: `加入黑名單`,
+    ja: `ブラックリストに追加`,
+    ko: `블랙리스트에 추가`,
+  },
+  remove_from_blacklist: {
+    zh: `移出黑名单`,
+    en: `Remove from Blacklist`,
+    zh_TW: `移出黑名單`,
+    ja: `ブラックリストから削除`,
+    ko: `블랙리스트에서 제거`,
+  },
   disabled_orilist: {
     zh: `禁用Origin名单`,
     en: `Disabled Origin List`,

--- a/src/views/Popup/PopupCont.js
+++ b/src/views/Popup/PopupCont.js
@@ -40,7 +40,7 @@ export default function PopupCont({
   isContent = false,
 }) {
   const i18n = useI18n();
-  const { updateSetting } = useSetting();
+  const { setting: contextSetting, updateSetting } = useSetting();
   const [commands, setCommands] = useState({});
   const [domainOptions, setDomainOptions] = useState([]);
   const [selectedDomain, setSelectedDomain] = useState("");
@@ -49,26 +49,26 @@ export default function PopupCont({
 
   const [currentHref, setCurrentHref] = useState("");
 
+  const blacklistValue = contextSetting?.blacklist || "";
+
   const isInCurrentBlacklist = useMemo(() => {
-    if (!selectedDomain || !setting.blacklist) return false;
-    return isInBlacklist(currentHref, setting.blacklist);
-  }, [selectedDomain, setting.blacklist, currentHref]);
+    if (!selectedDomain || !blacklistValue) return false;
+    return isInBlacklist(currentHref, blacklistValue);
+  }, [selectedDomain, blacklistValue, currentHref]);
 
   const handleAddToBlacklist = useCallback(() => {
     if (!selectedDomain) return;
-    const blacklist = setting.blacklist || "";
-    const newBlacklist = blacklist ? `${blacklist}\n${selectedDomain}` : selectedDomain;
+    const newBlacklist = blacklistValue ? `${blacklistValue}\n${selectedDomain}` : selectedDomain;
     updateSetting((pre) => ({ ...pre, blacklist: newBlacklist }));
     setSnackbar({
       open: true,
       message: `${i18n("add_to_blacklist")}: ${selectedDomain}`,
     });
-  }, [selectedDomain, setting.blacklist, updateSetting, i18n]);
+  }, [selectedDomain, blacklistValue, updateSetting, i18n]);
 
   const handleRemoveFromBlacklist = useCallback(() => {
     if (!selectedDomain) return;
-    const blacklist = setting.blacklist || "";
-    const newList = blacklist
+    const newList = blacklistValue
       .split(/\n|,/)
       .map((url) => url.trim())
       .filter((url) => url !== selectedDomain)
@@ -78,7 +78,7 @@ export default function PopupCont({
       open: true,
       message: `${i18n("remove_from_blacklist")}: ${selectedDomain}`,
     });
-  }, [selectedDomain, setting.blacklist, updateSetting, i18n]);
+  }, [selectedDomain, blacklistValue, updateSetting, i18n]);
 
   const handleTransToggle = async (e) => {
     try {

--- a/src/views/Popup/PopupCont.js
+++ b/src/views/Popup/PopupCont.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import Stack from "@mui/material/Stack";
 import MenuItem from "@mui/material/MenuItem";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -27,6 +27,8 @@ import { tryClearCaches } from "../../libs/cache";
 import { kissLog } from "../../libs/log";
 import { getDomainOptions, truncateMiddle } from "../../libs/url";
 import { useAllTextStyles } from "../../hooks/CustomStyles";
+import { isInBlacklist } from "../../libs/blacklist";
+import { useSetting } from "../../hooks/Setting";
 
 export default function PopupCont({
   rule,
@@ -38,11 +40,45 @@ export default function PopupCont({
   isContent = false,
 }) {
   const i18n = useI18n();
+  const { updateSetting } = useSetting();
   const [commands, setCommands] = useState({});
   const [domainOptions, setDomainOptions] = useState([]);
   const [selectedDomain, setSelectedDomain] = useState("");
   const [snackbar, setSnackbar] = useState({ open: false, message: "" });
   const { allTextStyles } = useAllTextStyles();
+
+  const [currentHref, setCurrentHref] = useState("");
+
+  const isInCurrentBlacklist = useMemo(() => {
+    if (!selectedDomain || !setting.blacklist) return false;
+    return isInBlacklist(currentHref, setting.blacklist);
+  }, [selectedDomain, setting.blacklist, currentHref]);
+
+  const handleAddToBlacklist = useCallback(() => {
+    if (!selectedDomain) return;
+    const blacklist = setting.blacklist || "";
+    const newBlacklist = blacklist ? `${blacklist}\n${selectedDomain}` : selectedDomain;
+    updateSetting((pre) => ({ ...pre, blacklist: newBlacklist }));
+    setSnackbar({
+      open: true,
+      message: `${i18n("add_to_blacklist")}: ${selectedDomain}`,
+    });
+  }, [selectedDomain, setting.blacklist, updateSetting, i18n]);
+
+  const handleRemoveFromBlacklist = useCallback(() => {
+    if (!selectedDomain) return;
+    const blacklist = setting.blacklist || "";
+    const newList = blacklist
+      .split(/\n|,/)
+      .map((url) => url.trim())
+      .filter((url) => url !== selectedDomain)
+      .join("\n");
+    updateSetting((pre) => ({ ...pre, blacklist: newList }));
+    setSnackbar({
+      open: true,
+      message: `${i18n("remove_from_blacklist")}: ${selectedDomain}`,
+    });
+  }, [selectedDomain, setting.blacklist, updateSetting, i18n]);
 
   const handleTransToggle = async (e) => {
     try {
@@ -170,6 +206,7 @@ export default function PopupCont({
         }
 
         if (href && typeof href === "string") {
+          setCurrentHref(href);
           const options = getDomainOptions(href);
           setDomainOptions(options);
           if (options.length > 0) {
@@ -471,6 +508,13 @@ export default function PopupCont({
             disabled={domainOptions.length === 0}
           >
             {i18n("save_rule")}
+          </Button>
+          <Button
+            variant="text"
+            onClick={isInCurrentBlacklist ? handleRemoveFromBlacklist : handleAddToBlacklist}
+            disabled={domainOptions.length === 0}
+          >
+            {i18n(isInCurrentBlacklist ? "remove_from_blacklist" : "add_to_blacklist")}
           </Button>
           <Button variant="text" onClick={handleClearCache}>
             {i18n("clear_cache")}


### PR DESCRIPTION
## Summary
- 在悬浮球触发的弹出菜单中新增"加入黑名单" / "移出黑名单"按钮
- 点击后自动将当前网站域名添加到或从全局翻译黑名单中移除，无需打开设置页
- 支持多语言（zh/en/zh_TW/ja/ko）
- 操作后显示 Snackbar 提示

若不符合原仓库的代码风格，或存在错误，可随意close，感谢开发者的付出

## Modified Files
- `src/config/i18n.js` — 新增 `add_to_blacklist` / `remove_from_blacklist` i18n key
- `src/views/Popup/PopupCont.js` — 新增黑名单判断逻辑、处理函数和按钮 UI

## ⚠️ Disclaimer
**This code is generated by GLM-5.1 (华为云码道 CodeArts) and is provided for reference only.**
Please review carefully before merging.

🤖 Generated with CodeMate