### PR TITLE
fix: 修复 YouTube 无 kind 词级字幕的逐词渲染、重复、怪空格与过早消失 (#722)

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -27,6 +27,8 @@ const CONTORLS_SELECT = ".ytp-right-controls";
 const YT_CAPTION_SELECT = "#ytp-caption-window-container";
 const YT_AD_SELECT = ".video-ads";
 const YT_SUBTITLE_BTN_SELECT = "button.ytp-subtitles-button";
+// 零宽字符（U+200B~U+200D、U+FEFF），个别 YouTube 轨用它做占位 seg
+const ZERO_WIDTH_RE = new RegExp("[\\u200B-\\u200D\\uFEFF]", "g");
 
 class YouTubeCaptionProvider {
   #setting = {};
@@ -797,6 +799,7 @@ class YouTubeCaptionProvider {
         return;
       }
 
+      this.#cleanOriginals(subtitles);
       this.#subtitles = subtitles;
       this.#progressed = progressed;
 
@@ -1372,6 +1375,19 @@ class YouTubeCaptionProvider {
     return out;
   }
 
+  // 清掉原文里的零宽字符和多余空格（个别轨用零宽 seg 占位，会让原文出现怪空格）
+  #cleanOriginals(subtitles = []) {
+    for (const sub of subtitles) {
+      if (sub?.text) {
+        sub.text = sub.text
+          .replace(ZERO_WIDTH_RE, "")
+          .replace(/\s+/g, " ")
+          .trim();
+      }
+    }
+    return subtitles;
+  }
+
   #genFlatEvents(events = []) {
     const segments = [];
     let buffer = null;
@@ -1380,6 +1396,7 @@ class YouTubeCaptionProvider {
       segs.forEach(({ utf8 = "", tOffsetMs = 0 }, j) => {
         const text = utf8
           .replace(/<[^>]+>/g, "")
+          .replace(ZERO_WIDTH_RE, "")
           .trim()
           .replace(/\s+/g, " ");
         const start = tStartMs + tOffsetMs;
@@ -1524,6 +1541,7 @@ class YouTubeCaptionProvider {
       }
 
       if (subtitlesForThisChunk.length > 0) {
+        this.#cleanOriginals(subtitlesForThisChunk);
         const progressed = Math.floor((chunkNum * 100) / chunks.length);
         this.#subtitles.push(...subtitlesForThisChunk);
         this.#subtitles.sort((a, b) => a.start - b.start);

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -715,10 +715,8 @@ class YouTubeCaptionProvider {
         captionTrack.baseUrl = window.location.origin + captionTrack.baseUrl;
       }
       const capUrl = new URL(captionTrack.baseUrl);
-      const events = await this.#getSubtitleEvents(
-        capUrl,
-        potUrl,
-        responseText
+      const events = this.#dedupeEvents(
+        await this.#getSubtitleEvents(capUrl, potUrl, responseText)
       );
       if (this.#isStaleProcessing(processingVersion)) return;
 
@@ -1356,6 +1354,22 @@ class YouTubeCaptionProvider {
     flushBuffer();
 
     return sentences;
+  }
+
+  // YouTube 个别字幕轨会把每个 event 原样重复两遍，去掉连续完全相同的 event
+  #dedupeEvents(events = []) {
+    const out = [];
+    let prevKey = null;
+    for (const e of events || []) {
+      const sig = (e.segs || [])
+        .map((s) => `${s.utf8 || ""}@${s.tOffsetMs || 0}`)
+        .join("|");
+      const key = `${e.tStartMs}|${e.dDurationMs}|${sig}`;
+      if (key === prevKey) continue;
+      out.push(e);
+      prevKey = key;
+    }
+    return out;
   }
 
   #genFlatEvents(events = []) {

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -29,6 +29,8 @@ const YT_AD_SELECT = ".video-ads";
 const YT_SUBTITLE_BTN_SELECT = "button.ytp-subtitles-button";
 // 零宽字符（U+200B~U+200D、U+FEFF），个别 YouTube 轨用它做占位 seg
 const ZERO_WIDTH_RE = new RegExp("[\\u200B-\\u200D\\uFEFF]", "g");
+// 记录字幕原始 end，延长尾巴时从原始值算，避免异步重算时累加
+const RAW_END = Symbol("rawEnd");
 
 class YouTubeCaptionProvider {
   #setting = {};
@@ -617,15 +619,11 @@ class YouTubeCaptionProvider {
         const gapCues = nonSpeechEvents
           .filter(
             (ns) =>
-              !result.some(
-                (sub) => ns.start < sub.end && ns.end > sub.start
-              )
+              !result.some((sub) => ns.start < sub.end && ns.end > sub.start)
           )
           .map(toStandaloneSub);
 
-        return [...result, ...gapCues].sort(
-          (a, b) => a.start - b.start
-        );
+        return [...result, ...gapCues].sort((a, b) => a.start - b.start);
       }
     } catch (err) {
       logger.info("Youtube Provider: ai segmentation", err);
@@ -800,6 +798,9 @@ class YouTubeCaptionProvider {
       }
 
       this.#cleanOriginals(subtitles);
+      if (this.#isWordLevelCaption(this.#events)) {
+        this.#extendSubtitleEnds(subtitles);
+      }
       this.#subtitles = subtitles;
       this.#progressed = progressed;
 
@@ -899,7 +900,13 @@ class YouTubeCaptionProvider {
     });
   }
 
-  async #eventsToSubtitles({ videoId, events, flatEvents, fromLang, processingVersion }) {
+  async #eventsToSubtitles({
+    videoId,
+    events,
+    flatEvents,
+    fromLang,
+    processingVersion,
+  }) {
     const { segSlug, transApis, chunkLength, toLang } = this.#setting;
 
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
@@ -1388,6 +1395,29 @@ class YouTubeCaptionProvider {
     return subtitles;
   }
 
+  // 词级字幕的 end 是最后一个词的时间槽末尾，太紧会让词没说完字幕就消失。
+  // 给 end 加一个温和的尾巴：封顶到下一句开始，最多延长 500ms，尽量保证 700ms 可读时长。
+  // 长停顿仍留空白（不做完整 gap-fill）；从原始 end 算保证幂等；重叠的收到下一句开始。
+  #extendSubtitleEnds(subtitles = []) {
+    const TAIL = 250;
+    const MIN_ON_SCREEN = 700;
+    const MAX_EXTEND = 500;
+    for (let i = 0; i < subtitles.length; i += 1) {
+      const sub = subtitles[i];
+      if (!sub) continue;
+      if (sub[RAW_END] == null) sub[RAW_END] = sub.end;
+      const rawEnd = sub[RAW_END];
+      const nextStart =
+        i + 1 < subtitles.length ? subtitles[i + 1].start : Infinity;
+      sub.end = Math.min(
+        nextStart,
+        rawEnd + MAX_EXTEND,
+        Math.max(rawEnd + TAIL, sub.start + MIN_ON_SCREEN)
+      );
+    }
+    return subtitles;
+  }
+
   #genFlatEvents(events = []) {
     const segments = [];
     let buffer = null;
@@ -1545,6 +1575,7 @@ class YouTubeCaptionProvider {
         const progressed = Math.floor((chunkNum * 100) / chunks.length);
         this.#subtitles.push(...subtitlesForThisChunk);
         this.#subtitles.sort((a, b) => a.start - b.start);
+        this.#extendSubtitleEnds(this.#subtitles);
         this.#progressed = progressed;
 
         logger.debug(

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -902,9 +902,12 @@ class YouTubeCaptionProvider {
     const { segSlug, transApis, chunkLength, toLang } = this.#setting;
 
     const segApiSetting = transApis?.find((api) => api.apiSlug === segSlug);
-    const isAutoCaption = this.#interceptedCaptionKind === "asr";
+    const isWordLevel = this.#isWordLevelCaption(events);
+    logger.info(
+      `Youtube Provider: caption kind=${this.#interceptedCaptionKind}, wordLevel=${isWordLevel}`
+    );
 
-    if (isAutoCaption && segSlug && segSlug !== "-" && segApiSetting) {
+    if (isWordLevel && segSlug && segSlug !== "-" && segApiSetting) {
       if (this.#isStaleProcessing(processingVersion)) return [[], 0];
       logger.info("Youtube Provider: Starting AI segmentation...");
       this.#showNotification(this.#i18n("ai_processing_pls_wait"));
@@ -951,14 +954,27 @@ class YouTubeCaptionProvider {
       return [firstBatchSubtitles, 100];
     }
 
-    if (isAutoCaption) {
+    if (isWordLevel) {
       return [this.#builtinSegment(events, flatEvents, fromLang), 100];
     }
 
     logger.info(
-      "Youtube Provider: Sentence break mode: MANUAL (human caption)"
+      "Youtube Provider: Sentence break mode: PASS-THROUGH (sentence-level track)"
     );
     return [flatEvents.filter((e) => e.text), 100];
+  }
+
+  // kind 不可靠：词级轨可能没有 kind=asr（见 issue #722）。
+  // asr 必为词级；其余按逐词时间戳 tOffsetMs 判断，人工整句轨没有 tOffsetMs。
+  #isWordLevelCaption(events = []) {
+    if (this.#interceptedCaptionKind === "asr") return true;
+    let offsetSegs = 0;
+    for (const { segs = [] } of events) {
+      for (const s of segs) {
+        if (Number(s.tOffsetMs) > 0 && ++offsetSegs >= 2) return true;
+      }
+    }
+    return false;
   }
 
   #builtinSegment(events, flatEvents, fromLang) {

--- a/src/subtitle/sentenceBreaker.js
+++ b/src/subtitle/sentenceBreaker.js
@@ -19,6 +19,9 @@ const DEFAULT_PARAMS = {
   forcePunctuationMinDurationMs: 2000,
 };
 
+// 零宽字符（U+200B~U+200D、U+FEFF），个别 YouTube 轨用它做占位 seg
+const ZERO_WIDTH_RE = new RegExp("[\\u200B-\\u200D\\uFEFF]", "g");
+
 /**
  * Word 类 - 单词对象
  */
@@ -177,8 +180,8 @@ function parseYoutubeData(data) {
 
     for (let i = 0; i < segs.length; i++) {
       const seg = segs[i];
-      const text = seg.utf8 || "";
-      if (!text || text === "\n") continue;
+      const text = (seg.utf8 || "").replace(ZERO_WIDTH_RE, "");
+      if (!text.trim()) continue;
 
       const offset = seg.tOffsetMs || 0;
       const wordStart = tStart + offset;


### PR DESCRIPTION
### 背景

issue #722：部分 YouTube 视频（MrBeast 这类多音轨）的英文字幕轨没有 kind=asr，但实际是词级结构（每个词带 tOffsetMs）。#eventsToSubtitles 用 kind === "asr" 判断要不要断句合并，这类无 kind 的词级轨被当成人工整句字幕原样输出，每个词渲染成一条字幕。

修这个的过程里又发现同一批轨道的三个连带问题：event 被原样发两遍、seg 用零宽字符占位、词级句子 end 太紧导致字幕过早消失。

用 yt-dlp 核对过，kind 不能判断词级：同一视频可同时有 .en（无 kind、词级）和 a.en（asr）两条英文轨，无 kind 那条照样词级。

### 改动

1. 按数据粒度判断词级，不再看 kind（a80c9f7）

新增 #isWordLevelCaption：kind=asr 或存在逐词时间戳 tOffsetMs 即判词级，人工整句轨两者都没有，走原样放行。AI、统计、规则三条断句分支统一用它。

2. 去掉重复 event（e5ff874）

新增 #dedupeEvents，取到 events 后去掉连续完全相同的 event，源头去重。

3. 清理原文零宽字符（5fc5de7）

在 #genFlatEvents 和 parseYoutubeData 源头去掉零宽字符（U+200B~U+200D、U+FEFF），占位 seg 变空被过滤；#cleanOriginals 写入前再清一遍多余空格兜底。

4. 词级字幕 end 加温和尾巴，避免过早消失（3f5ac49）

新增 #extendSubtitleEnds：给每句 end 加最多 500ms 尾巴，封顶到下一句开始，尽量保证 700ms 可读时长，长停顿仍留空白。从原始 end 算保证幂等，重叠的收到下一句开始。只对词级轨生效。

### 影响范围

- 看 asr 自动字幕的用户：词级判断行为不变；字幕结束时间会略微延后（更跟得上语音）
- 看无 kind 词级轨的用户：修复，单词字幕恢复成整句，不再重复、无怪空格、不再过早消失（#722）
- 看人工整句字幕的用户：行为不变，无 tOffsetMs 原样放行，不参与断句和 end 延长
- kind 仍用于字幕轨的选择和请求（#findCaptionTrack 等），未改动