### PR TITLE
feat: add blur translation. 增加模糊译文的功能

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2521,6 +2521,13 @@ export const I18N = {
     ja: `バイリンガル表示`,
     ko: `이중 언어 표시`,
   },
+  is_blur_translation: {
+    zh: `模糊译文`,
+    en: `Blur Translation`,
+    zh_TW: `模糊譯文`,
+    ja: `翻訳をぼかす`,
+    ko: `번역 흐림`,
+  },
   is_skip_ad: {
     zh: `快进广告`,
     en: `Skip AD`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -132,6 +132,7 @@ export const DEFAULT_SUBTITLE_SETTING = {
   // fromLang: "en",
   toLang: "zh-CN",
   isBilingual: true, // 是否双语显示
+  blurTranslation: false, // 是否模糊译文
   skipAd: false, // 是否快进广告
   windowStyle: SUBTITLE_WINDOW_STYLE, // 背景样式
   originStyle: SUBTITLE_ORIGIN_STYLE, // 原文样式

--- a/src/subtitle/BilingualSubtitleManager.js
+++ b/src/subtitle/BilingualSubtitleManager.js
@@ -808,6 +808,17 @@ export class BilingualSubtitleManager {
         this.#captionWindowEl.replaceChildren(p2);
       }
 
+      if (this.#setting.blurTranslation) {
+        const blurValue = "blur(6px)";
+        p2.style.setProperty("filter", blurValue);
+        p2.addEventListener("pointerenter", () => {
+          p2.style.removeProperty("filter");
+        });
+        p2.addEventListener("pointerleave", () => {
+          p2.style.setProperty("filter", blurValue);
+        });
+      }
+
       if (isHoverLookupEnabled) {
         this.#attachSpanListeners();
       }

--- a/src/subtitle/Menus.js
+++ b/src/subtitle/Menus.js
@@ -226,7 +226,14 @@ export function Menus({
     return i18n("processing_subtitles");
   }, [progressed, i18n]);
 
-  const { segSlug, skipAd, isBilingual, showOrigin, aiContextSlug } = formData;
+  const {
+    segSlug,
+    skipAd,
+    isBilingual,
+    blurTranslation,
+    showOrigin,
+    aiContextSlug,
+  } = formData;
 
   return (
     <div
@@ -263,6 +270,12 @@ export function Menus({
         name="isBilingual"
         value={isBilingual}
         label={i18n("is_bilingual_view")}
+      />
+      <Switch
+        onChange={handleChange}
+        name="blurTranslation"
+        value={blurTranslation}
+        label={i18n("is_blur_translation")}
       />
       <Switch
         onChange={handleChange}

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -212,7 +212,7 @@ class YouTubeCaptionProvider {
 
     this.#updateMenuProps(); // 更新菜单 props
 
-    if (name === "isBilingual") {
+    if (name === "isBilingual" || name === "blurTranslation") {
       this.#managerInstance?.updateSetting({ [name]: value });
     } else if (name === "segSlug") {
       this.#reProcessEvents();
@@ -260,6 +260,7 @@ class YouTubeCaptionProvider {
       segSlug,
       skipAd,
       isBilingual,
+      blurTranslation,
       showOrigin,
       aiContextSlug,
     } = this.#setting;
@@ -273,6 +274,7 @@ class YouTubeCaptionProvider {
         segSlug,
         skipAd,
         isBilingual,
+        blurTranslation,
         showOrigin,
         aiContextSlug,
       },

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -257,6 +257,7 @@ export default function SubtitleSetting() {
     throttleTrans = 30,
     toLang,
     isBilingual,
+    blurTranslation = false,
     enhanceMode,
     hoverLookupMode,
     showList = OPT_ENHANCE_MOBILE_OFF,
@@ -660,6 +661,20 @@ export default function SubtitleSetting() {
                 name="isBilingual"
                 value={isBilingual}
                 label={i18n("is_bilingual_view")}
+                onChange={handleChange}
+              >
+                <MenuItem value={true}>{i18n("enable")}</MenuItem>
+                <MenuItem value={false}>{i18n("disable")}</MenuItem>
+              </TextField>
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                fullWidth
+                select
+                size="small"
+                name="blurTranslation"
+                value={blurTranslation}
+                label={i18n("is_blur_translation")}
                 onChange={handleChange}
               >
                 <MenuItem value={true}>{i18n("enable")}</MenuItem>


### PR DESCRIPTION
简要说明：为 Youtube 视频的字幕翻译增加**模糊译文**的功能，当鼠标放上去时才显示译文。

相关讨论：#686

UI 改动：

1. 在配置页面的**字幕翻译**区域中新增配置项**模糊译文**，其位置紧跟在 "双语显示" 的按钮之后，默认禁用

2. 在视频底部小弹窗中新增按钮**模糊译文**，其位置紧跟在 "双语显示" 的按钮之后 —— 和讨论帖中的截图不同，实际已经修改