### PR TITLE
fix: Skip whitespace-only translation groups in auto-scan

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -1372,12 +1372,12 @@ export class Translator {
       return true;
     }
 
-    if (this.#rule.autoScan && this.#isBlockNode(node)) {
+    if (this.#rule.autoScan === "true" && this.#isBlockNode(node)) {
       return true;
     }
 
     if (
-      !this.#rule.autoScan &&
+      this.#rule.autoScan === "false" &&
       (node.matches(this.#rule.selector) ||
         node.querySelector(this.#rule.selector))
     ) {
@@ -1394,6 +1394,10 @@ export class Translator {
     }
 
     const trimmedText = text.trim();
+
+    if (!trimmedText) {
+      return true;
+    }
 
     // 文本长度
     if (
@@ -1959,6 +1963,7 @@ export class Translator {
       // 文本节点
       if (node.nodeType === Node.TEXT_NODE) {
         let text = node.textContent;
+        if (!text.trim()) return "";
 
         // 专业术语替换
         if (this.#combinedTermsRegex) {

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -15,7 +15,7 @@ const flushAsync = async () => {
   await Promise.resolve();
 };
 
-function createTranslator(rule = {}) {
+function createTranslator(rule = {}, setting = {}) {
   return new Translator({
     rule: {
       transOpen: "true",
@@ -34,6 +34,7 @@ function createTranslator(rule = {}) {
       mouseHoverSetting: {},
       customStyles: [],
       transApis: [],
+      ...setting,
     },
   });
 }
@@ -110,5 +111,79 @@ describe("Translator rule styles", () => {
 
     expect(apiTranslate).toHaveBeenCalled();
     expect(target.style.cssText).toContain("color: red");
+  });
+
+  test("skips whitespace-only groups around block children in selected list items", async () => {
+    apiTranslate.mockImplementation(({ text }) =>
+      Promise.resolve({
+        trText: text.trim() ? `Translated ${text}` : " ",
+        isSame: false,
+      })
+    );
+    document.body.innerHTML = `
+      <main id="root">
+        <ul dir="auto">
+          <li>
+            <p dir="auto"><a href="https://website.ltx.video/blog/introducing-ltx-2" rel="nofollow">LTX-2: A New Chapter in Generative AI</a></p>
+          </li>
+          <li>
+            <p dir="auto">ComfyUI official <a href="https://blog.comfy.org/p/ltx-2-open-source-audio-video-ai" rel="nofollow">blogpost</a></p>
+          </li>
+        </ul>
+      </main>
+    `;
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "li, p",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    const wrappers = document.querySelectorAll(
+      `.${Translator.KISS_CLASS.warpper}`
+    );
+    const directListItemWrappers = Array.from(
+      document.querySelectorAll("li")
+    ).flatMap((li) =>
+      Array.from(li.children).filter((child) =>
+        child.classList.contains(Translator.KISS_CLASS.warpper)
+      )
+    );
+    const requestedTexts = apiTranslate.mock.calls.map(([args]) => args.text);
+
+    expect(wrappers.length).toBeGreaterThan(0);
+    expect(directListItemWrappers).toHaveLength(0);
+    expect(requestedTexts.every((text) => text.trim())).toBe(true);
+  });
+
+  test("still translates mixed inline text groups", async () => {
+    apiTranslate.mockResolvedValue({
+      trText: "Translated mixed inline content",
+      isSame: false,
+    });
+    document.body.innerHTML =
+      '<main id="root"><p id="target">Text <a href="#">link</a> tail</p></main>';
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "#target",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    const wrapper = document.querySelector(`.${Translator.KISS_CLASS.warpper}`);
+    const requestedTexts = apiTranslate.mock.calls.map(([args]) => args.text);
+    const combinedRequestedText = requestedTexts.join(" ");
+
+    expect(apiTranslate).toHaveBeenCalled();
+    expect(combinedRequestedText).toContain("Text");
+    expect(combinedRequestedText).toContain("tail");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.textContent).toBe("Translated mixed inline content");
   });
 });


### PR DESCRIPTION
非自动扫描时，忽略翻译空白文本