### PR TITLE
fix: Only spoof Origin header on non-target-site pages (#759)

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -75,6 +75,27 @@ async function updateIcon(isActive, tabId) {
 // declarativeNetRequest 动态规则的起始 ID 段，避免 ID 冲突
 const CSP_RULE_START_ID = 1;
 const ORI_RULE_START_ID = 10000;
+
+/**
+ * 从一个 URL 或域名字符串中提取可注册域名 (registrable domain, 即 eTLD+1)。
+ * 例如 "https://dict.youdao.com/xxx" -> "youdao.com"。
+ * 用于 DNR 的 excludedInitiatorDomains，使其能匹配目标站点的所有子域名页面。
+ * @param {string} input URL 或域名（可不带协议）
+ * @returns {string} 可注册域名；解析失败时返回空字符串
+ */
+function getRegistrableDomain(input) {
+  try {
+    const hostname = new URL(
+      /^[a-z]+:\/\//i.test(input) ? input : `https://${input}`
+    ).hostname;
+    const labels = hostname.split(".").filter(Boolean);
+    // 取最后两段作为可注册域名（足以覆盖有道等常见翻译源场景）
+    return labels.length <= 2 ? hostname : labels.slice(-2).join(".");
+  } catch (err) {
+    kissLog("getRegistrableDomain error", err);
+    return "";
+  }
+}
 // 需要从 HTTP 响应头中移除的 CSP (Content-Security-Policy) 键名，用以允许加载第三方翻译接口脚本/发送翻译请求
 const CSP_REMOVE_HEADERS = [
   `content-security-policy`,
@@ -354,17 +375,31 @@ async function updateCspRules({ csplist, orilist }) {
       idsToRemove.push(...oldOriRuleIds);
 
       // 将发往特定翻译源的 xmlhttprequest 请求的 Origin 修改为目标源域名，伪装成同源请求
-      const newOriRules = processedOriList.map((url, index) => ({
-        id: ORI_RULE_START_ID + index,
-        action: {
-          type: "modifyHeaders",
-          requestHeaders: [{ header: "Origin", operation: "set", value: url }],
-        },
-        condition: {
+      const newOriRules = processedOriList.map((url, index) => {
+        const condition = {
           urlFilter: url,
           resourceTypes: ["xmlhttprequest"],
-        },
-      }));
+        };
+
+        // 仅对“非目标站点本身”的页面发起的请求伪装 Origin。
+        // 否则会篡改用户在目标站点（如有道）自身页面上发出的请求的 Origin，
+        // 反而触发该站点的跨域校验失败 (CORS AllowOriginMismatch)。详见 issue #759。
+        const initiatorDomain = getRegistrableDomain(url);
+        if (initiatorDomain) {
+          condition.excludedInitiatorDomains = [initiatorDomain];
+        }
+
+        return {
+          id: ORI_RULE_START_ID + index,
+          action: {
+            type: "modifyHeaders",
+            requestHeaders: [
+              { header: "Origin", operation: "set", value: url },
+            ],
+          },
+          condition,
+        };
+      });
       rulesToAdd.push(...newOriRules);
     }
 


### PR DESCRIPTION
## 问题 (Fixes #759)

扩展通过 MV3 `declarativeNetRequest` 把发往翻译源（默认 `https://dict.youdao.com`）的 `xmlhttprequest` 的 `Origin` 请求头无条件改写为目标域名，以伪装同源绕过跨域限制。

但该规则是**全局**的，不区分请求来自哪个页面。当用户访问有道自身站点 `https://youdao.com/` 时，其页面向 `https://dict.youdao.com/vip/privilege/...` 发起的请求，`Origin` 被强行改成 `https://dict.youdao.com`，导致有道服务端 CORS校验失败：`AllowOriginMismatch` / `net::ERR_FAILED`。

## 改动

`src/background.js` 中给 Origin 改写规则的 `condition` 增加 `excludedInitiatorDomains`，使规则在「请求由目标站点自身页面发起」时不生效：

- 新增 `getRegistrableDomain()`，从 `https://dict.youdao.com` 解析出可注册域名 `youdao.com`（取 hostname 最后两段，覆盖 `youdao.com` / `www.youdao.com` / `dict.youdao.com` 等所有子域名页面）。
- 构造每条 Origin 规则时将该域名加入 `excludedInitiatorDomains`。

## 效果

- 在 **youdao.com 自身页面**发起的请求 → 不改 Origin，CORS 恢复正常
- 在 **其它网页**上由扩展发起的有道翻译请求 → 仍伪装 Origin，翻译/词典功能照常
