### PR TITLE
feat: add support for OpenCode AI translation

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -143,6 +143,7 @@ const userscriptWebpack = (config, env) => {
 // @connect       dict.youdao.com
 // @connect       api.anthropic.com
 // @connect       api.deepseek.com
+// @connect       opencode.ai
 // @connect       api.siliconflow.cn
 // @connect       api.xiaomimimo.com
 // @connect       dashscope.aliyuncs.com

--- a/public/api/OpenCodeGo.svg
+++ b/public/api/OpenCodeGo.svg
@@ -1,0 +1,7 @@
+<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em"
+    xmlns="http://www.w3.org/2000/svg">
+    <title>OpenCode Go</title>
+    <rect width="24" height="24" rx="4" fill="#131010"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M18 20H6V4h12v16zm-3-12H9v8h6V8z" fill="white"/>
+    <path d="M15 10v6h-6v-6h6z" fill="#5A5858"/>
+</svg>

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -8,6 +8,7 @@ import {
   OPT_TRANS_DEEPLFREE,
   OPT_TRANS_DEEPLX,
   OPT_TRANS_DEEPSEEK,
+  OPT_TRANS_OPENCODEGO,
   OPT_TRANS_SILICONFLOW,
   OPT_TRANS_XIAOMIMIMO,
   OPT_TRANS_ALIYUNBAILIAN,
@@ -344,9 +345,9 @@ const usesIndexSubtitleInput = (prompt = "") => {
 const geminiText = (parts) =>
   Array.isArray(parts)
     ? parts
-        .filter((p) => !p.thought && p.text)
-        .map((p) => p.text)
-        .join("")
+      .filter((p) => !p.thought && p.text)
+      .map((p) => p.text)
+      .join("")
     : "";
 
 const parseIndexSubtitleRes = (raw, events) => {
@@ -953,6 +954,7 @@ const genReqFuncs = {
   [OPT_TRANS_DEEPL]: genDeepl,
   [OPT_TRANS_DEEPLFREE]: genDeeplFree,
   [OPT_TRANS_DEEPSEEK]: genOpenAI,
+  [OPT_TRANS_OPENCODEGO]: genOpenAI,
   [OPT_TRANS_SILICONFLOW]: genOpenAI,
   [OPT_TRANS_XIAOMIMIMO]: genOpenAI,
   [OPT_TRANS_ALIYUNBAILIAN]: genOpenAI,
@@ -1059,49 +1061,49 @@ export const genTransReq = async ({ reqHook, ...args }) => {
 
     let baseSystemPrompt = events
       ? genSubtitlePrompt({
-          subtitlePrompt,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo,
-          tone,
-          aiTerms,
-        })
+        subtitlePrompt,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo,
+        tone,
+        aiTerms,
+      })
       : genSystemPrompt({
-          systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo,
-          tone,
-        });
+        systemPrompt: useBatchFetch ? systemPrompt : nobatchPrompt,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo,
+        tone,
+      });
 
     args.systemPrompt = baseSystemPrompt;
     args.userPrompt = events
       ? buildSubtitleUserPrompt({
-          formattedEvents: usesIndexSubtitleInput(subtitlePrompt)
-            ? formatIndexSubtitleEvents(events)
-            : events,
-          prevContext,
-          nextContext,
-        })
+        formattedEvents: usesIndexSubtitleInput(subtitlePrompt)
+          ? formatIndexSubtitleEvents(events)
+          : events,
+        prevContext,
+        nextContext,
+      })
       : genUserPrompt({
-          nobatchUserPrompt,
-          useBatchFetch,
-          from,
-          to,
-          fromLang,
-          toLang,
-          texts,
-          docInfo,
-          tone,
-          glossary,
-          aiTerms,
-        });
+        nobatchUserPrompt,
+        useBatchFetch,
+        from,
+        to,
+        fromLang,
+        toLang,
+        texts,
+        docInfo,
+        tone,
+        glossary,
+        aiTerms,
+      });
   }
 
   const {
@@ -1261,6 +1263,7 @@ export const parseTransRes = async (
     case OPT_TRANS_EPHONEAI:
     case OPT_TRANS_OPENAI:
     case OPT_TRANS_DEEPSEEK:
+    case OPT_TRANS_OPENCODEGO:
     case OPT_TRANS_SILICONFLOW:
     case OPT_TRANS_XIAOMIMIMO:
     case OPT_TRANS_ALIYUNBAILIAN:
@@ -1336,6 +1339,7 @@ function parseDictRes(res, apiType) {
     case OPT_TRANS_EPHONEAI:
     case OPT_TRANS_OPENAI:
     case OPT_TRANS_DEEPSEEK:
+    case OPT_TRANS_OPENCODEGO:
     case OPT_TRANS_SILICONFLOW:
     case OPT_TRANS_XIAOMIMIMO:
     case OPT_TRANS_ALIYUNBAILIAN:
@@ -1917,6 +1921,7 @@ export const handleSubtitle = async ({
     case OPT_TRANS_EPHONEAI:
     case OPT_TRANS_OPENAI:
     case OPT_TRANS_DEEPSEEK:
+    case OPT_TRANS_OPENCODEGO:
     case OPT_TRANS_SILICONFLOW:
     case OPT_TRANS_XIAOMIMIMO:
     case OPT_TRANS_ALIYUNBAILIAN:
@@ -2119,6 +2124,7 @@ export const handleSummarize = async ({
     case OPT_TRANS_EPHONEAI:
     case OPT_TRANS_OPENAI:
     case OPT_TRANS_DEEPSEEK:
+    case OPT_TRANS_OPENCODEGO:
     case OPT_TRANS_SILICONFLOW:
     case OPT_TRANS_XIAOMIMIMO:
     case OPT_TRANS_ALIYUNBAILIAN:

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -48,6 +48,7 @@ export const OPT_TRANS_GOOGLE_2 = "Google2"; // 谷歌翻译 pa 网页 API (支�
 export const OPT_TRANS_MICROSOFT = "Microsoft"; // 微软翻译服务
 export const OPT_TRANS_AZUREAI = "AzureAI"; // 微软 Azure 翻译
 export const OPT_TRANS_DEEPSEEK = "DeepSeek"; // DeepSeek 深度求索 AI 翻译
+export const OPT_TRANS_OPENCODEGO = "OpenCodeGo"; // OpenCode Go AI 翻译订阅服务
 export const OPT_TRANS_SILICONFLOW = "SiliconFlow"; // 硅基流动 AI 翻译 (云端部署大模型)
 export const OPT_TRANS_XIAOMIMIMO = "XiaomiMimo"; // 小米米莫 AI 翻译
 export const OPT_TRANS_ALIYUNBAILIAN = "AliyunBailian"; // 阿里云百炼大模型翻译
@@ -78,6 +79,7 @@ export const OPT_ALL_TRANS_TYPES = [
   OPT_TRANS_AZUREAI,
   // OPT_TRANS_BAIDU,
   OPT_TRANS_DEEPSEEK,
+  OPT_TRANS_OPENCODEGO,
   OPT_TRANS_SILICONFLOW,
   OPT_TRANS_XIAOMIMIMO,
   OPT_TRANS_ALIYUNBAILIAN,
@@ -126,6 +128,7 @@ export const API_SPE_TYPES = {
     OPT_TRANS_EPHONEAI,
     OPT_TRANS_OPENAI,
     OPT_TRANS_DEEPSEEK,
+    OPT_TRANS_OPENCODEGO,
     OPT_TRANS_SILICONFLOW,
     OPT_TRANS_XIAOMIMIMO,
     OPT_TRANS_ALIYUNBAILIAN,
@@ -142,6 +145,7 @@ export const API_SPE_TYPES = {
   mulkeys: new Set([
     OPT_TRANS_AZUREAI,
     OPT_TRANS_DEEPSEEK,
+    OPT_TRANS_OPENCODEGO,
     OPT_TRANS_SILICONFLOW,
     OPT_TRANS_XIAOMIMIMO,
     OPT_TRANS_ALIYUNBAILIAN,
@@ -162,6 +166,7 @@ export const API_SPE_TYPES = {
   batch: new Set([
     OPT_TRANS_AZUREAI,
     OPT_TRANS_DEEPSEEK,
+    OPT_TRANS_OPENCODEGO,
     OPT_TRANS_SILICONFLOW,
     OPT_TRANS_XIAOMIMIMO,
     OPT_TRANS_ALIYUNBAILIAN,
@@ -183,6 +188,7 @@ export const API_SPE_TYPES = {
   // 支持带历史会话（Context）关联的翻译引擎
   context: new Set([
     OPT_TRANS_DEEPSEEK,
+    OPT_TRANS_OPENCODEGO,
     OPT_TRANS_SILICONFLOW,
     OPT_TRANS_XIAOMIMIMO,
     OPT_TRANS_ALIYUNBAILIAN,
@@ -200,6 +206,7 @@ export const API_SPE_TYPES = {
   // 支持流式文本返回（Server-Sent Events / Stream）的翻译引擎
   stream: new Set([
     OPT_TRANS_DEEPSEEK,
+    OPT_TRANS_OPENCODEGO,
     OPT_TRANS_SILICONFLOW,
     OPT_TRANS_XIAOMIMIMO,
     OPT_TRANS_ALIYUNBAILIAN,
@@ -236,6 +243,13 @@ export const API_SPE_TYPES = {
 // disableSupported: 是否允许用户手动关闭思考模式，默认 true。若为 false 则说明该模型强制开启思考（如 Claude 的部分高推理模型）。
 export const THINKING_PARAM_MAP = {
   [OPT_TRANS_DEEPSEEK]: {
+    type: "deepseek",
+    efforts: [
+      { value: "max", label: "Max" },
+      { value: "high", label: "High" },
+    ],
+  },
+  [OPT_TRANS_OPENCODEGO]: {
     type: "deepseek",
     efforts: [
       { value: "max", label: "Max" },
@@ -465,6 +479,7 @@ export const OPT_LANGS_TO_SPEC = {
     ["zh-TW", "ZH"],
   ]),
   [OPT_TRANS_DEEPSEEK]: OPT_LANGS_SPEC_NAME,
+  [OPT_TRANS_OPENCODEGO]: OPT_LANGS_SPEC_NAME,
   [OPT_TRANS_SILICONFLOW]: OPT_LANGS_SPEC_NAME,
   [OPT_TRANS_XIAOMIMIMO]: OPT_LANGS_SPEC_NAME,
   [OPT_TRANS_ALIYUNBAILIAN]: OPT_LANGS_SPEC_NAME,
@@ -881,6 +896,12 @@ const defaultApiOpts = {
   [OPT_TRANS_DEEPSEEK]: {
     ...defaultApi,
     url: "https://api.deepseek.com/chat/completions",
+    model: "deepseek-v4-flash",
+    ...defaultAiApiOpts,
+  },
+  [OPT_TRANS_OPENCODEGO]: {
+    ...defaultApi,
+    url: "https://opencode.ai/zen/go/v1/chat/completions",
     model: "deepseek-v4-flash",
     ...defaultAiApiOpts,
   },

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -54,6 +54,7 @@ import {
   OPT_TRANS_GOOGLE_2,
   OPT_TRANS_MICROSOFT,
   OPT_TRANS_DEEPSEEK,
+  OPT_TRANS_OPENCODEGO,
   OPT_TRANS_SILICONFLOW,
   OPT_TRANS_XIAOMIMIMO,
   OPT_TRANS_ALIYUNBAILIAN,
@@ -117,6 +118,7 @@ const API_ICON_FILES = {
   [OPT_TRANS_MICROSOFT]: "Microsoft.svg",
   [OPT_TRANS_AZUREAI]: "AzureAI.svg",
   [OPT_TRANS_DEEPSEEK]: "DeepSeek.svg",
+  [OPT_TRANS_OPENCODEGO]: "OpenCodeGo.svg",
   [OPT_TRANS_SILICONFLOW]: "SiliconFlow.svg",
   [OPT_TRANS_XIAOMIMIMO]: "XiaomiMimo.svg",
   [OPT_TRANS_ALIYUNBAILIAN]: "AliyunBailian.svg",
@@ -177,7 +179,7 @@ function ApiProviderIcon({ apiType, disabled = false, sx = {} }) {
             display: "block",
             filter:
               theme.palette.mode === "dark" &&
-              API_SPE_TYPES.darkIcon.has(apiType)
+                API_SPE_TYPES.darkIcon.has(apiType)
                 ? "invert(100%)"
                 : "none",
           })}
@@ -272,9 +274,9 @@ function SensitiveTextField({ value = "", onChange, inputProps, ...props }) {
   const displayValue = editing
     ? value
     : String(value)
-        .split("\n")
-        .map((line) => (line ? "•".repeat(Math.min(line.length, 24)) : ""))
-        .join("\n");
+      .split("\n")
+      .map((line) => (line ? "•".repeat(Math.min(line.length, 24)) : ""))
+      .join("\n");
 
   return (
     <TextField


### PR DESCRIPTION
Add OpenCode (opencode.ai) as a new translation provider, enabling users to use its API alongside existing services like DeepSeek. This includes adding the required @connect directive, API constant, request generation, and response parsing logic.