### PR TITLE
fix: AI 断句响应解析失败导致字幕丢失

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -366,18 +366,20 @@ const parseIndexSubtitleRes = (raw, events) => {
   };
 
   const stripped = stripMarkdownCodeBlock(String(raw ?? "")).trim();
+  // AI 有时在 JSON 值以 >> 开头时丢掉冒号和引号: "o">> → "o":">>
+  const repaired = stripped.replace(/"([a-z_]+)">>/g, '"$1":">>');
 
   try {
-    return buildResult(JSON.parse(stripped));
+    return buildResult(JSON.parse(repaired));
   } catch {
     try {
       const last = Math.max(
-        stripped.lastIndexOf("},"),
-        stripped.lastIndexOf("}\n"),
-        stripped.lastIndexOf("}\r")
+        repaired.lastIndexOf("},"),
+        repaired.lastIndexOf("}\n"),
+        repaired.lastIndexOf("}\r")
       );
       if (last < 0) return null;
-      return buildResult(JSON.parse(stripped.slice(0, last + 1) + "]"));
+      return buildResult(JSON.parse(repaired.slice(0, last + 1) + "]"));
     } catch {
       return null;
     }

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -365,18 +365,19 @@ const parseIndexSubtitleRes = (raw, events) => {
     return result.length ? result : null;
   };
 
+  const stripped = stripMarkdownCodeBlock(String(raw ?? "")).trim();
+
   try {
-    return buildResult(JSON.parse(raw));
+    return buildResult(JSON.parse(stripped));
   } catch {
     try {
-      const str = String(raw ?? "");
       const last = Math.max(
-        str.lastIndexOf("},"),
-        str.lastIndexOf("}\n"),
-        str.lastIndexOf("}\r")
+        stripped.lastIndexOf("},"),
+        stripped.lastIndexOf("}\n"),
+        stripped.lastIndexOf("}\r")
       );
       if (last < 0) return null;
-      return buildResult(JSON.parse(str.slice(0, last + 1) + "]"));
+      return buildResult(JSON.parse(stripped.slice(0, last + 1) + "]"));
     } catch {
       return null;
     }

--- a/src/subtitle/youtubeAiSegmentation.js
+++ b/src/subtitle/youtubeAiSegmentation.js
@@ -207,7 +207,10 @@ export async function aiSegment({
     logger.info("Youtube Provider: ai segmentation", err);
   }
 
-  return nonSpeechEvents.map(toStandaloneSub);
+  return [
+    ...formatSubtitles(speechEvents, fromLang),
+    ...nonSpeechEvents.map(toStandaloneSub),
+  ].sort((a, b) => a.start - b.start);
 }
 
 /**


### PR DESCRIPTION
### 背景

AI 断句 API 返回的 JSON 在以下情况解析失败，导致字幕列表只剩 [ __ ] 等非语音事件，所有语音字幕丢失：
- Gemini 3 Flash（thinking 开启）把 JSON 包在 ```json ``` markdown code fence 里
- DeepSeek V4 Flash 在翻译含 >> 的文本时输出 malformed JSON（"t">> 而非 "t":">>"）

解析失败后 aiSegment 只返回非语音事件，骗过了 eventsToSubtitles 的 !firstBatchSubtitles?.length fallback 检查，built-in 断句不会触发。

### 改动

1. parseIndexSubtitleRes 加 stripMarkdownCodeBlock（ ef01e22 ）

解析前剥离 markdown code fence，与同文件 parseAIRes 对齐。修复 Gemini 等模型返回 fenced JSON 的情况。

2. aiSegment fallback 包含 speech events（ f4bdc77 ）

AI 解析失败时，用 formatSubtitles(speechEvents, fromLang) 对语音事件做 built-in 断句兜底，而非只返回 nonSpeechEvents。确保任何 AI 输出异常都不会导致字幕全部丢失。

