### PR TITLE
fix: improve api icon contrast

### DIFF
--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -140,7 +140,7 @@ function getApiIconSrc(apiType) {
   return `${process.env.PUBLIC_URL || ""}/api/${iconFile}`;
 }
 
-function ApiProviderIcon({ apiType, disabled = false, sx = {} }) {
+function ApiProviderIcon({ apiType, sx = {} }) {
   const iconSrc = getApiIconSrc(apiType);
 
   return (
@@ -152,7 +152,10 @@ function ApiProviderIcon({ apiType, disabled = false, sx = {} }) {
         width: API_ICON_SIZE,
         height: API_ICON_SIZE,
         flex: "0 0 auto",
-        opacity: disabled ? 0.5 : 1,
+        opacity: 1,
+        background: "#fff",
+        borderRadius: "50%",
+        overflow: "hidden",
         ...sx,
       }}
     >
@@ -1227,7 +1230,7 @@ function ApiListItem({
             <DragIndicatorIcon fontSize="small" />
           </Box>
         </Tooltip>
-        <ApiProviderIcon apiType={api.apiType} disabled={api.isDisabled} />
+        <ApiProviderIcon apiType={api.apiType} />
         <Typography
           sx={{
             minWidth: 0,


### PR DESCRIPTION
修改样式，修复深色icon在夜间模式下不可见的问题。

原：
<img width="923" height="796" alt="4edf302ccdd9fda1" src="https://github.com/user-attachments/assets/055b1ebe-c135-45b4-aa92-f7ac30be3bf5" />

修改后：
<img width="668" height="1162" alt="d225aedeb66f6996" src="https://github.com/user-attachments/assets/479351b0-8360-4951-b0f7-d565cfbabf0a" />
<img width="727" height="1113" alt="77800e17b4882df7" src="https://github.com/user-attachments/assets/74ba09bf-20e8-40a5-9e00-9d29e951a647" />
