### PR TITLE
fix: make the extension work on the about:blank page

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -20,7 +20,8 @@
         "<all_urls>",
         "file://*/*"
       ],
-      "all_frames": true
+      "all_frames": true,
+      "match_about_blank": true
     }
   ],
   "web_accessible_resources": [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,7 +19,8 @@
         "<all_urls>",
         "file://*/*"
       ],
-      "all_frames": true
+      "all_frames": true,
+      "match_about_blank": true
     }
   ],
   "web_accessible_resources": [

--- a/public/manifest.thunderbird.json
+++ b/public/manifest.thunderbird.json
@@ -26,7 +26,8 @@
         "<all_urls>",
         "file://*/*"
       ],
-      "all_frames": true
+      "all_frames": true,
+      "match_about_blank": true
     }
   ],
   "web_accessible_resources": [


### PR DESCRIPTION
简要说明：让脚本能注入到 `about:blank` 页面中，因为部分网页可能会将消息写入到这样的 iframe 中。

相关讨论： #696 