### PR TITLE
fix: performance issue caused by repeatedly setting style properties

### DIFF
--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -960,6 +960,7 @@ export class YouTubeSubtitleList {
 
       const currentTimeMs = this.videoEl.currentTime * 1000;
       let currentIndex = this._binarySearchSubtitle(currentTimeMs);
+      if (this._lastActiveIndex === currentIndex) return;
 
       if (
         this.subtitleListEl &&


### PR DESCRIPTION
简要说明：在设置字幕列表的样式时，没有进行重复性验证，导致频繁设置了元素的 css 属性、读写 `offsetTop` 等属性，造成了性能损耗。

相关讨论： #710 