### PR TITLE
feat: 代码型输入框使用等宽字体 (#700)

### DIFF
--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import CodeField from "./CodeField";
 import Button from "@mui/material/Button";
 import LoadingButton from "@mui/lab/LoadingButton";
 import MenuItem from "@mui/material/MenuItem";
@@ -452,13 +453,12 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
 
       {apiType === OPT_TRANS_CUSTOMIZE && (
         <>
-          <TextField
+          <CodeField
             size="small"
             label={"Request Hook"}
             name="reqHook"
             value={reqHook}
             onChange={handleChange}
-            multiline
             maxRows={10}
             FormHelperTextProps={{
               component: "div",
@@ -469,13 +469,12 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
               </Box>
             }
           />
-          <TextField
+          <CodeField
             size="small"
             label={"Response Hook"}
             name="resHook"
             value={resHook}
             onChange={handleChange}
-            multiline
             maxRows={10}
             FormHelperTextProps={{
               component: "div",
@@ -877,23 +876,21 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
           {apiType !== OPT_TRANS_BUILTINAI && (
             <>
               {" "}
-              <TextField
+              <CodeField
                 size="small"
                 label={i18n("custom_header")}
                 name="customHeader"
                 value={customHeader}
                 onChange={handleChange}
-                multiline
                 maxRows={10}
                 helperText={i18n("custom_header_help")}
               />
-              <TextField
+              <CodeField
                 size="small"
                 label={i18n("custom_body")}
                 name="customBody"
                 value={customBody}
                 onChange={handleChange}
-                multiline
                 maxRows={10}
                 helperText={i18n("custom_body_help")}
               />
@@ -903,13 +900,12 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
           {apiType !== OPT_TRANS_CUSTOMIZE &&
             apiType !== OPT_TRANS_BUILTINAI && (
               <>
-                <TextField
+                <CodeField
                   size="small"
                   label={"Request Hook"}
                   name="reqHook"
                   value={reqHook}
                   onChange={handleChange}
-                  multiline
                   maxRows={10}
                   FormHelperTextProps={{
                     component: "div",
@@ -920,13 +916,12 @@ function ApiFields({ apiSlug, isUserApi, deleteApi, copyApi, onCollapse }) {
                     </Box>
                   }
                 />
-                <TextField
+                <CodeField
                   size="small"
                   label={"Response Hook"}
                   name="resHook"
                   value={resHook}
                   onChange={handleChange}
-                  multiline
                   maxRows={10}
                   FormHelperTextProps={{
                     component: "div",

--- a/src/views/Options/CodeField.js
+++ b/src/views/Options/CodeField.js
@@ -1,0 +1,25 @@
+import TextField from "@mui/material/TextField";
+
+const MONO_FONT =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+
+/**
+ * 用于编辑代码型内容（CSS、JS Hook、JSON、CSS 选择器等）的 TextField。
+ * 默认 multiline + 等宽字体，其余 props 透传。
+ */
+export default function CodeField({ InputProps, ...rest }) {
+  return (
+    <TextField
+      multiline
+      {...rest}
+      InputProps={{
+        ...InputProps,
+        sx: {
+          fontFamily: MONO_FONT,
+          fontSize: "0.875rem",
+          ...(InputProps?.sx || {}),
+        },
+      }}
+    />
+  );
+}

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import CodeField from "./CodeField";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import Alert from "@mui/material/Alert";
@@ -231,7 +232,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
   return (
     <form onSubmit={handleSubmit}>
       <Stack spacing={2}>
-        <TextField
+        <CodeField
           size="small"
           label={i18n("pattern")}
           error={!!errors.pattern}
@@ -241,9 +242,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
           disabled={rule?.pattern === "*" || disabled}
           onChange={handleChange}
           onFocus={handleFocus}
-          multiline
         />
-        <TextField
+        <CodeField
           size="small"
           label={i18n("root_selector")}
           helperText={i18n("root_selector_helper")}
@@ -251,9 +251,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
           value={rootsSelector}
           disabled={disabled}
           onChange={handleChange}
-          multiline
         />
-        <TextField
+        <CodeField
           size="small"
           label={i18n("ignore_selector")}
           helperText={i18n("ignore_selector_helper")}
@@ -261,9 +260,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
           value={ignoreSelector}
           disabled={disabled}
           onChange={handleChange}
-          multiline
         />
-        <TextField
+        <CodeField
           size="small"
           label={i18n("target_selector")}
           error={!!errors.selector}
@@ -273,9 +271,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
           disabled={autoScan === "true" || disabled}
           onChange={handleChange}
           onFocus={handleFocus}
-          multiline
         />
-        <TextField
+        <CodeField
           size="small"
           label={i18n("keep_selector")}
           helperText={i18n("keep_selector_helper")}
@@ -283,7 +280,6 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
           value={keepSelector}
           disabled={disabled}
           onChange={handleChange}
-          multiline
         />
 
         <Box>
@@ -608,7 +604,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               maxRows={10}
             />
 
-            <TextField
+            <CodeField
               size="small"
               label={i18n("terms_style")}
               name="termsStyle"
@@ -616,9 +612,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("highlight_style")}
               name="highlightStyle"
@@ -626,9 +621,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("text_ext_style")}
               name="textExtStyle"
@@ -636,9 +630,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("selector_style")}
               name="selectStyle"
@@ -646,9 +639,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("selector_parent_style")}
               name="parentStyle"
@@ -656,9 +648,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("selector_grand_style")}
               name="grandStyle"
@@ -666,10 +657,9 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
 
-            <TextField
+            <CodeField
               size="small"
               label={i18n("translate_start_hook")}
               helperText={i18n("translate_start_hook_helper")}
@@ -677,10 +667,9 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               value={transStartHook}
               disabled={disabled}
               onChange={handleChange}
-              multiline
               maxRows={10}
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("translate_end_hook")}
               helperText={i18n("translate_end_hook_helper")}
@@ -688,7 +677,6 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               value={transEndHook}
               disabled={disabled}
               onChange={handleChange}
-              multiline
               maxRows={10}
             />
             {/* <TextField
@@ -703,7 +691,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               maxRows={10}
             /> */}
 
-            <TextField
+            <CodeField
               size="small"
               label={i18n("inject_css")}
               helperText={i18n("inject_css_helper")}
@@ -712,9 +700,8 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
-            <TextField
+            <CodeField
               size="small"
               label={i18n("inject_js")}
               helperText={i18n("inject_js_helper")}
@@ -723,7 +710,6 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
               disabled={disabled}
               onChange={handleChange}
               maxRows={10}
-              multiline
             />
           </>
         )}

--- a/src/views/Options/StylesSetting.js
+++ b/src/views/Options/StylesSetting.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import CodeField from "./CodeField";
 import Button from "@mui/material/Button";
 import { useI18n } from "../../hooks/I18n";
 import Typography from "@mui/material/Typography";
@@ -95,13 +96,12 @@ function StyleFields({ customStyle, deleteStyle, updateStyle, isBuiltin }) {
         onChange={handleChange}
         disabled={isBuiltin}
       />
-      <TextField
+      <CodeField
         size="small"
         label={i18n("style_code")}
         name="styleCode"
         value={styleCode}
         onChange={handleChange}
-        multiline
         maxRows={10}
         disabled={isBuiltin}
       />

--- a/src/views/Options/Subtitle.js
+++ b/src/views/Options/Subtitle.js
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import CodeField from "./CodeField";
 import MenuItem from "@mui/material/MenuItem";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
@@ -954,38 +955,35 @@ export default function SubtitleSetting() {
               <AccordionDetails>
                 <Grid container spacing={2}>
                   <Grid item xs={12} sm={4}>
-                    <TextField
+                    <CodeField
                       size="small"
                       label={i18n("origin_styles")}
                       name="originStyle"
                       value={originStyle}
                       onChange={handleChange}
                       maxRows={10}
-                      multiline
                       fullWidth
                     />
                   </Grid>
                   <Grid item xs={12} sm={4}>
-                    <TextField
+                    <CodeField
                       size="small"
                       label={i18n("translation_styles")}
                       name="translationStyle"
                       value={translationStyle}
                       onChange={handleChange}
                       maxRows={10}
-                      multiline
                       fullWidth
                     />
                   </Grid>
                   <Grid item xs={12} sm={4}>
-                    <TextField
+                    <CodeField
                       size="small"
                       label={i18n("background_styles")}
                       name="windowStyle"
                       value={windowStyle}
                       onChange={handleChange}
                       maxRows={10}
-                      multiline
                       fullWidth
                     />
                   </Grid>


### PR DESCRIPTION
Closes #700

按 #700 中讨论的方案 B 实现：新增 `CodeField` 组件包装 `TextField`，仅对明确属于代码/结构化文本的字段使用等宽字体，其余字段保持原样。

本 PR 的边界是：只处理代码型/结构化输入内容，例如 CSS、JavaScript hooks、JSON、选择器；prompt、词条、黑名单、颜色 hex 等非纯代码字段保持默认字体。

## 改动

- 新增 `src/views/Options/CodeField.js`
- 替换 25 处代码型输入框：
  - `Apis.js`: `reqHook` (x2), `resHook` (x2), `customHeader`, `customBody`
  - `StylesSetting.js`: `styleCode`
  - `Rules.js`: `pattern`, `rootsSelector`, `ignoreSelector`, `selector`, `keepSelector`, `termsStyle`, `highlightStyle`, `textExtStyle`, `selectStyle`, `parentStyle`, `grandStyle`, `transStartHook`, `transEndHook`, `injectCss`, `injectJs`
  - `Subtitle.js`: `originStyle`, `translationStyle`, `windowStyle`

## 未改动

- prompt 类字段：`systemPrompt`, `nobatchPrompt`, `nobatchUserPrompt`, `subtitlePrompt`
- 词条类字段：`terms`, `aiTerms`
- 黑名单等多 URL 列表、颜色 hex、字号等单值输入

## 验证

- `pnpm exec prettier --write src/views/Options/CodeField.js src/views/Options/Apis.js src/views/Options/Rules.js src/views/Options/StylesSetting.js src/views/Options/Subtitle.js`
- `pnpm build:chrome`
- `pnpm run test --watchAll=false --passWithNoTests`（仓库当前没有测试）
- `git diff --check`
- 手动验证 Options 页面（Chrome 扩展模式加载 `build/chrome`，以及通过 `pnpm start` 在 `http://localhost:3000/options.html` 实时调试）：
  - 代码型字段使用等宽字体
  - 字幕翻译的高级 CSS 编辑字段使用等宽字体
  - prompt / terms / blacklist 等非代码字段未受影响
  - 暗色模式显示正常