### PR TITLE
feat: add iframe whitelist

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -9,7 +9,7 @@ import { genEventName } from "./libs/utils";
 import { handlePing, injectScript } from "./libs/gm";
 import { matchRule } from "./libs/rules";
 import { trySyncAllSubRules } from "./libs/subRules";
-import { isInBlacklist } from "./libs/blacklist";
+import { isInBlacklist, isInWhitelist } from "./libs/blacklist";
 import { runSubtitle } from "./subtitle/subtitle";
 import { logger } from "./libs/log";
 import { injectInlineJs } from "./libs/injector";
@@ -170,6 +170,11 @@ export async function run(isUserscript = false) {
 
     // 5. 网页黑名单校验，命中时彻底不启动翻译
     if (isInBlacklist(href, setting.blacklist)) {
+      return;
+    }
+
+    // 5.1. iframe 白名单校验：如果是 iframe，但不在白名单中，则提前退出
+    if (isIframe && !isInWhitelist(href, setting.iframeWhitelist)) {
       return;
     }
 

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1787,6 +1787,13 @@ export const I18N = {
     ja: `翻訳ブラックリスト`,
     ko: `번역 블랙리스트`,
   },
+  iframe_whitelist: {
+    zh: `iframe翻译白名单`,
+    en: `iframe Translate Whitelist`,
+    zh_TW: `iframe翻譯白名單`,
+    ja: `iframe翻訳ホワイトリスト`,
+    ko: `iframe 번역 화이트리스트`,
+  },
   blacklist: {
     zh: `禁用黑名单`,
     en: `Blacklist`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -38,6 +38,7 @@ export const DEFAULT_BLACKLIST = [
 ];
 export const DEFAULT_CSPLIST = []; // 默认禁用 CSP 安全策略的网址列表
 export const DEFAULT_ORILIST = ["https://dict.youdao.com"]; // 默认在跨域请求中需要重写 Origin 请求头的域名
+export const DEFAULT_IFRAME_WHITELIST = []; // 默认允许进入 iframe 翻译的网址/白名单列表
 
 // --- 配置同步设置 ---
 export const OPT_SYNCTYPE_WORKER = "KISS-Worker"; // 自建 Cloudflare Worker 同步方案
@@ -206,7 +207,9 @@ export const DEFAULT_SETTING = {
   // touchTranslate: 2, // 触屏翻译 {5:单指双击，6:单指三击，7:双指双击} (作废)
   touchModes: [2], // 触屏移动端翻译触发行为配置 (数组，支持多选，如单指双击/三击)
   blacklist: DEFAULT_BLACKLIST.join(",\n"), // 禁用整页双语翻译的网址/黑名单列表
+  iframeWhitelist: DEFAULT_IFRAME_WHITELIST.join(",\n"), // 允许进入 iframe 翻译的网址/白名单列表
   csplist: DEFAULT_CSPLIST.join(",\n"), // 强制禁用内容安全策略(CSP)以允许向翻译 API 发送请求的网址列表
+
   orilist: DEFAULT_ORILIST.join(",\n"), // 需要改写或删除 Cross-Origin HTTP 请求头的网址列表
   // disableLangs: [], // 不翻译的语言(移至rule，作废)
   skipLangs: [], // 忽略翻译的语种代码列表 (即如果网页检测到是这些语言，则不触发自动整页翻译)

--- a/src/libs/blacklist.js
+++ b/src/libs/blacklist.js
@@ -18,3 +18,16 @@ import { isMatch } from "./utils";
  */
 export const isInBlacklist = (href, blacklist = "") =>
   blacklist.split(/\n|,/).some((url) => isMatch(href, url.trim()));
+
+/**
+ * 检查当前网页 URL 是否处于配置的白名单列表中
+ * @param {string} href 当前页面的完整 URL (如 location.href)
+ * @param {string} [whitelist=""] 逗号或换行分隔的白名单网址/匹配模式列表
+ * @returns {boolean} 如果处于白名单中，返回 true；否则返回 false
+ */
+export const isInWhitelist = (href, whitelist = "") => {
+  if (!whitelist || !whitelist.trim()) {
+    return false;
+  }
+  return whitelist.split(/\n|,/).some((url) => isMatch(href, url.trim()));
+};

--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -539,12 +539,10 @@ export class YouTubeSubtitleList {
     // 交互事件绑定：点击字幕跳跃视频播放时间点，鼠标悬停高亮
     li.addEventListener("click", () => this.jumpToTime(sub.start));
     li.addEventListener("mouseenter", () => {
-      if (!li.classList.contains("active-subtitle"))
-        li.style.opacity = 1;
+      if (!li.classList.contains("active-subtitle")) li.style.opacity = 1;
     });
     li.addEventListener("mouseleave", () => {
-      if (!li.classList.contains("active-subtitle"))
-        li.style.opacity = 0.6;
+      if (!li.classList.contains("active-subtitle")) li.style.opacity = 0.6;
     });
 
     textContainer.appendChild(textSpan);

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -22,6 +22,7 @@ import {
   DEFAULT_BLACKLIST,
   DEFAULT_CSPLIST,
   DEFAULT_ORILIST,
+  DEFAULT_IFRAME_WHITELIST,
   MSG_CONTEXT_MENUS,
   MSG_UPDATE_CSP,
   DEFAULT_HTTP_TIMEOUT,
@@ -110,6 +111,7 @@ export default function Settings() {
     contextMenuType = 1,
     touchModes = [2],
     blacklist = DEFAULT_BLACKLIST.join(",\n"),
+    iframeWhitelist = DEFAULT_IFRAME_WHITELIST.join(",\n"),
     csplist = DEFAULT_CSPLIST.join(",\n"),
     orilist = DEFAULT_ORILIST.join(",\n"),
     transInterval = 100,
@@ -382,6 +384,18 @@ export default function Settings() {
           helperText={i18n("pattern_helper")}
           name="blacklist"
           value={blacklist}
+          onChange={handleChange}
+          maxRows={10}
+          multiline
+        />
+
+        {/* iframe 网页翻译的白名单域名匹配列表 (一行一条) */}
+        <TextField
+          size="small"
+          label={i18n("iframe_whitelist")}
+          helperText={i18n("pattern_helper")}
+          name="iframeWhitelist"
+          value={iframeWhitelist}
           onChange={handleChange}
           maxRows={10}
           multiline


### PR DESCRIPTION
在某些情况下，进入 iframe 页面翻译可能引起页面崩溃。

鉴于 iframe 页面的翻译需求并不常见，特增加一个白名单设置，只有加入白名单的页面才进入 iframe 并翻译，默认不翻译。