### PR TITLE
Option: Translation First 可选项：译文在上方显示

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1962,6 +1962,27 @@ export const I18N = {
     ja: `完全な実装ではなく、一部のページでスタイルの問題が発生する可能性があります。`,
     ko: `완벽한 구현이 아니며 일부 페이지에서 스타일 문제가 발생할 수 있습니다.`,
   },
+  trans_order: {
+    zh: `文本顺序`,
+    en: `Translation Order`,
+    zh_TW: `文字順序`,
+    ja: `テキスト順序`,
+    ko: `텍스트 순서`,
+  },
+  original_first: {
+    zh: `原文在上方`,
+    en: `Original First`,
+    zh_TW: `原文在上方`,
+    ja: `原文が最初`,
+    ko: `원문이 먼저`,
+  },
+  translation_first: {
+    zh: `译文在上方`,
+    en: `Translation First`,
+    zh_TW: `譯文在上方`,
+    ja: `翻訳が最初`,
+    ko: `번역이 먼저`,
+  },
   transonly_revert: {
     zh: `悬浮显示原文`,
     en: `Hover to Show Original`,

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -88,6 +88,7 @@ export const DEFAULT_RULE = {
   transOnly: GLOBAL_KEY, // 是否仅显示译文而不显示原文 (单语翻译)
   transOnlyRevert: GLOBAL_KEY, // 仅译文模式下，鼠标悬浮时是否临时恢复显示原文
   transOnlyRevertDelay: GLOBAL_KEY, // 悬浮恢复原文的延迟时间 (秒)
+  transOrder: GLOBAL_KEY, // 文本顺序：原文在上 ("original-first") 或 译文在上 ("translation-first")
   // transTiming: GLOBAL_KEY, // 翻译时机/鼠标悬停翻译 (暂时作废)
   transTag: GLOBAL_KEY, // 译文嵌套的 HTML 标签 (如 font, span 等)
   transTitle: GLOBAL_KEY, // 是否翻译网页的 document.title

--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -156,6 +156,7 @@ export const GLOBLA_RULE = {
   splitParagraph: OPT_SPLIT_PARAGRAPH_DISABLE,
   splitLength: 100,
   highlightWords: OPT_HIGHLIGHT_WORDS_DISABLE,
+  transOrder: "original-first", // 文本顺序：原文在上 ("original-first") 或 译文在上 ("translation-first")
 };
 
 // 预设规则列表，初始化时直接注册

--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -145,6 +145,7 @@ const mergeRules = (baseRule, overrideRule) => {
     "transOpen",
     "transOnly",
     "transOnlyRevert",
+    "transOrder",
     "autoScan",
     "hasRichText",
     "hasShadowroot",
@@ -291,6 +292,7 @@ export const checkRules = (rules) => {
         transOnly,
         transOnlyRevert,
         transOnlyRevertDelay,
+        transOrder,
         autoScan,
         hasRichText,
         hasShadowroot,
@@ -342,6 +344,10 @@ export const checkRules = (rules) => {
           !isNaN(parseFloat(transOnlyRevertDelay))
             ? transOnlyRevertDelay
             : GLOBAL_KEY,
+        transOrder: matchValue(
+          [GLOBAL_KEY, "original-first", "translation-first"],
+          transOrder
+        ),
         autoScan: matchValue([GLOBAL_KEY, "true", "false"], autoScan),
         hasRichText: matchValue([GLOBAL_KEY, "true", "false"], hasRichText),
         hasShadowroot: matchValue([GLOBAL_KEY, "true", "false"], hasShadowroot),

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -2213,6 +2213,7 @@ export class Translator {
 
   // 切换译文和双语显示
   #toggleTranslationOnly(node, transOnly) {
+    const { transOrder = "original-first" } = this.#rule;
     this.#findTranslationWrappers(node).forEach((el) => {
       const br = el.querySelector(":scope > br");
       const { nodes } = this.#translationNodes.get(el) || {};
@@ -2221,6 +2222,8 @@ export class Translator {
         this.#withViewportAnchor(() => {
           if (br) br.hidden = true;
           this.#removeNodes(nodes);
+          // 根据 transOrder 调整 wrapper 位置以遵循全局文本顺序设置
+          this.#adjustWrapperPosition(el, nodes, transOrder);
         });
         this.#translationNodes.set(el, { nodes, isHide: true });
       } else {
@@ -2228,10 +2231,44 @@ export class Translator {
         this.#withViewportAnchor(() => {
           if (br) br.hidden = false;
           this.#restoreOriginal(el, nodes);
+          // 根据 transOrder 调整 wrapper 位置以遵循全局文本顺序设置
+          this.#adjustWrapperPosition(el, nodes, transOrder);
         });
         this.#translationNodes.set(el, { nodes, isHide: false });
       }
     });
+  }
+
+  // 根据 transOrder 调整 wrapper 位置
+  #adjustWrapperPosition(wrapper, nodes, transOrder) {
+    if (!nodes || !nodes.length) return;
+
+    // 获取第一个和最后一个原文节点的位置
+    const firstNode = nodes[0];
+    const lastNode = nodes[nodes.length - 1];
+
+    // 获取 wrapper 和原文节点的父容器
+    const wrapperParent = wrapper.parentElement;
+    const firstNodeParent = firstNode?.parentElement;
+    const lastNodeParent = lastNode?.parentElement;
+
+    // 仅在同一父容器下才需要调整位置
+    if (wrapperParent !== firstNodeParent || wrapperParent !== lastNodeParent) {
+      return;
+    }
+
+    // 根据 transOrder 决定 wrapper 位置
+    if (transOrder === "translation-first") {
+      // 译文在上：wrapper 应在原文节点前面
+      if (firstNode.previousElementSibling !== wrapper) {
+        firstNode.before(wrapper);
+      }
+    } else {
+      // 原文在上（默认）：wrapper 应在原文节点后面
+      if (lastNode.nextElementSibling !== wrapper) {
+        lastNode.after(wrapper);
+      }
+    }
   }
 
   // 更新样式
@@ -2242,6 +2279,18 @@ export class Translator {
       );
       inner.classList.remove(this.#textClass[oldStyle]);
       inner.classList.add(this.#textClass[newStyle]);
+    });
+  }
+
+  // 更新文本顺序
+  #updateTransOrder(node, transOrder) {
+    this.#findTranslationWrappers(node).forEach((el) => {
+      const { nodes } = this.#translationNodes.get(el) || {};
+      if (nodes && nodes.length) {
+        this.#withViewportAnchor(() => {
+          this.#adjustWrapperPosition(el, nodes, transOrder);
+        });
+      }
     });
   }
 
@@ -2259,8 +2308,15 @@ export class Translator {
       return;
     }
 
-    const { apiSlug, fromLang, toLang, hasRichText, textStyle, transOnly } =
-      this.#rule;
+    const {
+      apiSlug,
+      fromLang,
+      toLang,
+      hasRichText,
+      textStyle,
+      transOnly,
+      transOrder = "original-first",
+    } = this.#rule;
 
     const needsRefresh =
       appliedRule.apiSlug !== apiSlug ||
@@ -2277,6 +2333,7 @@ export class Translator {
         hasRichText,
         textStyle,
         transOnly,
+        transOrder,
       });
       this.#refreshNode(node); // 会自动应用新样式
       return;
@@ -2287,6 +2344,12 @@ export class Translator {
       const oldStyle = appliedRule.textStyle;
       appliedRule.textStyle = textStyle;
       this.#updateStyle(node, oldStyle, textStyle);
+    }
+
+    // 文本顺序规则过时
+    if (appliedRule.transOrder !== transOrder) {
+      appliedRule.transOrder = transOrder;
+      this.#updateTransOrder(node, transOrder);
     }
 
     // 切换原文显示

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -1705,12 +1705,6 @@ export class Translator {
       const wrapper = document.createElement(this.#translationTagName);
       wrapper.className = `${Translator.KISS_CLASS.warpper} notranslate`;
 
-      if (processedString.length > newlineLength) {
-        const br = document.createElement("br");
-        br.hidden = hideOrigin;
-        wrapper.appendChild(br);
-      }
-
       const inner = document.createElement(transTag);
       inner.lang = toLang;
       inner.className = `${Translator.KISS_CLASS.inner} ${this.#textClass[textStyle] || ""}`;
@@ -1718,12 +1712,23 @@ export class Translator {
         inner.style.cssText = textExtStyle; // 附加内联样式
       }
       inner.appendChild(createLoadingSVG());
-      wrapper.appendChild(inner);
 
-      // 在原文和译文之间添加分隔换行
-      const separatorBr = document.createElement("br");
-      separatorBr.hidden = hideOrigin;
-      wrapper.appendChild(separatorBr);
+      // 将 <br> 作为 wrapper 的子节点，以便 toggleTranslationOnly 统一管理
+      if (processedString.length > newlineLength) {
+        const br = document.createElement("br");
+        br.hidden = hideOrigin;
+        if (transOrder === "translation-first") {
+          // 译文在上：inner → br
+          wrapper.appendChild(inner);
+          wrapper.appendChild(br);
+        } else {
+          // 原文在上：br → inner
+          wrapper.appendChild(br);
+          wrapper.appendChild(inner);
+        }
+      } else {
+        wrapper.appendChild(inner);
+      }
 
       this.#withViewportAnchor(() => {
         // 根据 transOrder 选项决定译文显示位置
@@ -2222,17 +2227,26 @@ export class Translator {
         this.#withViewportAnchor(() => {
           if (br) br.hidden = true;
           this.#removeNodes(nodes);
-          // 根据 transOrder 调整 wrapper 位置以遵循全局文本顺序设置
-          this.#adjustWrapperPosition(el, nodes, transOrder);
         });
         this.#translationNodes.set(el, { nodes, isHide: true });
       } else {
         // 仅译文变为双语
         this.#withViewportAnchor(() => {
           if (br) br.hidden = false;
-          this.#restoreOriginal(el, nodes);
-          // 根据 transOrder 调整 wrapper 位置以遵循全局文本顺序设置
-          this.#adjustWrapperPosition(el, nodes, transOrder);
+          if (nodes && nodes.length) {
+            const frag = document.createDocumentFragment();
+            nodes.forEach((n) => frag.appendChild(n));
+            const parent = el.parentElement;
+            if (parent) {
+              if (transOrder === "translation-first") {
+                // 译文在上：原文节点应在 wrapper 之后
+                el.after(frag);
+              } else {
+                // 原文在上：原文节点应在 wrapper 之前
+                el.before(frag);
+              }
+            }
+          }
         });
         this.#translationNodes.set(el, { nodes, isHide: false });
       }
@@ -2257,7 +2271,7 @@ export class Translator {
       return;
     }
 
-    // 根据 transOrder 决定 wrapper 位置
+    // br 是 wrapper 的子节点，只需调整 wrapper 相对于原文节点的位置
     if (transOrder === "translation-first") {
       // 译文在上：wrapper 应在原文节点前面
       if (firstNode.previousElementSibling !== wrapper) {

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -302,10 +302,10 @@ export class Translator {
   #${APP_CONSTS.boxID}, .${APP_CONSTS.boxID}_warpper,
   #${APP_CONSTS.popupID}, .${APP_CONSTS.popupID}_warpper`;
 
-  static BUILTIN_IGNORE_SELECTOR = `address, area, audio, br, canvas, 
-  data, datalist, embed, head, iframe, input, noscript, map, 
-  object, option, param, picture, progress, 
-  select, script, style, svg, track, textarea, template, 
+  static BUILTIN_IGNORE_SELECTOR = `address, area, audio, br, canvas,
+  data, datalist, embed, head, iframe, input, noscript, map,
+  object, option, param, picture, progress,
+  select, script, style, svg, track, textarea, template,
   video, wbr, .notranslate, [contenteditable='true'], [translate='no']`;
 
   #setting; // 设置选项
@@ -1686,6 +1686,7 @@ export class Translator {
       toLang,
       // skipLangs = [],
       highlightWords,
+      transOrder = "original-first",
     } = this.#rule;
     const {
       newlineLength,
@@ -1718,8 +1719,19 @@ export class Translator {
       }
       inner.appendChild(createLoadingSVG());
       wrapper.appendChild(inner);
+
+      // 在原文和译文之间添加分隔换行
+      const separatorBr = document.createElement("br");
+      separatorBr.hidden = hideOrigin;
+      wrapper.appendChild(separatorBr);
+
       this.#withViewportAnchor(() => {
-        nodes[nodes.length - 1].after(wrapper);
+        // 根据 transOrder 选项决定译文显示位置
+        if (transOrder === "translation-first") {
+          nodes[0].before(wrapper); // 译文在上
+        } else {
+          nodes[nodes.length - 1].after(wrapper); // 原文在上（默认）
+        }
       });
 
       const currentRunId = this.#runId;

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -151,7 +151,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
     splitParagraph = OPT_SPLIT_PARAGRAPH_DISABLE, // 段落切分策略
     splitLength = 0, // 段落切分最大长度
     highlightWords = OPT_HIGHLIGHT_WORDS_DISABLE, // 单词高亮策略
-    transOrder = "original-first", // 文本顺序：原文在上或译文在上
+    transOrder, // 文本顺序：由 DEFAULT_RULE / GLOBLA_RULE 提供初始值
   } = formValues;
 
   // 判断当前表单值是否与初始值不同，决定是否激活“保存”按钮

--- a/src/views/Options/Rules.js
+++ b/src/views/Options/Rules.js
@@ -151,6 +151,7 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
     splitParagraph = OPT_SPLIT_PARAGRAPH_DISABLE, // 段落切分策略
     splitLength = 0, // 段落切分最大长度
     highlightWords = OPT_HIGHLIGHT_WORDS_DISABLE, // 单词高亮策略
+    transOrder = "original-first", // 文本顺序：原文在上或译文在上
   } = formValues;
 
   // 判断当前表单值是否与初始值不同，决定是否激活“保存”按钮
@@ -488,6 +489,28 @@ function RuleFields({ rule, rules, setShow, setKeyword }) {
                 {GlobalItem}
                 <MenuItem value={"false"}>{i18n("disable")}</MenuItem>
                 <MenuItem value={"true"}>{i18n("enable")}</MenuItem>
+              </TextField>
+            </Grid>
+
+            {/* 文本顺序设置 */}
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                select
+                size="small"
+                fullWidth
+                name="transOrder"
+                value={transOrder}
+                label={i18n("trans_order")}
+                disabled={disabled}
+                onChange={handleChange}
+              >
+                {GlobalItem}
+                <MenuItem value="original-first">
+                  {i18n("original_first")}
+                </MenuItem>
+                <MenuItem value="translation-first">
+                  {i18n("translation_first")}
+                </MenuItem>
               </TextField>
             </Grid>
 


### PR DESCRIPTION
New global rules: Original First / Translation First
新增全局规则：文本顺序 **原文在上方**(默认) **译文在上方**(可选)
设置方法
<img width="1365" height="1288" alt="f20260605T085727" src="https://github.com/user-attachments/assets/0bc8a78e-e5a2-4cb2-8ea6-03b456e2d3c3" />
效果演示
<img width="1301" height="1237" alt="f20260605T085841" src="https://github.com/user-attachments/assets/b96efe6a-d7f5-427e-8116-7e821af80ec0" />
