### PR TITLE
fix(opencodego): add missing OPT_TRANS_OPENCODEGO to getStreamDelta

### DIFF
--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -7,6 +7,7 @@ import { JSONParser } from "@streamparser/json";
 import {
   OPT_TRANS_OPENAI,
   OPT_TRANS_DEEPSEEK,
+  OPT_TRANS_OPENCODEGO,
   OPT_TRANS_SILICONFLOW,
   OPT_TRANS_XIAOMIMIMO,
   OPT_TRANS_ALIYUNBAILIAN,
@@ -124,6 +125,7 @@ export function getStreamDelta(json, apiType) {
   switch (apiType) {
     case OPT_TRANS_OPENAI:
     case OPT_TRANS_DEEPSEEK:
+    case OPT_TRANS_OPENCODEGO:
     case OPT_TRANS_SILICONFLOW:
     case OPT_TRANS_XIAOMIMIMO:
     case OPT_TRANS_ALIYUNBAILIAN:
@@ -240,7 +242,7 @@ export function createStreamingJsonParser() {
     }
   };
 
-  parser.onError = () => {};
+  parser.onError = () => { };
 
   return {
     /**


### PR DESCRIPTION
## 问题

使用 OpenCodeGO 接口并启用流式翻译时，出现 `No response for item at index 0` 报错。

## 根因

`src/libs/stream.js` 中 `OPT_TRANS_OPENCODEGO` 遗漏在两个地方：
1. import 列表
2. `getStreamDelta()` switch 语句

导致流式 SSE 数据到达时 delta 提取始终返回空字符串，整个流式管道收不到任何内容，async generator 空 yield，最终 `batchQueue.js` 的兜底检查抛出 `No response for item at index 0`。

## 修改

照搬 DeepSeek 的写法，在 `src/libs/stream.js` 中补上两处：

| 位置 | 改动 |
|------|------|
| import 列表 (第 11 行) | 添加 `OPT_TRANS_OPENCODEGO,` |
| getStreamDelta switch (第 130 行) | 添加 `case OPT_TRANS_OPENCODEGO:` |

OpenCodeGO 使用 OpenAI 兼容协议，与 DeepSeek 共享同一段 `json.choices?.[0]?.delta?.content` delta 提取逻辑。

## 全量审计

对比 `OPT_TRANS_DEEPSEEK` 在全项目的出现位置，确认 OpenCodeGO 在其他所有文件中均已正确包含（`src/config/api.js`、`src/apis/trans.js`、`src/views/Options/Apis.js`），**仅此一处遗漏**。

## 验证

- `pnpm test` — stream + api + config 共 **57 个测试全部通过**
- 修复影响 3 条流式路径：网页段落翻译、词典翻译、字幕翻译（共用 `getStreamDelta`）