### PR TITLE
fix: hide api keys

### DIFF
--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -238,6 +238,35 @@ function TestButton({ api }) {
   );
 }
 
+/**
+ * 敏感文本输入框。
+ * 失焦时仅展示圆点，避免 API 密钥在配置页面长期明文暴露；
+ * 聚焦编辑时恢复真实值，确保保存、测试和多行密钥逻辑仍使用原始字段值。
+ */
+function SensitiveTextField({ value = "", onChange, inputProps, ...props }) {
+  const [editing, setEditing] = useState(false);
+  const displayValue = editing
+    ? value
+    : String(value)
+        .split("\n")
+        .map((line) => (line ? "•".repeat(Math.min(line.length, 24)) : ""))
+        .join("\n");
+
+  return (
+    <TextField
+      {...props}
+      value={displayValue}
+      onFocus={() => setEditing(true)}
+      onBlur={() => setEditing(false)}
+      onChange={editing ? onChange : undefined}
+      inputProps={{
+        ...inputProps,
+        readOnly: !editing,
+      }}
+    />
+  );
+}
+
 function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   const { api, update, reset } = useApiItem(apiSlug);
   const i18n = useI18n();
@@ -466,7 +495,7 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
                 apiType === OPT_TRANS_DEEPLX ? i18n("mulkeys_help") : ""
               }
             />
-            <TextField
+            <SensitiveTextField
               size="small"
               label={"Key"}
               name="key"


### PR DESCRIPTION
调整 API 配置页的密钥展示方式，避免 `Key` 字段在页面中长期明文暴露。
现在密钥默认以圆点遮罩显示，用户聚焦输入框进行编辑时才显示真实内容。

<img width="571" height="384" alt="e4bca706478af98a" src="https://github.com/user-attachments/assets/abb0a53b-aac9-4414-b343-e5cfd35b24ac" />

<img width="695" height="408" alt="image" src="https://github.com/user-attachments/assets/616340ba-d640-454b-8987-cc165f214c23" />
