### PR TITLE
fix: add `match_origin_as_fallback` to manifest files

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -21,6 +21,7 @@
         "file://*/*"
       ],
       "all_frames": true,
+      "match_origin_as_fallback": true,
       "match_about_blank": true
     }
   ],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,7 @@
         "file://*/*"
       ],
       "all_frames": true,
+      "match_origin_as_fallback": true,
       "match_about_blank": true
     }
   ],

--- a/public/manifest.thunderbird.json
+++ b/public/manifest.thunderbird.json
@@ -27,6 +27,7 @@
         "file://*/*"
       ],
       "all_frames": true,
+      "match_origin_as_fallback": true,
       "match_about_blank": true
     }
   ],


### PR DESCRIPTION
Fixes #785

简要描述：当 `iframe.src` 为 blob url 时，脚本可以注入到其中。

问题说明：在上述 issue 中，网页的内容被处理成 blob url，然后放入到 `iframe` 中，插件无法注入到其中，无法翻译其中的内容。