### PR TITLE
fix: 字幕列表面板在约8分钟后停止渲染

### DIFF
--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -136,7 +136,7 @@ export class YouTubeSubtitleList {
     const CHUNK_SIZE = 100;
     const subtitles = this.bilingualSubtitles;
 
-    this._cachedSubtitleItems = new Array(subtitles.length);
+    this._cachedSubtitleItems = [];
 
     const renderNextChunk = (startIndex) => {
       if (startIndex >= subtitles.length || !this.subtitleListEl) return;


### PR DESCRIPTION
https://www.youtube.com/watch?v=WvrfLa2MaAo
<img width="3402" height="886" alt="image" src="https://github.com/user-attachments/assets/dd1ac250-7e8e-4303-a003-975668c60b86" />

背景

使用 AI 断句处理长视频时，右侧双语字幕列表（YouTubeSubtitleList）在约8分钟后停止显示新条目。播放器叠加字幕仍正常、VTT 下载也包含完整数据，仅面板截断。

根因是 _renderSubtitlesInChunks 使用 new Array(subtitles.length) 预分配缓存数组。该稀疏数组的 .length 等于总字幕数，而非实际已渲染的 DOM 数量。当 #processRemainingChunksAsync 完成 AI 分段后调用 setBilingualSubtitles 追加新字幕时，updateBilingualSubtitles 先调 _cancelChunkRender() 取消了尚在进行的分块渲染（items 100+ 未完成），再用 _cachedSubtitleItems.length（已是预分配的总数 N）判断追加起点——导致 items 100 ~ N-1 永远未被渲染到 DOM，自动滚动在这些索引处拿到 undefined 后静默跳过，面板冻结。

改动

1. 缓存数组改为空数组初始化（ c4a042d ）

new Array(subtitles.length) → []，使 .length 正确反映已渲染的 DOM 元素数量。当分块渲染被中途取消后，追加分支从实际渲染位置继续填补缺失条目。