### PR TITLE
fix: reduce prompt backup size

### DIFF
--- a/src/libs/settingBackup.js
+++ b/src/libs/settingBackup.js
@@ -1,0 +1,82 @@
+import { DEFAULT_API_LIST } from "../config/api";
+
+const API_PROMPT_FIELDS = [
+  "systemPrompt",
+  "subtitlePrompt",
+  "nobatchPrompt",
+  "nobatchUserPrompt",
+];
+
+const DEFAULT_API_BY_TYPE = new Map(
+  DEFAULT_API_LIST.map((api) => [api.apiType, api])
+);
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const getDefaultApi = (api) =>
+  isPlainObject(api) ? DEFAULT_API_BY_TYPE.get(api.apiType) : null;
+
+/**
+ * 导出或同步设置前，删除与内置默认值完全一致的 Prompt 字段。
+ * 缺失字段即表示继续使用对应 apiType 的内置默认 Prompt。
+ *
+ * @param {Object} setting 完整运行时设置对象
+ * @returns {Object} 适合备份/同步的精简设置对象
+ */
+export function packSettingForBackup(setting) {
+  if (!isPlainObject(setting) || !Array.isArray(setting.transApis)) {
+    return setting;
+  }
+
+  return {
+    ...setting,
+    transApis: setting.transApis.map((api) => {
+      if (!isPlainObject(api)) return api;
+
+      const defaultApi = getDefaultApi(api);
+      const packedApi = { ...api };
+      if (!defaultApi) return packedApi;
+
+      API_PROMPT_FIELDS.forEach((field) => {
+        if (packedApi[field] === defaultApi[field]) {
+          delete packedApi[field];
+        }
+      });
+
+      return packedApi;
+    }),
+  };
+}
+
+/**
+ * 导入或读取同步设置后，把精简备份中缺失的默认 Prompt 字段补回。
+ * 已存在的字段保持原值，用于保留用户自定义 Prompt。
+ *
+ * @param {Object} setting 从备份/同步读取到的设置对象
+ * @returns {Object} 可直接写入本地存储和运行时使用的完整设置对象
+ */
+export function unpackSettingFromBackup(setting) {
+  if (!isPlainObject(setting) || !Array.isArray(setting.transApis)) {
+    return setting;
+  }
+
+  return {
+    ...setting,
+    transApis: setting.transApis.map((api) => {
+      if (!isPlainObject(api)) return api;
+
+      const defaultApi = getDefaultApi(api);
+      const unpackedApi = { ...api };
+      if (!defaultApi) return unpackedApi;
+
+      API_PROMPT_FIELDS.forEach((field) => {
+        if (!(field in unpackedApi)) {
+          unpackedApi[field] = defaultApi[field];
+        }
+      });
+
+      return unpackedApi;
+    }),
+  };
+}

--- a/src/libs/settingBackup.test.js
+++ b/src/libs/settingBackup.test.js
@@ -1,0 +1,68 @@
+import { DEFAULT_API_LIST, OPT_TRANS_OPENAI } from "../config/api";
+import { packSettingForBackup, unpackSettingFromBackup } from "./settingBackup";
+
+const PROMPT_FIELDS = [
+  "systemPrompt",
+  "subtitlePrompt",
+  "nobatchPrompt",
+  "nobatchUserPrompt",
+];
+
+const defaultOpenAiApi = DEFAULT_API_LIST.find(
+  (api) => api.apiType === OPT_TRANS_OPENAI
+);
+
+describe("setting backup prompt packing", () => {
+  test("removes prompt fields that exactly match defaults", () => {
+    const packed = packSettingForBackup({
+      transApis: [{ ...defaultOpenAiApi }],
+    });
+
+    PROMPT_FIELDS.forEach((field) => {
+      expect(packed.transApis[0]).not.toHaveProperty(field);
+      expect(defaultOpenAiApi).toHaveProperty(field);
+    });
+  });
+
+  test("keeps prompt fields changed by the user", () => {
+    const customSystemPrompt = "用户自定义批量系统提示词";
+    const packed = packSettingForBackup({
+      transApis: [
+        {
+          ...defaultOpenAiApi,
+          systemPrompt: customSystemPrompt,
+        },
+      ],
+    });
+
+    expect(packed.transApis[0].systemPrompt).toBe(customSystemPrompt);
+    expect(packed.transApis[0]).not.toHaveProperty("subtitlePrompt");
+    expect(packed.transApis[0]).not.toHaveProperty("nobatchPrompt");
+    expect(packed.transApis[0]).not.toHaveProperty("nobatchUserPrompt");
+  });
+
+  test("restores missing default prompt fields after import", () => {
+    const customSubtitlePrompt = "用户自定义字幕提示词";
+    const unpacked = unpackSettingFromBackup({
+      transApis: [
+        {
+          apiSlug: defaultOpenAiApi.apiSlug,
+          apiName: defaultOpenAiApi.apiName,
+          apiType: defaultOpenAiApi.apiType,
+          subtitlePrompt: customSubtitlePrompt,
+        },
+      ],
+    });
+
+    expect(unpacked.transApis[0].systemPrompt).toBe(
+      defaultOpenAiApi.systemPrompt
+    );
+    expect(unpacked.transApis[0].subtitlePrompt).toBe(customSubtitlePrompt);
+    expect(unpacked.transApis[0].nobatchPrompt).toBe(
+      defaultOpenAiApi.nobatchPrompt
+    );
+    expect(unpacked.transApis[0].nobatchUserPrompt).toBe(
+      defaultOpenAiApi.nobatchUserPrompt
+    );
+  });
+});

--- a/src/libs/sync.js
+++ b/src/libs/sync.js
@@ -31,6 +31,7 @@ import { createClient, getPatcher } from "webdav";
 import { fetchPatcher } from "./fetch";
 import { kissLog } from "./log";
 import { encryptSyncValue, decryptSyncValue } from "./syncCrypto";
+import { packSettingForBackup, unpackSettingFromBackup } from "./settingBackup";
 
 let webdavRequestPatched = false;
 const GIST_SYNC_DESCRIPTION = "kiss translator sync files";
@@ -230,7 +231,7 @@ const syncByType = async (syncType, data, args, options) =>
     ? await syncByWebdav(data, args, options)
     : syncType === OPT_SYNCTYPE_GIST
       ? await syncByGist(data, args, options)
-    : await syncByWorker(data, args);
+      : await syncByWorker(data, args);
 
 /**
  * 将已经读取成功的旧版明文远端数据，用当前同步加密口令回写成密文。
@@ -273,10 +274,12 @@ const forceSyncDataWithEncryptKey = async (key, value, syncEncryptKey) => {
     syncUser,
     syncKey,
   };
+  const syncValue =
+    key === KV_SETTING_KEY ? packSettingForBackup(value) : value;
   const data = await encryptSyncData(
     {
       key,
-      value: JSON.stringify(value),
+      value: JSON.stringify(syncValue),
       updateAt,
     },
     syncEncryptKey
@@ -328,9 +331,11 @@ export const syncData = async (key, value) => {
     updateAt = 0; // 若从未同步过，将更新时间置 0 以触发首次拉取云端
   }
 
+  const syncValue =
+    key === KV_SETTING_KEY ? packSettingForBackup(value) : value;
   const data = {
     key,
-    value: JSON.stringify(value),
+    value: JSON.stringify(syncValue),
     updateAt,
   };
   const args = {
@@ -352,13 +357,22 @@ export const syncData = async (key, value) => {
     encryptedOrLegacyRes,
     syncEncryptKey
   );
-  const newVal = JSON.parse(res.value);
+  const parsedValue = JSON.parse(res.value);
+  const newVal =
+    key === KV_SETTING_KEY ? unpackSettingFromBackup(parsedValue) : parsedValue;
   // 若返回的云端数据更新时间戳晚于本地，则说明云端有新更改需要覆盖本地
   const isNew = res.updateAt > updateAt;
 
   // 新版客户端首次遇到旧版明文远端数据时，读取后立即迁移为密文。
   if (!encrypted) {
-    await migratePlainSyncData(syncType, res, args, syncEncryptKey);
+    await migratePlainSyncData(
+      syncType,
+      key === KV_SETTING_KEY
+        ? { ...res, value: JSON.stringify(packSettingForBackup(newVal)) }
+        : res,
+      args,
+      syncEncryptKey
+    );
   }
 
   // 更新本地同步元数据，包含云端的最新修改时间及当前的同步操作时间

--- a/src/libs/sync.test.js
+++ b/src/libs/sync.test.js
@@ -61,6 +61,7 @@ import {
   apiListGists,
   apiUpdateGistFile,
 } from "../apis";
+import { DEFAULT_API_LIST, OPT_TRANS_OPENAI } from "../config/api";
 import {
   getSettingWithDefault,
   getRulesWithDefault,
@@ -78,6 +79,15 @@ const NEW_SYNC_ENCRYPT_KEY = "new-sync-encrypt-passphrase";
 const SETTING_KEY = "kiss-setting_v2.json";
 const RULES_KEY = "kiss-rules_v2.json";
 const WORDS_KEY = "kiss-words.json";
+const PROMPT_FIELDS = [
+  "systemPrompt",
+  "subtitlePrompt",
+  "nobatchPrompt",
+  "nobatchUserPrompt",
+];
+const defaultOpenAiApi = DEFAULT_API_LIST.find(
+  (api) => api.apiType === OPT_TRANS_OPENAI
+);
 
 const gistFileContent = (value, updateAt) =>
   JSON.stringify({
@@ -105,7 +115,10 @@ describe("GitHub Gist sync", () => {
       }
       if (value.startsWith("cipher:")) {
         return Promise.resolve({
-          value: Buffer.from(value.slice("cipher:".length), "base64").toString(),
+          value: Buffer.from(
+            value.slice("cipher:".length),
+            "base64"
+          ).toString(),
           encrypted: true,
         });
       }
@@ -286,6 +299,79 @@ describe("GitHub Gist sync", () => {
     expect(result).toEqual({ value: { remote: true }, isNew: true });
   });
 
+  test("uploads setting sync data without unchanged default prompts", async () => {
+    getSyncWithDefault.mockResolvedValue({
+      syncType: "GitHub Gist",
+      syncUrl: "existing-gist",
+      syncKey: SYNC_KEY,
+      syncEncryptKey: SYNC_ENCRYPT_KEY,
+      syncMeta: {
+        [SETTING_KEY]: {
+          updateAt: 200,
+          syncAt: 1,
+        },
+      },
+    });
+    apiGetGist.mockResolvedValue({ files: {} });
+
+    const result = await syncData(SETTING_KEY, {
+      transApis: [{ ...defaultOpenAiApi }],
+    });
+    const uploadedSetting = JSON.parse(encryptSyncValue.mock.calls[0][0]);
+
+    PROMPT_FIELDS.forEach((field) => {
+      expect(uploadedSetting.transApis[0]).not.toHaveProperty(field);
+    });
+    expect(result.value.transApis[0].systemPrompt).toBe(
+      defaultOpenAiApi.systemPrompt
+    );
+  });
+
+  test("restores default prompts from compact setting sync data", async () => {
+    getSyncWithDefault.mockResolvedValue({
+      syncType: "GitHub Gist",
+      syncUrl: "existing-gist",
+      syncKey: SYNC_KEY,
+      syncEncryptKey: SYNC_ENCRYPT_KEY,
+      syncMeta: {
+        [SETTING_KEY]: {
+          updateAt: 10,
+          syncAt: 1,
+        },
+      },
+    });
+    apiGetGist.mockResolvedValue({
+      files: {
+        [SETTING_KEY]: {
+          content: encryptedGistFileContent(
+            {
+              transApis: [
+                {
+                  apiSlug: defaultOpenAiApi.apiSlug,
+                  apiName: defaultOpenAiApi.apiName,
+                  apiType: defaultOpenAiApi.apiType,
+                },
+              ],
+            },
+            50
+          ),
+        },
+      },
+    });
+
+    const result = await syncData(SETTING_KEY, {
+      transApis: [{ ...defaultOpenAiApi }],
+    });
+
+    expect(apiUpdateGistFile).not.toHaveBeenCalled();
+    expect(result.value.transApis[0].systemPrompt).toBe(
+      defaultOpenAiApi.systemPrompt
+    );
+    expect(result.value.transApis[0].subtitlePrompt).toBe(
+      defaultOpenAiApi.subtitlePrompt
+    );
+  });
+
   test("migrates newer legacy plaintext gist data to encrypted content", async () => {
     getSyncWithDefault.mockResolvedValue({
       syncType: "GitHub Gist",
@@ -358,9 +444,9 @@ describe("GitHub Gist sync", () => {
       JSON.stringify(
         {
           key: SETTING_KEY,
-          value: `cipher:${Buffer.from(JSON.stringify({ local: true })).toString(
-            "base64"
-          )}`,
+          value: `cipher:${Buffer.from(
+            JSON.stringify({ local: true })
+          ).toString("base64")}`,
           updateAt: 200,
         },
         null,

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -35,6 +35,10 @@ import { kissLog, LogLevel } from "../../libs/log";
 import UploadButton from "./UploadButton";
 import DownloadButton from "./DownloadButton";
 import ValidationInput from "../../hooks/ValidationInput";
+import {
+  packSettingForBackup,
+  unpackSettingFromBackup,
+} from "../../libs/settingBackup";
 
 /**
  * 包装单个快捷键录入表单项组件
@@ -93,7 +97,7 @@ export default function Settings() {
   // 导入备份 JSON 配置文件
   const handleImport = async (data) => {
     try {
-      updateSetting(JSON.parse(data));
+      updateSetting(unpackSettingFromBackup(JSON.parse(data)));
     } catch (err) {
       kissLog("import setting", err);
     }
@@ -134,7 +138,7 @@ export default function Settings() {
         >
           <UploadButton text={i18n("import")} handleImport={handleImport} />
           <DownloadButton
-            handleData={() => JSON.stringify(setting, null, 2)}
+            handleData={() => JSON.stringify(packSettingForBackup(setting))}
             text={i18n("export")}
             fileName={`kiss-setting_v2_${Date.now()}.json`}
           />


### PR DESCRIPTION
本次优化备份与云同步的设置数据体积。对于内置翻译 API 中未修改过的默认 Prompt，不再写入备份或同步文件；导入或拉取同步数据后，会根据 API 类型自动恢复默认 Prompt，用户自定义 Prompt 仍完整保留。

默认设置备份体积从约 105KB 降至约 20KB，云同步加密文件从约 141KB 降至约 27KB。新增了设置备份压缩/恢复测试，并补充了同步场景测试，确保本地导入导出和云端同步行为兼容旧数据。