### PR TITLE
bad pr

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -21,7 +21,8 @@
         "file://*/*"
       ],
       "all_frames": true,
-      "match_about_blank": true
+      "match_about_blank": true,
+      "match_origin_as_fallback": true
     }
   ],
   "web_accessible_resources": [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,7 +20,8 @@
         "file://*/*"
       ],
       "all_frames": true,
-      "match_about_blank": true
+      "match_about_blank": true,
+      "match_origin_as_fallback": true
     }
   ],
   "web_accessible_resources": [

--- a/public/manifest.thunderbird.json
+++ b/public/manifest.thunderbird.json
@@ -27,7 +27,8 @@
         "file://*/*"
       ],
       "all_frames": true,
-      "match_about_blank": true
+      "match_about_blank": true,
+      "match_origin_as_fallback": true
     }
   ],
   "web_accessible_resources": [


### PR DESCRIPTION
简要描述：当 `iframe.src` 为 blob url 时，脚本可以注入到其中。

问题说明：在上述 issue 中，网页的内容被处理成 blob url，然后放入到 `iframe` 中，插件无法注入到其中，无法翻译其中的内容。
