### PR TITLE
fix: simplify subtitle segmentation

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -38,7 +38,6 @@ class YouTubeCaptionProvider {
   #fromLang = "auto";
   #docInfo = {};
   #fullDescription = "";
-  #interceptedCaptionKind = null;
 
   #processingId = null;
   #processingVersion = 0;
@@ -102,7 +101,6 @@ class YouTubeCaptionProvider {
       this.#fromLang = "auto";
       this.#docInfo = {};
       this.#fullDescription = "";
-      this.#interceptedCaptionKind = null;
       this.#processingId = null;
       this.#processingVersion += 1;
       this.#activeTrackKey = null;
@@ -708,7 +706,6 @@ class YouTubeCaptionProvider {
       this.#flatEvents = [];
       this.#progressed = 0;
       this.#activeTrackKey = null;
-      this.#interceptedCaptionKind = null;
     }
 
     try {
@@ -764,7 +761,6 @@ class YouTubeCaptionProvider {
       this.#events = events;
       this.#flatEvents = flatEvents;
       this.#fromLang = fromLang;
-      this.#interceptedCaptionKind = interceptedKind;
       this.#activeTrackKey = trackKey;
       this.#docInfo = getDocInfo();
       await this.#enrichDocInfoWithAI(flatEvents, processingVersion);
@@ -926,9 +922,10 @@ class YouTubeCaptionProvider {
     const { segSlug, transApis, chunkLength, toLang } = this.#setting;
 
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
-    const isAutoCaption = this.#interceptedCaptionKind === "asr";
+    const useAiSegmentation = segSlug && segSlug !== "-" && segApiSetting;
 
-    if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
+    // 断句策略仅由用户配置的 segSlug 决定；kind 只负责定位用户实际选择的字幕轨道。
+    if (useAiSegmentation) {
       if (this.#isStaleProcessing(processingVersion)) return [[], 0];
       logger.info("Youtube Provider: Starting AI segmentation...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
@@ -975,14 +972,7 @@ class YouTubeCaptionProvider {
       return [firstBatchSubtitles, 100];
     }
 
-    if (isAutoCaption) {
-      return [this.#builtinSegment(events, flatEvents, fromLang), 100];
-    }
-
-    logger.info(
-      "Youtube Provider: Sentence break mode: MANUAL (human caption)"
-    );
-    return [flatEvents.filter((e) => e.text), 100];
+    return [this.#builtinSegment(events, flatEvents, fromLang), 100];
   }
 
   #builtinSegment(events, flatEvents, fromLang) {


### PR DESCRIPTION
修改了当前youtube字幕断句逻辑。
现在不再通过 `kind === "asr"` 判断是否断句，而是统一由 `segSlug` 控制：
- 启用 `segSlug`：走 AI 断句
- 未启用 `segSlug`：走内置断句
`kind` 仍然保留用于匹配用户实际选择的字幕轨道，不再参与断句策略判断。

虽然实际上解决了 #722 的词级字幕的问题，不过内置断句对于[此视频](https://www.youtube.com/watch?v=GpQSUjNsNm0)的效果并不好，或许对于这种字幕需要专门的优化。

<img width="531" height="1128" alt="29b0b75a20d2058e" src="https://github.com/user-attachments/assets/9adb1ad9-fbf9-45d1-8feb-c7553ef26bcd" />