### PR TITLE
fix: follow UI language for API test target lang

### DIFF
--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -79,6 +79,7 @@ import {
   DEFAULT_BATCH_LENGTH,
   DEFAULT_CONTEXT_SIZE,
   OPT_ALL_TRANS_TYPES,
+  OPT_LANGS_LIST,
   API_SPE_TYPES,
   BUILTIN_STONES,
   BUILTIN_PLACEHOLDERS,
@@ -191,7 +192,7 @@ function ApiProviderIcon({ apiType, disabled = false, sx = {} }) {
 function TestButton({ api }) {
   const i18n = useI18n();
   const alert = useAlert();
-  const { setting: { prompts, subtitleSetting } = {} } = useSetting();
+  const { setting: { prompts, subtitleSetting, uiLang } = {} } = useSetting();
   const [loading, setLoading] = useState(false);
   const handleApiTest = async () => {
     try {
@@ -204,10 +205,18 @@ function TestButton({ api }) {
         subtitleSetting
       );
 
+      // 测试译文目标语言跟随界面语言；界面语言为英文（与原文相同）时回退到简体中文
+      const fromLang = "en";
+      const UI_LANG_TO_TRANS = { zh: "zh-CN", zh_TW: "zh-TW" };
+      let toLang = UI_LANG_TO_TRANS[uiLang] || uiLang;
+      if (!OPT_LANGS_LIST.includes(toLang) || toLang === fromLang) {
+        toLang = "zh-CN";
+      }
+
       const { trText } = await apiTranslate({
         text,
-        fromLang: "en",
-        toLang: "zh-CN",
+        fromLang,
+        toLang,
         apiSetting,
         useCache: false,
         usePool: false,


### PR DESCRIPTION
The API test button was hardcoded to translate into `zh-CN`. 
Now the target language follows the UI language (`zh` -> zh-CN, `zh_TW` -> zh-TW, others as-is). 

When the UI is English, it falls back to `zh-CN`.