### PR TITLE
feat: 划词翻译弹窗中支持单击翻译、双击翻译和禁用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ package-lock.json
 *.crx
 *.pem
 *.zip
+.repomixignore
+.agents

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2442,6 +2442,27 @@ export const I18N = {
     ja: `翻訳ボックスの高さ自動調整`,
     ko: `번역 상자 높이 자동 조절`,
   },
+  tranbox_interact_mode: {
+    zh: `翻译框内交互模式`,
+    en: `Transbox Interact Mode`,
+    zh_TW: `翻譯框內互動模式`,
+    ja: `翻訳ボックス内インタラクションモード`,
+    ko: `번역 상자 내 인터랙션 모드`,
+  },
+  tranbox_interact_click: {
+    zh: `单击选中文本触发翻译`,
+    en: `Click selected text to translate`,
+    zh_TW: `單擊選取文字觸發翻譯`,
+    ja: `選択したテキストをクリックして翻訳`,
+    ko: `선택한 텍스트를 클릭하여 번역`,
+  },
+  tranbox_interact_dblclick: {
+    zh: `双击选中文本触发翻译`,
+    en: `Double-click selected text to translate`,
+    zh_TW: `雙擊選取文字觸發翻譯`,
+    ja: `選択したテキストをダブルクリックして翻訳`,
+    ko: `선택한 텍스트를 더블클릭하여 번역`,
+  },
   translate_start_hook: {
     zh: `翻译开始钩子函数`,
     en: `Translate Start Hook`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -107,6 +107,8 @@ export const OPT_TRANBOX_BTN_POSITION_ALL = [
   OPT_TRANBOX_BTN_POSITION_FIXED,
   OPT_TRANBOX_BTN_POSITION_MOUSE,
 ];
+export const OPT_TRANBOX_INTERACT_CLICK = "click"; // 单击翻译框内选中文本触发新翻译
+export const OPT_TRANBOX_INTERACT_DBLCLICK = "dblclick"; // 双击翻译框内选中文本触发新翻译
 export const DEFAULT_TRANBOX_SHORTCUT = ["AltLeft", "KeyS"]; // 呼出划词翻译面板的键盘快捷键
 export const DEFAULT_TRANBOX_SETTING = {
   transOpen: true, // 是否启用划词翻译功能
@@ -128,6 +130,7 @@ export const DEFAULT_TRANBOX_SETTING = {
   autoHeight: false, // 翻译结果框高度是否自适应其文本内容长度
   triggerMode: OPT_TRANBOX_TRIGGER_CLICK, // 划词触发翻译的行为模式
   btnPositionMode: OPT_TRANBOX_BTN_POSITION_FIXED, // 划词后弹出按钮的定位模式
+  tranboxInteractMode: "-", // 翻译框内交互模式（"-"表示禁用）
   // extStyles: "", // 附加样式
   enDict: OPT_DICT_BING, // 默认英文网络词典数据源
   enSug: OPT_SUG_YOUDAO, // 英文输入联想建议源

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -8,6 +8,8 @@ import {
   OPT_TRANBOX_BTN_POSITION_MOUSE,
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
+  OPT_TRANBOX_INTERACT_CLICK,
+  OPT_TRANBOX_INTERACT_DBLCLICK,
 } from "../config";
 
 const TRANBTN_SIZE = isMobile ? 32 : 20;
@@ -199,6 +201,7 @@ export default function useSelectionController({
     btnPositionMode = OPT_TRANBOX_BTN_POSITION_FIXED,
     btnOffsetX = 0,
     btnOffsetY = 0,
+    tranboxInteractMode = "-",
   } = tranboxSetting;
 
   const [showBox, setShowBox] = useState(false);
@@ -275,6 +278,11 @@ export default function useSelectionController({
       pendingSelectionRef.current = snapshot;
       setSelText(snapshot.text);
 
+      // 翻译框内交互模式：拦截面板内选区，等待用户单击/双击触发
+      if (snapshot.source === "panel" && tranboxInteractMode !== "-") {
+        return;
+      }
+
       if (snapshot.rect && followSelection) {
         const x = (snapshot.rect.left + snapshot.rect.right) / 2 + boxOffsetX;
         const y = snapshot.rect.bottom + boxOffsetY;
@@ -319,6 +327,7 @@ export default function useSelectionController({
     [
       hideTranBtn,
       triggerMode,
+      tranboxInteractMode,
       btnPositionMode,
       btnOffsetX,
       btnOffsetY,
@@ -442,6 +451,34 @@ export default function useSelectionController({
       window.removeEventListener("click", handleHideBox);
     };
   }, [hideClickAway]);
+
+  // 监听翻译框内交互事件（单击/双击选中文本触发新翻译）
+  useEffect(() => {
+    if (
+      tranboxInteractMode !== OPT_TRANBOX_INTERACT_CLICK &&
+      tranboxInteractMode !== OPT_TRANBOX_INTERACT_DBLCLICK
+    ) {
+      return;
+    }
+
+    const eventName =
+      tranboxInteractMode === OPT_TRANBOX_INTERACT_DBLCLICK
+        ? "dblclick"
+        : "mouseup";
+
+    function handleInteract(e) {
+      if (!isTranboxEvent(e)) return;
+      const selection = window.getSelection();
+      const currentSelectedText = selection?.toString()?.trim() || "";
+      if (!currentSelectedText) return;
+      handleOpenTranbox(currentSelectedText);
+    }
+
+    document.addEventListener(eventName, handleInteract, true);
+    return () => {
+      document.removeEventListener(eventName, handleInteract, true);
+    };
+  }, [tranboxInteractMode, handleOpenTranbox]);
 
   return {
     showBox,

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -11,6 +11,8 @@ import {
   OPT_TRANBOX_TRIGGER_ALL,
   OPT_TRANBOX_BTN_POSITION_FIXED,
   OPT_TRANBOX_BTN_POSITION_ALL,
+  OPT_TRANBOX_INTERACT_CLICK,
+  OPT_TRANBOX_INTERACT_DBLCLICK,
   OPT_DICT_BING,
   OPT_DICT_ALL,
   OPT_SUG_ALL,
@@ -93,6 +95,7 @@ export default function Tranbox() {
     followSelection = false,
     autoHeight = false,
     triggerMode = OPT_TRANBOX_TRIGGER_CLICK,
+    tranboxInteractMode = "-",
     btnPositionMode = OPT_TRANBOX_BTN_POSITION_FIXED,
     enDict = OPT_DICT_BING,
     enSug = OPT_SUG_YOUDAO,
@@ -459,6 +462,27 @@ export default function Tranbox() {
               >
                 <MenuItem value={false}>{i18n("disable")}</MenuItem>
                 <MenuItem value={true}>{i18n("enable")}</MenuItem>
+              </TextField>
+            </Grid>
+
+            {/* 翻译框内部交互：单击或双击选中文本触发新翻译 */}
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <TextField
+                fullWidth
+                select
+                size="small"
+                name="tranboxInteractMode"
+                value={tranboxInteractMode}
+                label={i18n("tranbox_interact_mode")}
+                onChange={handleChange}
+              >
+                <MenuItem value="-">{i18n("disable")}</MenuItem>
+                <MenuItem value={OPT_TRANBOX_INTERACT_CLICK}>
+                  {i18n("tranbox_interact_click")}
+                </MenuItem>
+                <MenuItem value={OPT_TRANBOX_INTERACT_DBLCLICK}>
+                  {i18n("tranbox_interact_dblclick")}
+                </MenuItem>
               </TextField>
             </Grid>
             {/* 油猴脚本下触发调出主动查词输入框的热键录入 */}


### PR DESCRIPTION
划词翻译弹窗中支持单击翻译、双击翻译和禁用。以便于复制弹窗中的内容
之前提过一次（#582），但后来Revert就没有下文了。因为主分支又更新了很多，我又修改了一下。
这个PR主要是方便复制弹窗里的内容，我是不使用“显示翻译按钮”的，所以默认模式下很难复制，因此需要这个功能。