### PR TITLE
fix: guard node.matches(keepSelector) against CSS selector compatibility exceptions

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -1362,7 +1362,14 @@ export class Translator {
   // 判断是否需要换行
   #shouldBreak(node) {
     if (!Translator.isElementOrFragment(node)) return false;
-    if (node.matches(this.#rule.keepSelector)) return false;
+
+    let matchesKeepSelector = false;
+    try {
+      matchesKeepSelector = node.matches(this.#rule.keepSelector);
+    } catch (err) {
+      kissLog("keepSelector match error in shouldBreak", this.#rule.keepSelector, err);
+    }
+    if (matchesKeepSelector) return false;
 
     if (
       Translator.TAGS.BREAK_LINE.has(node.nodeName?.toUpperCase()) ||
@@ -1428,7 +1435,9 @@ export class Translator {
   // 将不同来源的异常统一转成可展示、可复制的纯文本错误信息
   #formatTranslateError(error) {
     if (error instanceof Error) {
-      return error.stack || error.message || error.name || String(error);
+      const tag = error.name ? `[${error.name}]` : "[UnknownError]";
+      const msg = error.message ? ` ${error.message}` : "";
+      return `${tag}${msg}\n${error.stack || ""}`;
     }
 
     if (typeof error === "string") {
@@ -1994,10 +2003,17 @@ export class Translator {
           return "";
         }
 
+        let matchesKeepSelector = false;
+        try {
+          matchesKeepSelector = node.matches(this.#rule.keepSelector);
+        } catch (err) {
+          kissLog("keepSelector match error", this.#rule.keepSelector, err);
+        }
+
         if (
           (this.#rule.hasRichText === "true" &&
             Translator.TAGS.REPLACE.has(node.tagName)) ||
-          node.matches(this.#rule.keepSelector) ||
+          matchesKeepSelector ||
           // node.matches(this.#ignoreSelector) ||
           !node.textContent.trim()
         ) {
@@ -2013,7 +2029,11 @@ export class Translator {
 
         let innerContent = "";
         node.childNodes.forEach((child) => {
-          innerContent += traverse(child);
+          try {
+            innerContent += traverse(child);
+          } catch (err) {
+            kissLog("traverse child error", child.nodeName, err);
+          }
         });
 
         if (


### PR DESCRIPTION
## Problem

When translating some websites (e.g. `http://swillkb.com/`), every text group fails with a cryptic `translate group error` stack trace. The error originates from `node.matches(this.#rule.keepSelector)` throwing a `SyntaxError` DOMException.

## Root Cause

`keepSelector` defaults to `code, cite, math, .math, a:has(code)`. The `:has()` CSS pseudo-class selector is either unsupported or throws in certain Selector API implementations / browser contexts. `node.matches()` propagates this exception uncaught through `traverse()` → `#serializeForTranslation()` → `#translateNodeGroup()`, failing the entire translation for all text groups.

## Changes

All in `src/libs/translator.js`:

1. **`#shouldBreak`** — wrap `node.matches(keepSelector)` in try-catch, fall back to `false` (not-a-break) when selector matching throws
2. **`traverse()`** — same protection, fall back to `false` (not-a-keep) so the element's children are still traversable for translation
3. **Child node isolation** — each `traverse(child)` call inside `node.childNodes.forEach` is individually try-catched. A single problematic child won't block translation of sibling nodes
4. **`#formatTranslateError`** — now emits `[ErrorType] message\nstack` instead of just the raw stack, making future diagnostics much easier

## Related

- PR #809 (`cacheDigest.js`) addressed a different HTTP-page crypto issue (`crypto.subtle.digest` being unavailable on non-secure contexts). The present fix is independent and complementary.

## Testing

- Verified on `http://swillkb.com/` (HTTP page) — translation now completes without errors
- Verified on `https://github.com/` (HTTPS page) — translation still works