### PR TITLE
fix: #474 修复【触摸屏的 youtube 字幕菜单中的下载按钮，点击无法下载】的问题

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -607,7 +607,9 @@ class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
-
+      if (!captionTrack.baseUrl.startsWith("https")) {
+        captionTrack.baseUrl = window.location.origin + captionTrack.baseUrl;
+      }
       const capUrl = new URL(captionTrack.baseUrl);
       const events = await this.#getSubtitleEvents(
         capUrl,


### PR DESCRIPTION
在 chrome 中开启设备模拟时测试有效，是字幕链接少了 `https` 前缀。