### PR TITLE
Fix: Via GM stream UTF-8 decoding fallback

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1388,34 +1388,23 @@ export async function* handleTranslate(
     }
   }
 
-  const [input, init, userMsg] = await genTransReq({
-    ...apiSetting,
-    texts,
-    from,
-    to,
-    fromLang,
-    toLang,
-    langMap,
-    glossary,
-    hisMsgs,
-    token,
-    useStream: enableStream,
-    docInfo,
-  });
-
-  if (enableStream) {
-    yield* handleTranslateStreamInternal(texts, input, init, {
-      apiType,
-      history,
-      userMsg,
-      usePool,
-      fetchInterval,
-      fetchLimit,
-      httpTimeout,
-      signal,
-      streamRenderMode: apiSetting.streamRenderMode || "disabled",
+  const getRequest = (requestUseStream) =>
+    genTransReq({
+      ...apiSetting,
+      texts,
+      from,
+      to,
+      fromLang,
+      toLang,
+      langMap,
+      glossary,
+      hisMsgs,
+      token,
+      useStream: requestUseStream,
+      docInfo,
     });
-  } else {
+
+  const runNonStream = async function* (input, init, userMsg) {
     const response = await fetchData(input, init, {
       useCache: false,
       usePool,
@@ -1446,7 +1435,39 @@ export async function* handleTranslate(
     for (let i = 0; i < result.length; i++) {
       yield { id: i, result: result[i] };
     }
+  };
+
+  const [input, init, userMsg] = await getRequest(enableStream);
+
+  if (enableStream) {
+    try {
+      yield* handleTranslateStreamInternal(texts, input, init, {
+        apiType,
+        history,
+        userMsg,
+        usePool,
+        fetchInterval,
+        fetchLimit,
+        httpTimeout,
+        signal,
+        streamRenderMode: apiSetting.streamRenderMode || "disabled",
+      });
+      return;
+    } catch (err) {
+      if (err?.name === "AbortError") {
+        throw err;
+      }
+      kissLog("translate stream failed, fallback to non-stream", err);
+    }
+
+    const [fallbackInput, fallbackInit, fallbackUserMsg] = await getRequest(
+      false
+    );
+    yield* runNonStream(fallbackInput, fallbackInit, fallbackUserMsg);
+    return;
   }
+
+  yield* runNonStream(input, init, userMsg);
 }
 
 /**

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -1,0 +1,115 @@
+jest.mock("query-string", () => ({
+  stringify: (obj) => new URLSearchParams(obj).toString(),
+}));
+
+jest.mock("@streamparser/json", () => ({
+  JSONParser: jest.fn(),
+}));
+
+jest.mock("../libs/fetch", () => ({
+  fetchData: jest.fn(),
+  fetchStream: jest.fn(),
+}));
+
+jest.mock("../libs/docInfo", () => ({
+  getDocInfo: () => ({}),
+}));
+
+import { handleTranslate } from "./trans";
+import { DEFAULT_API_LIST, OPT_TRANS_OPENAI } from "../config";
+import { fetchData, fetchStream } from "../libs/fetch";
+
+const getApiSetting = (apiType) => ({
+  ...DEFAULT_API_LIST.find((api) => api.apiType === apiType),
+  useStream: true,
+  useBatchFetch: true,
+  key: "test-key",
+  model: "test-model",
+  fetchInterval: 0,
+  fetchLimit: 1,
+  httpTimeout: 1000,
+});
+
+async function collectAsyncGenerator(generator) {
+  const result = [];
+  for await (const item of generator) {
+    result.push(item);
+  }
+  return result;
+}
+
+describe("handleTranslate", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("falls back to non-stream request when stream reader is unsupported", async () => {
+    async function* brokenStream() {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'getReader')"
+      );
+    }
+
+    fetchStream.mockReturnValueOnce(brokenStream());
+    fetchData.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify([
+              { text: "你好", sourceLanguage: "en" },
+            ]),
+          },
+        },
+      ],
+    });
+
+    const result = await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+        usePool: false,
+      })
+    );
+
+    expect(fetchStream).toHaveBeenCalledTimes(1);
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchStream.mock.calls[0][1].body).stream).toBe(true);
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).stream).toBe(false);
+    expect(result).toEqual([
+      {
+        id: 0,
+        result: [JSON.stringify([{ text: "你好", sourceLanguage: "en" }]), ""],
+      },
+    ]);
+  });
+
+  test("does not fall back when stream request is aborted", async () => {
+    async function* abortedStream() {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    fetchStream.mockReturnValueOnce(abortedStream());
+
+    await expect(
+      collectAsyncGenerator(
+        handleTranslate(["hello"], {
+          from: "en",
+          to: "zh-CN",
+          fromLang: "English",
+          toLang: "Chinese",
+          langMap: () => "",
+          glossary: "",
+          apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+          usePool: false,
+        })
+      )
+    ).rejects.toThrow("The operation was aborted.");
+
+    expect(fetchData).not.toHaveBeenCalled();
+  });
+});

--- a/src/common.js
+++ b/src/common.js
@@ -21,8 +21,8 @@ import TranslatorManager from "./libs/translatorManager";
  * 该函数负责把油猴特权 GM 接口暴露给页面环境，以便设置页面能直接读写油猴配置项。
  */
 function runSettingPage() {
-  // 若油猴赋予了 unsafeWindow (直通宿主 window 权限)，则直接挂载
-  if (GM.info?.script?.grant?.includes("unsafeWindow")) {
+  // 若油猴实际提供了 unsafeWindow (直通宿主 window 权限)，则直接挂载
+  if (hasUnsafeWindowBridge()) {
     unsafeWindow.GM = GM;
     unsafeWindow.APP_INFO = {
       name: process.env.REACT_APP_NAME,
@@ -37,6 +37,30 @@ function runSettingPage() {
       "kiss-translator-options-injector"
     );
   }
+}
+
+function hasUnsafeWindowBridge() {
+  return typeof unsafeWindow !== "undefined";
+}
+
+/**
+ * 建立旧式 GM_* API 到现代 GM 对象的兼容垫片。
+ * 必须在任何 storage 访问前执行，避免旧油猴环境在数据迁移阶段缺少 GM。
+ */
+function ensureUserscriptGM() {
+  globalThis.GM = globalThis.GM || {};
+
+  globalThis.GM.xmlHttpRequest =
+    globalThis.GM.xmlHttpRequest || globalThis.GM_xmlhttpRequest;
+  globalThis.GM.registerMenuCommand =
+    globalThis.GM.registerMenuCommand || globalThis.GM_registerMenuCommand;
+  globalThis.GM.unregisterMenuCommand =
+    globalThis.GM.unregisterMenuCommand || globalThis.GM_unregisterMenuCommand;
+  globalThis.GM.setValue = globalThis.GM.setValue || globalThis.GM_setValue;
+  globalThis.GM.getValue = globalThis.GM.getValue || globalThis.GM_getValue;
+  globalThis.GM.deleteValue =
+    globalThis.GM.deleteValue || globalThis.GM_deleteValue;
+  globalThis.GM.info = globalThis.GM.info || globalThis.GM_info;
 }
 
 /**
@@ -192,8 +216,10 @@ async function waitForIframeTranslatableText() {
  */
 export async function run(isUserscript = false) {
   try {
-    // 0. 执行核心数据迁移 (针对油猴等无后台更新事件的场景)
     if (isUserscript) {
+      ensureUserscriptGM();
+
+      // 0. 执行核心数据迁移 (针对油猴等无后台更新事件的场景)
       const { runDataMigration } = await import("./libs/storage");
       await runDataMigration();
     }
@@ -215,18 +241,6 @@ export async function run(isUserscript = false) {
 
     // 4. 若为油猴脚本环境，建立向后兼容的 GM 特权接口垫片
     if (isUserscript) {
-      if (!globalThis.GM) {
-        globalThis.GM = {
-          xmlHttpRequest: globalThis.GM_xmlhttpRequest,
-          registerMenuCommand: globalThis.GM_registerMenuCommand,
-          unregisterMenuCommand: globalThis.GM_unregisterMenuCommand,
-          setValue: globalThis.GM_setValue,
-          getValue: globalThis.GM_getValue,
-          deleteValue: globalThis.GM_deleteValue,
-          info: globalThis.GM_info,
-        };
-      }
-
       // 如果当前是设置面板 URL，跳转去执行设置面板专用代理
       if (
         href.includes(process.env.REACT_APP_OPTIONSPAGE_DEV) ||

--- a/src/common.test.js
+++ b/src/common.test.js
@@ -9,6 +9,7 @@ jest.mock("./libs/storage", () => ({
   getSettingWithDefault: jest.fn(),
   getFabWithDefault: jest.fn(),
   getWordsWithDefault: jest.fn(),
+  runDataMigration: jest.fn(),
 }));
 
 jest.mock("./libs/iframe", () => ({
@@ -60,9 +61,11 @@ const {
   getSettingWithDefault,
   getFabWithDefault,
   getWordsWithDefault,
+  runDataMigration,
 } = require("./libs/storage");
 const { matchRule } = require("./libs/rules");
 const { runSubtitle } = require("./subtitle/subtitle");
+const { injectInlineJs } = require("./libs/injector");
 const TranslatorManager = require("./libs/translatorManager").default;
 const { run } = require("./common");
 
@@ -74,10 +77,16 @@ function setReadyState(value) {
 }
 
 describe("common iframe startup", () => {
+  const originalOptionsPage = process.env.REACT_APP_OPTIONSPAGE;
+  const originalOptionsPageDev = process.env.REACT_APP_OPTIONSPAGE_DEV;
+
   beforeEach(() => {
     document.documentElement.innerHTML = "<head></head><body></body>";
     setReadyState("complete");
     mockIsIframe = false;
+    process.env.REACT_APP_OPTIONSPAGE = "https://kiss.example/options.html";
+    process.env.REACT_APP_OPTIONSPAGE_DEV = "http://localhost:3000/options.html";
+    delete globalThis.unsafeWindow;
     jest.clearAllMocks();
 
     TranslatorManager.mockImplementation(() => ({
@@ -92,10 +101,25 @@ describe("common iframe startup", () => {
     });
     getFabWithDefault.mockResolvedValue({ isHide: false });
     getWordsWithDefault.mockResolvedValue({});
+    runDataMigration.mockResolvedValue();
     matchRule.mockResolvedValue({
       transOpen: "true",
       highlightWords: "-",
     });
+  });
+
+  afterEach(() => {
+    if (originalOptionsPage === undefined) {
+      delete process.env.REACT_APP_OPTIONSPAGE;
+    } else {
+      process.env.REACT_APP_OPTIONSPAGE = originalOptionsPage;
+    }
+    if (originalOptionsPageDev === undefined) {
+      delete process.env.REACT_APP_OPTIONSPAGE_DEV;
+    } else {
+      process.env.REACT_APP_OPTIONSPAGE_DEV = originalOptionsPageDev;
+    }
+    delete globalThis.unsafeWindow;
   });
 
   test("starts translator manager for iframe with text", async () => {
@@ -152,5 +176,184 @@ describe("common iframe startup", () => {
     expect(TranslatorManager).toHaveBeenCalledTimes(1);
     expect(mockTranslatorManagerStart).toHaveBeenCalledTimes(1);
     expect(runSubtitle).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates legacy userscript GM shim before data migration", async () => {
+    const originalGM = globalThis.GM;
+    const originalGMGetValue = globalThis.GM_getValue;
+    const originalGMXmlhttpRequest = globalThis.GM_xmlhttpRequest;
+    const legacyGetValue = jest.fn();
+    const legacyXmlhttpRequest = jest.fn();
+    let gmDuringMigration;
+
+    delete globalThis.GM;
+    globalThis.GM_getValue = legacyGetValue;
+    globalThis.GM_xmlhttpRequest = legacyXmlhttpRequest;
+    runDataMigration.mockImplementation(async () => {
+      gmDuringMigration = globalThis.GM;
+    });
+
+    try {
+      await run(true);
+
+      expect(runDataMigration).toHaveBeenCalledTimes(1);
+      expect(gmDuringMigration).toBeDefined();
+      expect(gmDuringMigration.getValue).toBe(legacyGetValue);
+      expect(gmDuringMigration.xmlHttpRequest).toBe(legacyXmlhttpRequest);
+    } finally {
+      if (originalGM === undefined) {
+        delete globalThis.GM;
+      } else {
+        globalThis.GM = originalGM;
+      }
+      if (originalGMGetValue === undefined) {
+        delete globalThis.GM_getValue;
+      } else {
+        globalThis.GM_getValue = originalGMGetValue;
+      }
+      if (originalGMXmlhttpRequest === undefined) {
+        delete globalThis.GM_xmlhttpRequest;
+      } else {
+        globalThis.GM_xmlhttpRequest = originalGMXmlhttpRequest;
+      }
+    }
+  });
+
+  test("fills missing fields on existing userscript GM object", async () => {
+    const originalGM = globalThis.GM;
+    const originalGMXmlhttpRequest = globalThis.GM_xmlhttpRequest;
+    const existingSetValue = jest.fn();
+    const legacyXmlhttpRequest = jest.fn();
+    let gmDuringMigration;
+
+    globalThis.GM = { setValue: existingSetValue };
+    globalThis.GM_xmlhttpRequest = legacyXmlhttpRequest;
+    runDataMigration.mockImplementation(async () => {
+      gmDuringMigration = globalThis.GM;
+    });
+
+    try {
+      await run(true);
+
+      expect(runDataMigration).toHaveBeenCalledTimes(1);
+      expect(gmDuringMigration.setValue).toBe(existingSetValue);
+      expect(gmDuringMigration.xmlHttpRequest).toBe(legacyXmlhttpRequest);
+    } finally {
+      if (originalGM === undefined) {
+        delete globalThis.GM;
+      } else {
+        globalThis.GM = originalGM;
+      }
+      if (originalGMXmlhttpRequest === undefined) {
+        delete globalThis.GM_xmlhttpRequest;
+      } else {
+        globalThis.GM_xmlhttpRequest = originalGMXmlhttpRequest;
+      }
+    }
+  });
+
+  test("does not replace existing GM xmlHttpRequest", async () => {
+    const originalGM = globalThis.GM;
+    const originalGMXmlhttpRequest = globalThis.GM_xmlhttpRequest;
+    const existingXmlhttpRequest = jest.fn();
+    const legacyXmlhttpRequest = jest.fn();
+    let gmDuringMigration;
+
+    globalThis.GM = { xmlHttpRequest: existingXmlhttpRequest };
+    globalThis.GM_xmlhttpRequest = legacyXmlhttpRequest;
+    runDataMigration.mockImplementation(async () => {
+      gmDuringMigration = globalThis.GM;
+    });
+
+    try {
+      await run(true);
+
+      expect(runDataMigration).toHaveBeenCalledTimes(1);
+      expect(gmDuringMigration.xmlHttpRequest).toBe(existingXmlhttpRequest);
+    } finally {
+      if (originalGM === undefined) {
+        delete globalThis.GM;
+      } else {
+        globalThis.GM = originalGM;
+      }
+      if (originalGMXmlhttpRequest === undefined) {
+        delete globalThis.GM_xmlhttpRequest;
+      } else {
+        globalThis.GM_xmlhttpRequest = originalGMXmlhttpRequest;
+      }
+    }
+  });
+
+  test("falls back when unsafeWindow grant exists but unsafeWindow is unavailable", async () => {
+    const originalHref = window.location.href;
+    window.history.pushState({}, "", "/options.html");
+    process.env.REACT_APP_OPTIONSPAGE = window.location.href;
+    globalThis.GM = {
+      info: {
+        script: {
+          grant: ["unsafeWindow"],
+        },
+      },
+    };
+
+    try {
+      await run(true);
+
+      expect(injectInlineJs).toHaveBeenCalledTimes(1);
+      expect(injectInlineJs.mock.calls[0][1]).toBe(
+        "kiss-translator-options-injector"
+      );
+    } finally {
+      window.history.pushState({}, "", originalHref);
+      delete globalThis.GM;
+    }
+  });
+
+  test("mounts GM directly when unsafeWindow is available", async () => {
+    const originalHref = window.location.href;
+    const gm = {
+      info: {
+        script: {
+          grant: ["unsafeWindow"],
+        },
+      },
+    };
+    window.history.pushState({}, "", "/options.html");
+    process.env.REACT_APP_OPTIONSPAGE = window.location.href;
+    globalThis.GM = gm;
+    globalThis.unsafeWindow = {};
+
+    try {
+      await run(true);
+
+      expect(globalThis.unsafeWindow.GM).toBe(gm);
+      expect(globalThis.unsafeWindow.APP_INFO).toEqual({
+        name: process.env.REACT_APP_NAME,
+        version: process.env.REACT_APP_VERSION,
+      });
+      expect(injectInlineJs).not.toHaveBeenCalled();
+    } finally {
+      window.history.pushState({}, "", originalHref);
+      delete globalThis.GM;
+    }
+  });
+
+  test("falls back when GM grant metadata is missing", async () => {
+    const originalHref = window.location.href;
+    window.history.pushState({}, "", "/options.html");
+    process.env.REACT_APP_OPTIONSPAGE = window.location.href;
+    globalThis.GM = { info: {} };
+
+    try {
+      await run(true);
+
+      expect(injectInlineJs).toHaveBeenCalledTimes(1);
+      expect(injectInlineJs.mock.calls[0][1]).toBe(
+        "kiss-translator-options-injector"
+      );
+    } finally {
+      window.history.pushState({}, "", originalHref);
+      delete globalThis.GM;
+    }
   });
 });

--- a/src/hooks/Setting.js
+++ b/src/hooks/Setting.js
@@ -43,10 +43,13 @@ export function SettingProvider({ children, context }) {
     update,
     reload,
   } = useStorage(STOKEY_SETTING, DEFAULT_SETTING, KV_SETTING_KEY);
+  const hasSetting = !!setting;
+  const settingVersion = getSettingVersion(setting);
+  const logLevel = setting?.logLevel;
 
   // 兼容直接从 Storage 或云同步回填进来的旧版设置，确保进入界面的配置已经升级到 V2。
   useEffect(() => {
-    if (!setting || getSettingVersion(setting) >= SETTINGS_VERSION_V2) {
+    if (!hasSetting || settingVersion >= SETTINGS_VERSION_V2) {
       return;
     }
 
@@ -60,7 +63,7 @@ export function SettingProvider({ children, context }) {
 
       return migrateSettingPromptsToV2(currentSetting);
     });
-  }, [setting?.version, update]);
+  }, [hasSetting, settingVersion, update]);
 
   // 对设置项中老版本可能存在的 boolean 类型 darkMode 进行自动平滑升级为三种模式类型 (dark, light, auto)
   useEffect(() => {
@@ -79,15 +82,15 @@ export function SettingProvider({ children, context }) {
 
     (async () => {
       try {
-        logger.setLevel(setting?.logLevel);
+        logger.setLevel(logLevel);
         if (isExt) {
-          await sendBgMsg(MSG_SET_LOGLEVEL, setting?.logLevel);
+          await sendBgMsg(MSG_SET_LOGLEVEL, logLevel);
         }
       } catch (error) {
         logger.error("Failed to fetch log level, using default.", error);
       }
     })();
-  }, [isOptionsPage, setting?.logLevel]);
+  }, [isOptionsPage, logLevel]);
 
   // 包装后的更新设置项函数，更新状态的同时异步触发防抖的云端同步机制 (KV 同步)
   const updateSetting = useCallback(

--- a/src/libs/gm.js
+++ b/src/libs/gm.js
@@ -3,10 +3,27 @@ import { genEventName } from "./utils";
 
 // 各项 GM (Greasemonkey) 跨沙盒通信指令
 const MSG_GM_xmlHttpRequest = "xmlHttpRequest";
+const MSG_GM_xmlHttpRequestAbort = "xmlHttpRequestAbort";
 const MSG_GM_setValue = "setValue";
 const MSG_GM_getValue = "getValue";
 const MSG_GM_deleteValue = "deleteValue";
 const MSG_GM_info = "info";
+const GM_XHR_CALLBACKS = [
+  "onloadstart",
+  "onprogress",
+  "onreadystatechange",
+  "onload",
+  "onerror",
+  "onabort",
+  "ontimeout",
+];
+const GM_XHR_TERMINAL_CALLBACKS = new Set([
+  "onload",
+  "onerror",
+  "onabort",
+  "ontimeout",
+]);
+const gmRequestHandles = new Map();
 
 /**
  * 注入网页的初始化脚本，用于将油猴基本信息与事件通道公开给页面环境。
@@ -69,9 +86,62 @@ export const adaptScript = (ping) => {
       }, timeout);
     });
 
+  const xmlHttpRequest = (details) => {
+    const pong = genEventName();
+    const callbacks = {};
+    const requestDetails = { ...details };
+
+    GM_XHR_CALLBACKS.forEach((name) => {
+      if (typeof requestDetails[name] === "function") {
+        callbacks[name] = requestDetails[name];
+        delete requestDetails[name];
+      }
+    });
+
+    const cleanup = () => window.removeEventListener(pong, handleEvent);
+    const handleEvent = (e) => {
+      const { callback, data, error } = e.detail || {};
+      if (error) {
+        cleanup();
+        callbacks.onerror?.(new Error(error));
+        return;
+      }
+
+      callbacks[callback]?.(data);
+      if (GM_XHR_TERMINAL_CALLBACKS.has(callback)) {
+        cleanup();
+      }
+    };
+
+    window.addEventListener(pong, handleEvent);
+    window.dispatchEvent(
+      new CustomEvent(ping, {
+        detail: {
+          action: MSG_GM_xmlHttpRequest,
+          args: { details: requestDetails },
+          pong,
+        },
+      })
+    );
+
+    return {
+      abort: () => {
+        window.dispatchEvent(
+          new CustomEvent(ping, {
+            detail: {
+              action: MSG_GM_xmlHttpRequestAbort,
+              args: { requestId: pong },
+            },
+          })
+        );
+      },
+    };
+  };
+
   // 挂载垫片到宿主页面 window，使运行在普通页面沙盒中的 React / Web 业务代码可以像调用原生 GM 般顺畅
   window.KISS_GM = {
     fetch: (input, init) => promiseGM(MSG_GM_xmlHttpRequest, { input, init }),
+    xmlHttpRequest,
     setValue: (key, val) => promiseGM(MSG_GM_setValue, { key, val }),
     getValue: (key) => promiseGM(MSG_GM_getValue, { key }),
     deleteValue: (key) => promiseGM(MSG_GM_deleteValue, { key }),
@@ -101,9 +171,38 @@ export const handlePing = async (e) => {
   try {
     switch (action) {
       case MSG_GM_xmlHttpRequest:
-        const { input, init } = args;
-        res = await fetchGM(input, init); // 调用跨域特权 fetch
-        break;
+        if ("input" in args) {
+          const { input, init } = args;
+          res = await fetchGM(input, init); // 调用跨域特权 fetch
+          break;
+        }
+
+        gmRequestHandles.set(
+          pong,
+          GM.xmlHttpRequest(
+            GM_XHR_CALLBACKS.reduce(
+              (details, name) => ({
+                ...details,
+                [name]: (data) => {
+                  window.dispatchEvent(
+                    new CustomEvent(pong, {
+                      detail: { callback: name, data },
+                    })
+                  );
+                  if (GM_XHR_TERMINAL_CALLBACKS.has(name)) {
+                    gmRequestHandles.delete(pong);
+                  }
+                },
+              }),
+              args.details
+            )
+          )
+        );
+        return;
+      case MSG_GM_xmlHttpRequestAbort:
+        gmRequestHandles.get(args.requestId)?.abort?.();
+        gmRequestHandles.delete(args.requestId);
+        return;
       case MSG_GM_setValue:
         const { key, val } = args;
         await GM.setValue(key, val);

--- a/src/libs/gm.test.js
+++ b/src/libs/gm.test.js
@@ -1,0 +1,218 @@
+const mockFetchGM = jest.fn();
+
+jest.mock("./fetch", () => ({
+  fetchGM: (...args) => mockFetchGM(...args),
+}));
+
+const utils = require("./utils");
+jest.spyOn(utils, "genEventName").mockReturnValue("pong-adapt");
+const { adaptScript, handlePing } = require("./gm");
+
+describe("gm userscript bridge", () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = "<head></head><body></body>";
+    delete window.KISS_GM;
+    delete window.GM_info;
+    utils.genEventName.mockReturnValue("pong-adapt");
+    mockFetchGM.mockReset();
+  });
+
+  afterEach(() => {
+    delete globalThis.GM;
+    delete window.KISS_GM;
+    delete window.GM_info;
+  });
+
+  test("adaptScript exposes xmlHttpRequest through CustomEvent bridge", () => {
+    const bridgeEvents = [];
+    const onload = jest.fn();
+    window.addEventListener("kiss-ping", (event) => {
+      bridgeEvents.push(event.detail);
+    });
+
+    adaptScript("kiss-ping");
+    const handle = window.KISS_GM.xmlHttpRequest({
+      method: "GET",
+      url: "https://example.test/stream",
+      onload,
+    });
+
+    expect(typeof window.KISS_GM.xmlHttpRequest).toBe("function");
+    expect(typeof handle.abort).toBe("function");
+    expect(bridgeEvents[0]).toMatchObject({
+      action: "xmlHttpRequest",
+      args: {
+        details: {
+          method: "GET",
+          url: "https://example.test/stream",
+        },
+      },
+      pong: "pong-adapt",
+    });
+    expect(bridgeEvents[0].args.details.onload).toBeUndefined();
+
+    window.dispatchEvent(
+      new CustomEvent("pong-adapt", {
+        detail: { callback: "onload", data: { status: 200 } },
+      })
+    );
+
+    expect(onload).toHaveBeenCalledWith({ status: 200 });
+
+    const onabort = jest.fn();
+    utils.genEventName.mockReturnValueOnce("pong-abort-adapt");
+    const abortHandle = window.KISS_GM.xmlHttpRequest({
+      method: "GET",
+      url: "https://example.test/abort",
+      onabort,
+    });
+
+    expect(bridgeEvents[1]).toMatchObject({
+      action: "xmlHttpRequest",
+      args: {
+        details: {
+          method: "GET",
+          url: "https://example.test/abort",
+        },
+      },
+      pong: "pong-abort-adapt",
+    });
+
+    abortHandle.abort();
+
+    expect(bridgeEvents[2]).toMatchObject({
+      action: "xmlHttpRequestAbort",
+      args: { requestId: "pong-abort-adapt" },
+    });
+
+    window.dispatchEvent(
+      new CustomEvent("pong-abort-adapt", {
+        detail: { callback: "onabort", data: { type: "abort" } },
+      })
+    );
+
+    expect(onabort).toHaveBeenCalledWith({ type: "abort" });
+  });
+
+  test("handlePing keeps fetch-shaped xmlHttpRequest requests on fetchGM", async () => {
+    mockFetchGM.mockResolvedValue({
+      body: "ok",
+      headers: {},
+      status: 200,
+      statusText: "OK",
+    });
+    const pong = jest.fn();
+    window.addEventListener("pong-fetch", pong);
+
+    await handlePing(
+      new CustomEvent("kiss-ping", {
+        detail: {
+          action: "xmlHttpRequest",
+          args: {
+            input: "https://example.test/data",
+            init: { method: "POST" },
+          },
+          pong: "pong-fetch",
+        },
+      })
+    );
+
+    expect(mockFetchGM).toHaveBeenCalledWith("https://example.test/data", {
+      method: "POST",
+    });
+    expect(pong).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          data: {
+            body: "ok",
+            headers: {},
+            status: 200,
+            statusText: "OK",
+          },
+        },
+      })
+    );
+  });
+
+  test("handlePing forwards native GM xmlHttpRequest callbacks and aborts", async () => {
+    const abort = jest.fn();
+    let xhrDetails;
+    globalThis.GM = {
+      xmlHttpRequest: jest.fn((details) => {
+        xhrDetails = details;
+        return { abort };
+      }),
+    };
+    const pong = jest.fn();
+    window.addEventListener("pong-xhr", pong);
+
+    await handlePing(
+      new CustomEvent("kiss-ping", {
+        detail: {
+          action: "xmlHttpRequest",
+          args: {
+            details: {
+              method: "GET",
+              url: "https://example.test/events",
+              responseType: "stream",
+            },
+          },
+          pong: "pong-xhr",
+        },
+      })
+    );
+
+    expect(globalThis.GM.xmlHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: "https://example.test/events",
+        responseType: "stream",
+      })
+    );
+
+    xhrDetails.onloadstart({ response: "reader" });
+    xhrDetails.onload({ status: 200 });
+
+    expect(pong).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          callback: "onloadstart",
+          data: { response: "reader" },
+        },
+      })
+    );
+    expect(pong).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          callback: "onload",
+          data: { status: 200 },
+        },
+      })
+    );
+
+    await handlePing(
+      new CustomEvent("kiss-ping", {
+        detail: {
+          action: "xmlHttpRequest",
+          args: {
+            details: {
+              method: "GET",
+              url: "https://example.test/abort",
+            },
+          },
+          pong: "pong-abort",
+        },
+      })
+    );
+    await handlePing(
+      new CustomEvent("kiss-ping", {
+        detail: {
+          action: "xmlHttpRequestAbort",
+          args: { requestId: "pong-abort" },
+        },
+      })
+    );
+
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/libs/requestStream.js
+++ b/src/libs/requestStream.js
@@ -33,6 +33,99 @@ async function* fetchStreamGM(
 ) {
   const asyncQueue = createAsyncQueue();
   const parseSSE = createSSEParser();
+  let readerStarted = false;
+  let pushedChunk = false;
+  let lastResponseTextLength = 0;
+  let settled = false;
+  let responseTextEncoding = "unknown";
+  let pendingResponseText = "";
+  const responseTextDecoder = new TextDecoder();
+
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    asyncQueue.finish();
+  };
+
+  const fail = (error) => {
+    if (settled) return;
+    settled = true;
+    asyncQueue.error(error);
+  };
+
+  const getResponseText = (event = {}) => {
+    if (typeof event.responseText === "string") return event.responseText;
+    if (typeof event.response?.responseText === "string") {
+      return event.response.responseText;
+    }
+    if (typeof event.response === "string") return event.response;
+    return "";
+  };
+
+  const pushSSEText = (text) => {
+    for (const data of parseSSE(text)) {
+      pushedChunk = true;
+      asyncQueue.push(data);
+    }
+  };
+
+  const hasWideChar = (text) => /[^\u0000-\u00ff]/.test(text);
+  const hasHighByte = (text) => /[\u0080-\u00ff]/.test(text);
+  const looksLikeUtf8ByteString = (text) =>
+    /[\u00c2-\u00f4][\u0080-\u00bf]/.test(text);
+
+  const decodeBinaryString = (text, options) => {
+    const bytes = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i += 1) {
+      bytes[i] = text.charCodeAt(i) & 0xff;
+    }
+    return responseTextDecoder.decode(bytes, options);
+  };
+
+  const pushDecodedResponseText = (text, isFinal = false) => {
+    if (!text && !isFinal) return;
+
+    if (responseTextEncoding === "utf8-bytes") {
+      pushSSEText(decodeBinaryString(text, { stream: !isFinal }));
+      return;
+    }
+
+    pendingResponseText += text;
+    if (responseTextEncoding === "unknown") {
+      if (hasWideChar(pendingResponseText)) {
+        responseTextEncoding = "text";
+      } else if (looksLikeUtf8ByteString(pendingResponseText)) {
+        responseTextEncoding = "utf8-bytes";
+      } else if (hasHighByte(pendingResponseText) && !isFinal) {
+        return;
+      } else {
+        responseTextEncoding = "text";
+      }
+    }
+
+    if (responseTextEncoding === "utf8-bytes") {
+      pushSSEText(
+        decodeBinaryString(pendingResponseText, { stream: !isFinal })
+      );
+    } else {
+      pushSSEText(pendingResponseText);
+    }
+    pendingResponseText = "";
+  };
+
+  const pushResponseTextDelta = (event, isFinal = false) => {
+    if (readerStarted || settled) return;
+
+    const responseText = getResponseText(event);
+    if (responseText.length <= lastResponseTextLength) {
+      pushDecodedResponseText("", isFinal);
+      return;
+    }
+
+    const delta = responseText.slice(lastResponseTextLength);
+    lastResponseTextLength = responseText.length;
+    pushDecodedResponseText(delta, isFinal);
+  };
 
   const gmRequest = window.KISS_GM?.xmlHttpRequest || GM.xmlHttpRequest;
   const requestHandle = gmRequest({
@@ -43,7 +136,12 @@ async function* fetchStreamGM(
     anonymous: true,
     timeout,
     responseType: "stream",
-    onloadstart: async ({ response }) => {
+    onloadstart: async ({ response } = {}) => {
+      if (!response?.getReader) {
+        return;
+      }
+
+      readerStarted = true;
       try {
         const reader = response.getReader();
         const decoder = new TextDecoder();
@@ -53,21 +151,33 @@ async function* fetchStreamGM(
           for (const data of parseSSE(
             decoder.decode(value, { stream: true })
           )) {
+            pushedChunk = true;
             asyncQueue.push(data);
           }
         }
       } catch (e) {
-        asyncQueue.error(e);
+        fail(e);
         return;
       }
-      asyncQueue.finish();
+      finish();
     },
-    onerror: (e) => asyncQueue.error(e),
+    onprogress: (event) => pushResponseTextDelta(event),
+    onload: (event) => {
+      if (readerStarted || settled) return;
+
+      pushResponseTextDelta(event, true);
+      if (!pushedChunk) {
+        fail(new Error("GM stream response is not readable."));
+        return;
+      }
+      finish();
+    },
+    onerror: (e) => fail(e),
     onabort: () =>
-      asyncQueue.error(
+      fail(
         new DOMException("The operation was aborted.", "AbortError")
       ),
-    ontimeout: () => asyncQueue.error(new Error("GM stream request timeout")),
+    ontimeout: () => fail(new Error("GM stream request timeout")),
   });
 
   const abortBySignal = () => requestHandle?.abort?.();

--- a/src/libs/requestStream.test.js
+++ b/src/libs/requestStream.test.js
@@ -1,3 +1,7 @@
+let mockIsGm = false;
+const { TextDecoder: UtilTextDecoder } = require("util");
+const originalTextDecoder = global.TextDecoder || UtilTextDecoder;
+
 jest.mock("webextension-polyfill", () => ({
   runtime: {
     connect: jest.fn(),
@@ -6,7 +10,9 @@ jest.mock("webextension-polyfill", () => ({
 
 jest.mock("./client", () => ({
   isExt: false,
-  isGm: false,
+  get isGm() {
+    return mockIsGm;
+  },
 }));
 
 jest.mock("./browser", () => ({
@@ -21,11 +27,13 @@ jest.mock("./storage", () => ({
   getSettingWithDefault: jest.fn(() => Promise.resolve({ httpTimeout: 1000 })),
 }));
 
-import { fetchStreamNative } from "./requestStream";
+import { fetchStreamNative, requestStream } from "./requestStream";
 
 describe("fetchStreamNative", () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    mockIsGm = false;
+    global.TextDecoder = originalTextDecoder;
   });
 
   test("cancels the reader when stream consumption stops early", async () => {
@@ -62,5 +70,151 @@ describe("fetchStreamNative", () => {
     await iterator.return();
 
     expect(cancel).toHaveBeenCalled();
+  });
+});
+
+describe("requestStream in userscript", () => {
+  let requestDetails;
+  let abort;
+
+  const waitForRequestDetails = async () => {
+    for (let i = 0; i < 5 && !requestDetails; i += 1) {
+      await Promise.resolve();
+    }
+    expect(requestDetails).toBeTruthy();
+  };
+
+  beforeEach(() => {
+    mockIsGm = true;
+    abort = jest.fn();
+    requestDetails = null;
+    global.GM = {
+      xmlHttpRequest: jest.fn((details) => {
+        requestDetails = details;
+        return { abort };
+      }),
+    };
+  });
+
+  afterEach(() => {
+    mockIsGm = false;
+    delete global.GM;
+    global.TextDecoder = originalTextDecoder;
+    jest.restoreAllMocks();
+  });
+
+  test("uses readable stream response when getReader is available", async () => {
+    global.TextDecoder = class {
+      decode() {
+        return "data: one\n\n";
+      }
+    };
+    const reader = {
+      read: jest
+        .fn()
+        .mockResolvedValueOnce({
+          done: false,
+          value: new Uint8Array([100]),
+        })
+        .mockResolvedValueOnce({ done: true }),
+    };
+
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    requestDetails.onloadstart({
+      response: {
+        getReader: () => reader,
+      },
+    });
+
+    await expect(first).resolves.toEqual({ value: "one", done: false });
+    await expect(iterator.next()).resolves.toEqual({
+      value: undefined,
+      done: true,
+    });
+    expect(reader.read).toHaveBeenCalledTimes(2);
+  });
+
+  test("uses onprogress responseText when readable stream is unavailable", async () => {
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    requestDetails.onloadstart({});
+    requestDetails.onprogress({ responseText: "data: one\n\n" });
+
+    await expect(first).resolves.toEqual({ value: "one", done: false });
+
+    const second = iterator.next();
+    requestDetails.onprogress({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+
+    await expect(second).resolves.toEqual({ value: "two", done: false });
+
+    const done = iterator.next();
+    requestDetails.onload({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+
+    await expect(done).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test("does not duplicate cumulative responseText chunks", async () => {
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    requestDetails.onprogress({ responseText: "data: one\n\n" });
+    await expect(first).resolves.toEqual({ value: "one", done: false });
+
+    const second = iterator.next();
+    requestDetails.onprogress({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+    await expect(second).resolves.toEqual({ value: "two", done: false });
+
+    const done = iterator.next();
+    requestDetails.onload({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+    await expect(done).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test("decodes UTF-8 byte-string responseText from GM progress", async () => {
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    const data =
+      'data: {"choices":[{"delta":{"content":"ä½ å¥½"}}]}\n\n';
+    const partialDataEnd = 'data: {"choices":[{"delta":{"content":"ä½'
+      .length;
+    requestDetails.onprogress({
+      responseText: data.slice(0, partialDataEnd),
+    });
+    requestDetails.onprogress({ responseText: data });
+
+    await expect(first).resolves.toEqual({
+      value: '{"choices":[{"delta":{"content":"你好"}}]}',
+      done: false,
+    });
+
+    const done = iterator.next();
+    requestDetails.onload({ responseText: data });
+    await expect(done).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test("throws readable error when no stream or progress text is available", async () => {
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    requestDetails.onloadstart({});
+    requestDetails.onload({});
+
+    await expect(first).rejects.toThrow("GM stream response is not readable.");
   });
 });

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -35,7 +35,6 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import ApiIcon from "@mui/icons-material/Api";
 import Link from "@mui/material/Link";
-import { useTheme } from "../../hooks/Theme";
 import { useSetting } from "../../hooks/Setting";
 import { useAlert } from "../../hooks/Alert";
 import { useApiList, useApiItem } from "../../hooks/Api";

--- a/src/views/Options/Prompts.js
+++ b/src/views/Options/Prompts.js
@@ -88,7 +88,6 @@ function getPromptPlaceholders(category) {
 }
 
 function PromptPlaceholderButtons({ category, disabled, onInsert }) {
-  const i18n = useI18n();
   const placeholders = getPromptPlaceholders(category);
 
   if (placeholders.length === 0) {


### PR DESCRIPTION
1、修复via浏览器流式翻译的bug。
2、修复油猴脚本设置页面流式请求的链路问题。

https://github.com/fishjar/kiss-translator/issues/780
https://github.com/fishjar/kiss-translator/issues/782