### PR TITLE
perf: reduce animation effects for YouTube subtitle item interactions

### DIFF
--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -337,7 +337,6 @@ export class YouTubeSubtitleList {
             "--kt-primary": "#1e88e5",
             "--kt-time-bg": "rgba(30, 136, 229, 0.1)",
             "--kt-divider": "rgba(240,240,240,0.6)",
-            "--kt-item-hover-bg": "rgba(30, 136, 229, 0.05)",
             "--kt-active-bg": "rgba(30, 136, 229, 0.1)",
             "--kt-btn-bg": "var(--kt-primary)",
             "--kt-btn-color": "white",
@@ -353,7 +352,6 @@ export class YouTubeSubtitleList {
             "--kt-primary": "#90caf9",
             "--kt-time-bg": "rgba(144,202,249,0.08)",
             "--kt-divider": "rgba(255,255,255,0.06)",
-            "--kt-item-hover-bg": "rgba(255,255,255,0.02)",
             "--kt-active-bg": "rgba(144,202,249,0.12)",
             "--kt-btn-bg": "linear-gradient(180deg,#0f0f0f,#1b1b1b)",
             "--kt-btn-color": "#e6e6e6",
@@ -514,7 +512,7 @@ export class YouTubeSubtitleList {
     li.id = `kiss-youtube-item-${index}`;
     li.className = "kiss-youtube-item";
     li.dataset.time = sub.start;
-    li.style.cssText = `cursor: pointer; padding: 12px 16px; border-bottom: 1px solid var(--kt-divider); transition: all 0.2s ease; border-radius: 6px; margin-bottom: 4px; display: flex; align-items: flex-start;`;
+    li.style.cssText = `cursor: pointer; padding: 12px 16px; border-bottom: 1px solid var(--kt-divider); transition: opacity 0.2s ease; opacity: 0.6; border-radius: 6px; margin-bottom: 4px; display: flex; align-items: flex-start;`;
 
     // 播放时间指示器 span
     const timeSpan = document.createElement("span");
@@ -542,11 +540,11 @@ export class YouTubeSubtitleList {
     li.addEventListener("click", () => this.jumpToTime(sub.start));
     li.addEventListener("mouseenter", () => {
       if (!li.classList.contains("active-subtitle"))
-        li.style.backgroundColor = "var(--kt-item-hover-bg)";
+        li.style.opacity = 1;
     });
     li.addEventListener("mouseleave", () => {
       if (!li.classList.contains("active-subtitle"))
-        li.style.backgroundColor = "transparent";
+        li.style.opacity = 0.6;
     });
 
     textContainer.appendChild(textSpan);
@@ -988,15 +986,13 @@ export class YouTubeSubtitleList {
           this._cachedSubtitleItems[this._lastActiveIndex]
         ) {
           const lastEl = this._cachedSubtitleItems[this._lastActiveIndex];
-          lastEl.style.fontWeight = "normal";
-          lastEl.style.backgroundColor = "transparent";
+          lastEl.style.opacity = 0.6;
           lastEl.classList.remove("active-subtitle");
         }
 
         // 高亮当前字幕行，并设置粗体字
         const currentEl = this._cachedSubtitleItems[currentIndex];
-        currentEl.style.fontWeight = "600";
-        currentEl.style.backgroundColor = "var(--kt-active-bg)";
+        currentEl.style.opacity = 1;
         currentEl.classList.add("active-subtitle");
         this._lastActiveIndex = currentIndex;
 


### PR DESCRIPTION
简要说明：此前在字幕列表中的动画使用 `transition`，作用于 `background-color`，性能开销较大，所以现在修改其基于 `opacity`。

- 字幕默认情况下为 `opacity: 0.6`
- 高亮时为 `opacity: 1`

以下是实际的效果，第一个字幕高亮，第二个字幕是默认状态。

<img width="443" height="201" alt="image" src="https://github.com/user-attachments/assets/f0723dc9-29d5-4d38-ab72-f956c38dc2ec" />

---

这是在使用 `transition background-color` 时的性能开销，注意到底部的 `rendering、painting` 消耗。

<img width="1676" height="762" alt="Image" src="https://github.com/user-attachments/assets/565a4248-f992-48a4-859e-b77c8334d3e6" />

这是使用 `transition opacity` 时的性能开销。

<img width="1602" height="489" alt="Image" src="https://github.com/user-attachments/assets/db04edf9-dd8e-443d-9f5c-75d91b962264" />


修改范围：

- 字幕滚动时的动画
- 鼠标 `hover` 时的动画 


相关讨论： #710 