### PR TITLE
fix: 调整右键菜单选项文本

### DIFF
--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -12,7 +12,7 @@
     "message": "开启翻译"
   },
   "toggle_translate_only": {
-    "message": "仅显示译文"
+    "message": "仅看译文"
   },
   "toggle_style": {
     "message": "切换样式"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -12,7 +12,7 @@
     "message": "開啟翻譯"
   },
   "toggle_translate_only": {
-    "message": "僅顯示譯文"
+    "message": "僅看譯文"
   },
   "toggle_style": {
     "message": "切換樣式"


### PR DESCRIPTION
修改中文右键菜单选项的文本，让菜单项文本长度统一