### PR TITLE
fix: Invert dark mode icons

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -214,6 +214,19 @@ export const API_SPE_TYPES = {
   ]),
   // 官方推荐/赞助商的翻译服务
   sponsors: new Set([OPT_TRANS_EPHONEAI]),
+  // 暗黑模式下图标反色
+  darkIcon: new Set([
+    OPT_TRANS_SILICONFLOW,
+    OPT_TRANS_XIAOMIMIMO,
+    OPT_TRANS_EPHONEAI,
+    OPT_TRANS_ZAI,
+    OPT_TRANS_DEEPL,
+    OPT_TRANS_DEEPLFREE,
+    OPT_TRANS_DEEPLX,
+    OPT_TRANS_OPENAI,
+    OPT_TRANS_OLLAMA,
+    OPT_TRANS_OPENROUTER,
+  ]),
 };
 
 // REVIEW: 思考模式参数映射：定义各 API 的思考开关和强度参数。

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -162,12 +162,17 @@ function ApiProviderIcon({ apiType, disabled = false, sx = {} }) {
           src={iconSrc}
           alt=""
           aria-hidden="true"
-          sx={{
+          sx={(theme) => ({
             width: API_ICON_SIZE,
             height: API_ICON_SIZE,
             objectFit: "contain",
             display: "block",
-          }}
+            filter:
+              theme.palette.mode === "dark" &&
+              API_SPE_TYPES.darkIcon.has(apiType)
+                ? "invert(100%)"
+                : "none",
+          })}
         />
       ) : (
         <ApiIcon fontSize="small" color="action" />


### PR DESCRIPTION
通过反色，改进部分翻译服务的图标在暗黑模式下的显示效果。


<img width="405" height="864" alt="image" src="https://github.com/user-attachments/assets/f6be0ef0-2f02-475a-aaae-b8c63aeb5eb1" />
