### PR TITLE
fix: repeate translate node

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -176,6 +176,7 @@ export class Translator {
     br: `${APP_LCNAME}-br`,
     highlight: `${APP_LCNAME}-highlight`,
     retry: `${APP_LCNAME}-retry`,
+    backup: `${APP_LCNAME}-backup`,
   };
 
   // 内置过滤与跳过翻译的正则表达式规则（URL、邮箱、路径、数字、日期、模板等）
@@ -1272,7 +1273,13 @@ export class Translator {
   #startObserveNode(node) {
     // todo: DocumentFragment 无法被 this.#io.observe
     if (!Translator.isElement(node)) return;
-    if (this.#tryAdoptExistingTranslationHost(node)) return;
+    if (this.#tryAdoptExistingTranslationHost(node)) {
+      if (!this.#observedNodes.has(node)) {
+        this.#observedNodes.add(node);
+        this.#io.observe(node);
+      }
+      return;
+    }
 
     if (this.#rule.highlightWords === OPT_HIGHLIGHT_WORDS_BEFORETRANS) {
       this.#highlightWordsDeeply(node);
@@ -1328,9 +1335,13 @@ export class Translator {
 
     const hasText = Translator.hasTextNode(rootNode);
 
+    // 如果当前节点没有直接文本，但只有一个子节点，继续向下钻取，避免在过高层级包裹
     if (!hasText && rootNode.children.length === 1) {
-      this.#scanNode(rootNode.children[0]);
-      return;
+      const child = rootNode.children[0];
+      if (!child.classList?.contains(Translator.KISS_CLASS.warpper)) {
+        this.#scanNode(child);
+        return;
+      }
     }
 
     const hasBlock = this.#hasBlockNode(rootNode);
@@ -2096,7 +2107,7 @@ export class Translator {
       });
       if (hideOrigin) {
         this.#withViewportAnchor(() => {
-          this.#removeNodes(nodes);
+          this.#removeNodes(nodes, wrapper);
         });
       }
 
@@ -2481,6 +2492,22 @@ export class Translator {
     return nodes;
   }
 
+  #getTranslationBackup(wrapper) {
+    return wrapper.querySelector(
+      `:scope > template.${Translator.KISS_CLASS.backup}`
+    );
+  }
+
+  #getOrCreateTranslationBackup(wrapper) {
+    let backup = this.#getTranslationBackup(wrapper);
+    if (!backup) {
+      backup = document.createElement("template");
+      backup.className = Translator.KISS_CLASS.backup;
+      wrapper.appendChild(backup);
+    }
+    return backup;
+  }
+
   #tryAdoptExistingTranslationHost(hostNode) {
     if (!Translator.isElementOrFragment(hostNode)) return false;
 
@@ -2490,10 +2517,15 @@ export class Translator {
     if (!wrappers.length) return false;
 
     wrappers.forEach((wrapper) => {
-      const nodes = this.#collectExistingTranslationNodes(wrapper);
+      const backup = this.#getTranslationBackup(wrapper);
+      const backupNodes = backup ? Array.from(backup.content.childNodes) : [];
+      const hasBackupNodes = backupNodes.length > 0;
+      const nodes = hasBackupNodes
+        ? backupNodes
+        : this.#collectExistingTranslationNodes(wrapper);
       this.#translationNodes.set(wrapper, {
         nodes,
-        isHide: false,
+        isHide: hasBackupNodes,
       });
       nodes.forEach((node) => {
         if (node.nodeType === Node.ELEMENT_NODE) {
@@ -2542,8 +2574,11 @@ export class Translator {
   }
 
   // 移除多个节点
-  #removeNodes(nodes) {
-    if (nodes) {
+  #removeNodes(nodes, wrapper) {
+    if (nodes && wrapper) {
+      const backup = this.#getOrCreateTranslationBackup(wrapper);
+      nodes.forEach((n) => backup.content.appendChild(n));
+    } else if (nodes) {
       const frag = document.createDocumentFragment();
       nodes.forEach((n) => frag.appendChild(n));
     }
@@ -2559,7 +2594,7 @@ export class Translator {
         // 双语变为仅译文
         this.#withViewportAnchor(() => {
           if (br) br.hidden = true;
-          this.#removeNodes(nodes);
+          this.#removeNodes(nodes, el);
         });
         this.#translationNodes.set(el, { nodes, isHide: true });
       } else {
@@ -2860,7 +2895,7 @@ export class Translator {
     if (!data) return;
     const { nodes } = data;
     this.#withViewportAnchor(() => {
-      this.#removeNodes(nodes);
+      this.#removeNodes(nodes, wrapper);
       const inner = wrapper.querySelector(
         `:scope > .${Translator.KISS_CLASS.inner}`
       );

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -1272,6 +1272,7 @@ export class Translator {
   #startObserveNode(node) {
     // todo: DocumentFragment 无法被 this.#io.observe
     if (!Translator.isElement(node)) return;
+    if (this.#tryAdoptExistingTranslationHost(node)) return;
 
     if (this.#rule.highlightWords === OPT_HIGHLIGHT_WORDS_BEFORETRANS) {
       this.#highlightWordsDeeply(node);
@@ -2443,6 +2444,68 @@ export class Translator {
     this.#findTranslationWrappers(node).forEach((el) => {
       this.#removeTranslationElement(el);
     });
+  }
+
+  #collectExistingTranslationNodes(wrapper) {
+    const { transOrder = "original-first" } = this.#rule;
+    const nodes = [];
+    const isOriginalBefore = transOrder !== "translation-first";
+    let current = isOriginalBefore
+      ? wrapper.previousSibling
+      : wrapper.nextSibling;
+
+    while (current) {
+      if (
+        this.#shouldBreak(current) &&
+        !Translator.TAGS.WARP.has(current.nodeName?.toUpperCase())
+      ) {
+        break;
+      }
+
+      if (
+        current.nodeType === Node.ELEMENT_NODE ||
+        current.nodeType === Node.TEXT_NODE
+      ) {
+        if (isOriginalBefore) {
+          nodes.unshift(current);
+        } else {
+          nodes.push(current);
+        }
+      }
+
+      current = isOriginalBefore
+        ? current.previousSibling
+        : current.nextSibling;
+    }
+
+    return nodes;
+  }
+
+  #tryAdoptExistingTranslationHost(hostNode) {
+    if (!Translator.isElementOrFragment(hostNode)) return false;
+
+    const wrappers = Array.from(hostNode.children || []).filter((child) =>
+      child.classList?.contains(Translator.KISS_CLASS.warpper)
+    );
+    if (!wrappers.length) return false;
+
+    wrappers.forEach((wrapper) => {
+      const nodes = this.#collectExistingTranslationNodes(wrapper);
+      this.#translationNodes.set(wrapper, {
+        nodes,
+        isHide: false,
+      });
+      nodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          this.#processedNodes.set(node, { ...this.#rule });
+        }
+      });
+    });
+
+    this.#processedNodes.set(hostNode, { ...this.#rule });
+    this.#observedNodes.add(hostNode);
+    this.#viewNodes.add(hostNode);
+    return true;
   }
 
   // 清理译文

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -174,6 +174,7 @@ export class Translator {
     inner: `${APP_LCNAME}-inner`,
     term: `${APP_LCNAME}-term`,
     br: `${APP_LCNAME}-br`,
+    space: `${APP_LCNAME}-space`,
     highlight: `${APP_LCNAME}-highlight`,
     retry: `${APP_LCNAME}-retry`,
     backup: `${APP_LCNAME}-backup`,
@@ -1991,7 +1992,17 @@ export class Translator {
           wrapper.appendChild(inner);
         }
       } else {
-        wrapper.appendChild(inner);
+        const space = document.createElement("span");
+        space.textContent = " ";
+        space.className = Translator.KISS_CLASS.space;
+        space.hidden = hideOrigin;
+        if (transOrder === "translation-first") {
+          wrapper.appendChild(inner);
+          wrapper.appendChild(space);
+        } else {
+          wrapper.appendChild(space);
+          wrapper.appendChild(inner);
+        }
       }
 
       this.#withViewportAnchor(() => {
@@ -2589,11 +2600,15 @@ export class Translator {
     const { transOrder = "original-first" } = this.#rule;
     this.#findTranslationWrappers(node).forEach((el) => {
       const br = el.querySelector(":scope > br");
+      const space = el.querySelector(
+        `:scope > span.${Translator.KISS_CLASS.space}`
+      );
       const { nodes } = this.#translationNodes.get(el) || {};
       if (transOnly === "true") {
         // 双语变为仅译文
         this.#withViewportAnchor(() => {
           if (br) br.hidden = true;
+          if (space) space.hidden = true;
           this.#removeNodes(nodes, el);
         });
         this.#translationNodes.set(el, { nodes, isHide: true });
@@ -2601,6 +2616,7 @@ export class Translator {
         // 仅译文变为双语
         this.#withViewportAnchor(() => {
           if (br) br.hidden = false;
+          if (space) space.hidden = false;
           if (nodes && nodes.length) {
             const frag = document.createDocumentFragment();
             nodes.forEach((n) => frag.appendChild(n));

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -209,6 +209,106 @@ describe("Translator rule styles", () => {
     expect(wrapper.textContent).toBe("Translated mixed inline content");
   });
 
+  test("continues scanning block children after processing mixed parent nodes", async () => {
+    apiTranslate.mockImplementation(({ text }) =>
+      Promise.resolve({
+        trText: `Translated ${text}`,
+        isSame: false,
+      })
+    );
+    document.body.innerHTML = `
+      <main id="root">
+        <section id="mixed">
+          Intro text
+          <p>Nested paragraph</p>
+        </section>
+      </main>
+    `;
+
+    createTranslator({}, { minLength: 0 });
+    await flushAsync();
+
+    const requestedTexts = apiTranslate.mock.calls.map(([args]) => args.text);
+
+    expect(requestedTexts.some((text) => text.includes("Intro text"))).toBe(
+      true
+    );
+    expect(requestedTexts).toContain("Nested paragraph");
+  });
+
+  test("adopts restored translation wrappers without retranslating", async () => {
+    document.body.innerHTML = `
+      <main id="root">
+        <h3>
+          <a href="/discussion/1">How to fix playback buttons?</a>
+          <kiss-translator class="kiss-translator-wrapper notranslate">
+            <font lang="zh-CN" class="kiss-translator-inner">Existing translation</font>
+          </kiss-translator>
+        </h3>
+      </main>
+    `;
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "h3",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    const wrappers = document.querySelectorAll(
+      `.${Translator.KISS_CLASS.warpper}`
+    );
+    const requestedTexts = apiTranslate.mock.calls.map(([args]) => args.text);
+
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].textContent).toContain("Existing translation");
+    expect(
+      document.querySelector(`h3 a .${Translator.KISS_CLASS.warpper}`)
+    ).toBeNull();
+    expect(requestedTexts).toEqual([]);
+  });
+
+  test("syncs translation-only mode after adopting restored wrappers", async () => {
+    document.body.innerHTML = `
+      <main id="root">
+        <h3>
+          <a href="/discussion/1">How to fix playback buttons?</a>
+          <kiss-translator class="kiss-translator-wrapper notranslate">
+            <br>
+            <font lang="zh-CN" class="kiss-translator-inner">Existing translation</font>
+          </kiss-translator>
+        </h3>
+      </main>
+    `;
+
+    const translator = createTranslator(
+      {
+        autoScan: "false",
+        selector: "h3",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    translator.updateRule({ transOnly: "true" });
+    await flushAsync();
+
+    expect(document.querySelector("h3 a")).toBeNull();
+    expect(document.querySelector("h3").textContent).toContain(
+      "Existing translation"
+    );
+
+    translator.updateRule({ transOnly: "false" });
+    await flushAsync();
+
+    expect(document.querySelector("h3 a")?.textContent).toBe(
+      "How to fix playback buttons?"
+    );
+    expect(apiTranslate).not.toHaveBeenCalled();
+  });
+
   test("does not query shadow roots inside KISS translator elements when scanAll is enabled", async () => {
     document.body.innerHTML = `
       <main id="root">

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -261,9 +261,10 @@ describe("Translator rule styles", () => {
       `.${Translator.KISS_CLASS.warpper}`
     );
     const requestedTexts = apiTranslate.mock.calls.map(([args]) => args.text);
+    const inner = wrappers[0].querySelector(`.${Translator.KISS_CLASS.inner}`);
 
     expect(wrappers).toHaveLength(1);
-    expect(wrappers[0].textContent).toContain("Existing translation");
+    expect(inner.textContent).toContain("Existing translation");
     expect(
       document.querySelector(`h3 a .${Translator.KISS_CLASS.warpper}`)
     ).toBeNull();
@@ -299,6 +300,43 @@ describe("Translator rule styles", () => {
     expect(document.querySelector("h3").textContent).toContain(
       "Existing translation"
     );
+
+    translator.updateRule({ transOnly: "false" });
+    await flushAsync();
+
+    expect(document.querySelector("h3 a")?.textContent).toBe(
+      "How to fix playback buttons?"
+    );
+    expect(apiTranslate).not.toHaveBeenCalled();
+  });
+
+  test("restores original nodes from template backup after transOnly turbo restore", async () => {
+    document.body.innerHTML = `
+      <main id="root">
+        <h3>
+          <kiss-translator class="kiss-translator-wrapper notranslate">
+            <br hidden>
+            <font lang="zh-CN" class="kiss-translator-inner">Existing translation</font>
+            <template class="kiss-translator-backup">
+              <a href="/discussion/1">How to fix playback buttons?</a>
+            </template>
+          </kiss-translator>
+        </h3>
+      </main>
+    `;
+
+    const translator = createTranslator(
+      {
+        autoScan: "false",
+        selector: "h3",
+        transOnly: "true",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    expect(document.querySelector("h3 a")).toBeNull();
+    expect(apiTranslate).not.toHaveBeenCalled();
 
     translator.updateRule({ transOnly: "false" });
     await flushAsync();


### PR DESCRIPTION
修复译文的一些小问题：
- 不换行时，原文和译文之间增加一个空格
- 仅显示译文时，使用 template 来缓存原文
- 修复某些页面会重复翻译的问题，测试页面：https://github.com/TT-ReBORN/Georgia-ReBORN/discussions

<img width="959" height="429" alt="image" src="https://github.com/user-attachments/assets/dac37f52-da1e-45a7-9514-0b8e4dec01d0" />

