### PR TITLE
fix: sync YouTube subtitle button state

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -51,6 +51,7 @@ class YouTubeCaptionProvider {
   #notificationTimeout = null;
   #i18n = () => "";
   #menuManager = null; // 菜单管理器实例
+  #ytSubtitleStateObserver = null;
 
   // 新增：字幕列表管理器实例
   #subtitleListManager = null;
@@ -111,13 +112,7 @@ class YouTubeCaptionProvider {
     this.#waitForElement(CONTORLS_SELECT, (ytControls) => {
       const ytSubtitleBtn = ytControls.querySelector(YT_SUBTITLE_BTN_SELECT);
       if (ytSubtitleBtn) {
-        ytSubtitleBtn.addEventListener("click", () => {
-          if (ytSubtitleBtn.getAttribute("aria-pressed") === "true") {
-            this.#startManager();
-          } else {
-            this.#destroyManager();
-          }
-        });
+        this.#observeYtSubtitleState(ytSubtitleBtn);
       }
 
       this.#injectToggleButton(ytControls);
@@ -126,6 +121,33 @@ class YouTubeCaptionProvider {
     this.#waitForElement(YT_AD_SELECT, (adContainer) => {
       this.#moAds(adContainer);
     });
+  }
+
+  #observeYtSubtitleState(ytSubtitleBtn) {
+    this.#ytSubtitleStateObserver?.disconnect();
+    this.#ytSubtitleStateObserver = new MutationObserver(() => {
+      this.#syncYtSubtitleState(ytSubtitleBtn);
+    });
+    this.#ytSubtitleStateObserver.observe(ytSubtitleBtn, {
+      attributes: true,
+      attributeFilter: ["aria-pressed"],
+    });
+    this.#syncYtSubtitleState(ytSubtitleBtn);
+  }
+
+  #syncYtSubtitleState(ytSubtitleBtn) {
+    if (ytSubtitleBtn.getAttribute("aria-pressed") === "true") {
+      this.#startManager();
+    } else {
+      this.#destroyManager();
+    }
+  }
+
+  #isYtSubtitleEnabled() {
+    const ytSubtitleBtn = document.querySelector(YT_SUBTITLE_BTN_SELECT);
+    return (
+      !ytSubtitleBtn || ytSubtitleBtn.getAttribute("aria-pressed") === "true"
+    );
   }
 
   #moAds(adContainer) {
@@ -994,6 +1016,10 @@ class YouTubeCaptionProvider {
   }
 
   #startManager() {
+    if (!this.#isYtSubtitleEnabled()) {
+      return;
+    }
+
     if (this.#managerInstance) {
       return;
     }


### PR DESCRIPTION
当前控制字幕开关状态，取决于ytSubtitleBtn，是否触发click动作，但是youtube自身有快捷键c用于启用和关闭cc字幕。
这就会导致一个问题，用c键开关字幕，并不会触发click，也就做不到控制开关，并且，当用户点击字幕按钮关闭字幕后，再使用c键，还会拉起youtube的原生字幕。

现在改为监听youtube字幕按钮的aria-pressed状态变化，并以该状态作为字幕开关依据。这样无论用户点击按钮还是按c键，字幕都会跟随youtube原生字幕状态同步开启或关闭。