### PR TITLE
fix: 修复悬浮按钮被滚动条遮挡的问题

### DIFF
--- a/src/hooks/WindowSize.js
+++ b/src/hooks/WindowSize.js
@@ -3,14 +3,14 @@ import { useDebouncedCallback } from "./DebouncedCallback";
 
 function useWindowSize() {
   const [windowSize, setWindowSize] = useState({
-    w: window.innerWidth,
-    h: window.innerHeight,
+    w: document.documentElement.clientWidth,
+    h: document.documentElement.clientHeight,
   });
 
   const debounceWindowResize = useDebouncedCallback(() => {
     setWindowSize({
-      w: window.innerWidth,
-      h: window.innerHeight,
+      w: document.documentElement.clientWidth,
+      h: document.documentElement.clientHeight,
     });
   }, 200);
 


### PR DESCRIPTION
使用不含滚动条的窗口尺寸
<img width="100" height="200" alt="image" src="https://github.com/user-attachments/assets/af503474-c6de-48b6-a766-cfc30a21f933" />