### PR TITLE
feat: 为右键菜单添加翻译选中文本、仅译文选项立即执行翻译

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "Eine minimalistische zweisprachige Übersetzungserweiterung, die Webseiten-, Textauswahl- und Videountertitel-Übersetzung unterstützt."
   },
+  "translate_selection": {
+    "message": "\"%s\" übersetzen"
+  },
   "toggle_translate": {
     "message": "Übersetzung umschalten"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "A minimalist bilingual translation extension that supports webpage, text selection, and video subtitle translation."
   },
+  "translate_selection": {
+    "message": "Translate \"%s\""
+  },
   "toggle_translate": {
     "message": "Toggle Translation"
   },

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "Una extensión de traducción bilingüe minimalista que admite la traducción de páginas web, selección de texto y subtítulos de video."
   },
+  "translate_selection": {
+    "message": "Traducir \"%s\""
+  },
   "toggle_translate": {
     "message": "Alternar traducción"
   },

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "Une extension de traduction bilingue minimaliste prenant en charge la traduction de pages web, de texte sélectionné et de sous-titres vidéo."
   },
+  "translate_selection": {
+    "message": "Traduire \"%s\""
+  },
   "toggle_translate": {
     "message": "Activer/désactiver la traduction"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "Webサイト、テキスト選択、動画字幕などの翻訳に対応した、シンプルで直感的な二言語対応翻訳拡張機能。複数の翻訳サービスやAI翻訳APIをサポートし、豊富で柔軟なカスタマイズオプションを備えています。"
   },
+  "translate_selection": {
+    "message": "「%s」を翻訳"
+  },
   "toggle_translate": {
     "message": "翻訳の切り替え"
   },

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "웹페이지, 단어 선택, 동영상 자막 번역 등을 지원하는 심플한 이중 언어 대조 번역 확장 프로그램. 다양한 번역 서비스 및 AI 번역 인터페이스를 지원하며, 풍부하고 유연한 사용자 설정 옵션을 제공합니다."
   },
+  "translate_selection": {
+    "message": "\"%s\" 번역"
+  },
   "toggle_translate": {
     "message": "번역 켜기"
   },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "一个简约的双语对照翻译扩展，支持网页、划词、视频字幕翻译等功能，支持多种翻译服务及AI翻译接口，拥有丰富灵活的自定义选项。"
   },
+  "translate_selection": {
+    "message": "翻译 \"%s\""
+  },
   "toggle_translate": {
     "message": "开启翻译"
   },

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -5,6 +5,9 @@
   "app_description": {
     "message": "一個簡約的雙語對照翻譯擴充功能，支持網頁、劃詞、影片字幕翻譯等功能，支持多種翻譯服務及 AI 翻譯接口，擁有豐富靈活的自定義選項。"
   },
+  "translate_selection": {
+    "message": "翻譯 \"%s\""
+  },
   "toggle_translate": {
     "message": "開啟翻譯"
   },

--- a/src/background.js
+++ b/src/background.js
@@ -227,8 +227,13 @@ async function addContextMenus(contextMenuType = 1) {
     case 1:
       browser.contextMenus.create({
         id: CMD_TOGGLE_TRANSLATE,
-        title: browser.i18n.getMessage("app_name"),
-        contexts: ["page", "selection"],
+        title: browser.i18n.getMessage("toggle_translate"),
+        contexts: ["page"],
+      });
+      browser.contextMenus.create({
+        id: CMD_OPEN_TRANBOX,
+        title: browser.i18n.getMessage("translate_selection"),
+        contexts: ["selection"],
       });
       break;
     case 2:

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -2252,8 +2252,13 @@ export class Translator {
   }
 
   toggleTransOnly() {
-    const newValue = this.#rule.transOnly === "true" ? "false" : "true";
-    this.updateRule({ transOnly: newValue });
+    if (!this.#enabled) {
+      this.#rule.transOnly = "true";
+      this.enable();
+    } else {
+      const newValue = this.#rule.transOnly === "true" ? "false" : "true";
+      this.updateRule({ transOnly: newValue });
+    }
   }
 
   // 快速切换模糊样式


### PR DESCRIPTION
1.简单右键菜单下添加右键翻译选中文本
2.未开启翻译时右键”仅显示译文“选项立即执行翻译