### PR TITLE
fix: rescan processed nodes

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -996,6 +996,7 @@ export class Translator {
     const container = this.#findChangeContainer(changedNode);
     if (!container) return;
 
+    this.#processedNodes.delete(container); // 删除处理状态，允许重新翻译
     this.#cleanupAllTranslations(container);
     this.#scanNode(container);
   }


### PR DESCRIPTION
修复文本变化未能重新翻译的bug。

之前在处理“脏容器”时未将节点从“已处理节点”中移除，导致不会重新翻译。

相关另一个PR：
https://github.com/fishjar/kiss-translator/pull/763