### PR TITLE
Supports translation of the main text of `docs.google.com`

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -32,6 +32,7 @@ import {
   PORT_STREAM_FETCH,
   MSG_UPDATE_ICON,
   MSG_SHA256,
+  MSG_GOOGLE_DOCS_REDIRECT,
 } from "./config";
 import {
   getSettingWithDefault,
@@ -544,6 +545,26 @@ const messageHandlers = {
   [MSG_CLEAR_CACHES]: () => tryClearCaches(), // 清空翻译缓存
   [MSG_OPEN_SEPARATE_WINDOW]: () => openSeparateWindowWithSavedBounds(), // 打开独立翻译小窗口
   [MSG_UPDATE_ICON]: (args, sender) => updateIcon(args, sender?.tab?.id), // 变更页面的插件高亮图标
+  // 将当前激活的 Google Docs 标签页重定向到 mobilebasic 模式以触发翻译
+  // 普通 /edit|view 模式下 Google Docs 用 canvas 渲染无法翻译；mobilebasic 模式渲染为普通 HTML
+  [MSG_GOOGLE_DOCS_REDIRECT]: async () => {
+    const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+    const cur = tabs[0];
+    if (!cur?.url) return { ok: false, error: "No active tab" };
+    // URL 格式：https://docs.google.com/(document|presentation|spreadsheets)/<kind>/<id>/(edit|view|present)
+    const m = cur.url.match(
+      /^(https?:\/\/docs\.google\.com\/(?:document|presentation|spreadsheets)\/[^/]+\/[^/]+)\/(edit|view|present)(\?[^#]*)?(#.*)?$/
+    );
+    if (!m) {
+      return { ok: false, error: "Not a Google Docs edit/view URL", url: cur.url };
+    }
+    const base = m[1];
+    const query = m[3] || "";
+    const fragment = m[4] || "";
+    const mobilebasicUrl = base + "/mobilebasic" + query + fragment;
+    await browser.tabs.update(cur.id, { url: mobilebasicUrl });
+    return { ok: true, url: mobilebasicUrl };
+  },
 };
 
 /**
@@ -560,13 +581,39 @@ browser.runtime.onMessage.addListener(async ({ action, args }, sender) => {
 });
 
 /**
+ * 处理翻译开关动作：如果是 Google Docs 编辑页面，先跳转到 mobilebasic 模式（由页面 load 后自动启用翻译）；
+ * 否则直接发送 MSG_TRANS_TOGGLE 消息到 content script。
+ */
+const handleToggleTranslate = async () => {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const cur = tabs[0];
+  if (!cur?.url) {
+    sendTabMsg(MSG_TRANS_TOGGLE);
+    return;
+  }
+  // URL 格式：https://docs.google.com/(document|presentation|spreadsheets)/<kind>/<id>/(edit|view|present)
+  const m = cur.url.match(
+    /^(https?:\/\/docs\.google\.com\/(?:document|presentation|spreadsheets)\/[^/]+\/[^/]+)\/(edit|view|present)(\?[^#]*)?(#.*)?$/
+  );
+  if (m) {
+    const base = m[1];
+    const query = m[3] || "";
+    const fragment = m[4] || "";
+    const mobilebasicUrl = base + "/mobilebasic" + query + fragment;
+    await browser.tabs.update(cur.id, { url: mobilebasicUrl });
+    return;
+  }
+  sendTabMsg(MSG_TRANS_TOGGLE);
+};
+
+/**
  * 监听浏览器系统快捷键事件 (browser.commands)。
  * 用户在 manifest 中声明的快捷键按下时，后台直接将对应的翻译指令广播给前台 content 脚本。
  */
 browser.commands?.onCommand?.addListener?.((command) => {
   switch (command) {
     case CMD_TOGGLE_TRANSLATE:
-      sendTabMsg(MSG_TRANS_TOGGLE);
+      handleToggleTranslate();
       break;
     case CMD_TOGGLE_TRANSLATE_ONLY:
       sendTabMsg(MSG_TRANS_TOGGLE_ONLY);
@@ -600,7 +647,7 @@ browser?.contextMenus?.onClicked?.addListener?.(
   ({ menuItemId, selectionText }) => {
     switch (menuItemId) {
       case CMD_TOGGLE_TRANSLATE:
-        sendTabMsg(MSG_TRANS_TOGGLE);
+        handleToggleTranslate();
         break;
       case CMD_TOGGLE_TRANSLATE_ONLY:
         sendTabMsg(MSG_TRANS_TOGGLE_ONLY);

--- a/src/common.js
+++ b/src/common.js
@@ -267,6 +267,13 @@ export async function run(isUserscript = false) {
       return;
     }
 
+    // 3.1. Google Docs mobilebasic 模式标记：当 URL 已经是 mobilebasic 模式（如用户点击了 popup 的翻译按钮后跳转过来的），
+    // 此处不自动执行任何跳转，仅标记以便后续使用 mobilebasic 专用规则。
+    // Google Docs 的普通 /edit|view/present 模式重定向不在这里自动执行，必须由用户在 popup 中主动点击触发
+    // （见 PopupCont.js 的 handleTransToggle，会通过 browser.tabs.update 跳转）。
+    // URL 格式：https://docs.google.com/(document|presentation|spreadsheets)/<kind>/<id>/mobilebasic
+    const isGoogleDocsMobile = /^https?:\/\/docs\.google\.com\/(?:document|presentation|spreadsheets)\/[^/]+\/[^/]+\/(mobilebasic|mobile)/.test(href);
+
     // 5. 网页黑名单校验，命中时彻底不启动翻译
     if (isInBlacklist(href, setting.blacklist)) {
       return;
@@ -291,7 +298,23 @@ export async function run(isUserscript = false) {
     }
 
     // 7. 匹配当前网页专用的规则 (三级规则合并：个人 > 订阅 > 内置全局)
-    const rule = await matchRule(href, setting);
+    let rule = await matchRule(href, setting);
+
+    // 7.1. Google Docs mobilebasic 模式特殊处理：使用 .doc-content 容器内的 span 作为选择器
+    // mobilebasic 模式下 Google Docs 渲染为普通 HTML，文本在 span 元素中
+    // 此模式本身就是我们重定向过去的，所以默认开启翻译
+    if (isGoogleDocsMobile) {
+      rule = {
+        ...rule,
+        selector: ".doc-content span, .doc-content p, .doc-content",
+        rootsSelector: ".doc-content, body",
+        autoScan: "false",
+        hasRichText: "true",
+        ignoreSelector:
+          "button, .docs-ml-header, .docs-ml-footer, nav, [role='navigation'], script, style",
+        transOpen: "true",
+      };
+    }
     const favWords = await getFavWords(rule);
     const fabConfig = await getFabWithDefault();
 

--- a/src/config/msg.js
+++ b/src/config/msg.js
@@ -44,6 +44,7 @@ export const MSG_OPEN_SEPARATE_WINDOW = "open_separate_window"; // 请求后台�
 export const PORT_STREAM_FETCH = "kiss_stream_fetch"; // 双向长连接端口名称：用于大模型翻译时的流式输出通道
 export const MSG_UPDATE_ICON = "update_icon"; // 通知后台脚本更新扩展的工具栏图标状态 (激活/灰色状态)
 export const MSG_SHA256 = "sha256"; // 请求后台脚本代算 SHA-256 签名
+export const MSG_GOOGLE_DOCS_REDIRECT = "google_docs_redirect"; // 将当前 Google Docs 标签页重定向到 mobilebasic 模式以触发翻译
 
 // --- 用于 Window.postMessage 与自定义事件通信的事件名称 ---
 export const EVENT_KISS_INNER = "kiss_translator_inner"; // 插件沙箱/内容脚本内部事件

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -2990,11 +2990,9 @@ export class Translator {
     this.#runId++;
 
     if (this.#isInitialized) {
-      if (this.#transAllnow) {
-        this.rescan();
-      } else {
-        this.#reIOViewNodes();
-      }
+      // 总是调用 rescan() 重新扫描所有节点，确保新加载的内容也被翻译
+      // （原来根据 transAllnow 选择 rescan 或 reIOViewNodes，但后者只会重新观察已有节点）
+      this.rescan();
     } else {
       this.#init();
     }

--- a/src/views/Popup/PopupCont.js
+++ b/src/views/Popup/PopupCont.js
@@ -8,6 +8,7 @@ import Grid from "@mui/material/Grid";
 import Snackbar from "@mui/material/Snackbar";
 import MuiAlert from "@mui/material/Alert";
 import { sendBgMsg, sendTabMsg, getCurTab } from "../../libs/msg";
+import { browser } from "../../libs/browser";
 import { isExt } from "../../libs/client";
 import { useI18n } from "../../hooks/I18n";
 import TextField from "@mui/material/TextField";
@@ -109,6 +110,35 @@ export default function PopupCont({
   const handleTransToggle = async (e) => {
     try {
       setRule({ ...rule, transOpen: e.target.checked ? "true" : "false" });
+
+      // Google Docs 编辑/查看页面用 canvas 渲染，无法直接翻译。
+      // 点击翻译时自动跳转到 mobilebasic 模式（该模式渲染为普通 HTML，可翻译）。
+      const isGoogleDocsEdit =
+        currentHref &&
+        /^https?:\/\/docs\.google\.com\/(?:document|presentation|spreadsheets)\/[^/]+\/[^/]+\/(edit|view|present)(?:[?#]|$)/.test(
+          currentHref
+        );
+      if (isGoogleDocsEdit && e.target.checked) {
+        const m = currentHref.match(
+          /^(https?:\/\/docs\.google\.com\/(?:document|presentation|spreadsheets)\/[^/]+\/[^/]+)\/(edit|view|present)(\?[^#]*)?(#.*)?$/
+        );
+        if (m) {
+          const query = m[3] || "";
+          const fragment = m[4] || "";
+          const mobilebasicUrl = m[1] + "/mobilebasic" + query + fragment;
+          try {
+            // 直接调用 background 跳转（无需消息）
+            const tab = await getCurTab();
+            if (tab?.id != null) {
+              await browser.tabs.update(tab.id, { url: mobilebasicUrl });
+            }
+            window.close();
+          } catch (err) {
+            kissLog("google docs redirect", err);
+          }
+          return;
+        }
+      }
 
       if (!processActions) {
         await sendTabMsg(MSG_TRANS_TOGGLE);


### PR DESCRIPTION
- For  https://github.com/fishjar/kiss-translator/issues/479#issuecomment-4817507140 .
- Supports translation of the main text of `docs.google.com`.
- I'm not entirely sure if this is the right direction. The current main idea of ​​the PR is to redirect to https://docs.google.com/document/d/189AbzVGpxhQczTcdfJd13o_EL36t-M5jOEt1hgBIh7w/mobilebasic when translating https://docs.google.com/document/d/189AbzVGpxhQczTcdfJd13o_EL36t-M5jOEt1hgBIh7w . This doesn't seem suitable for implementation in https://github.com/fishjar/kiss-rules.

```bash
brew install vfox
echo 'eval "$(vfox activate bash)"' >> ~/.bashrc
source ~/.bashrc
vfox add nodejs
vfox install nodejs@24.17.0
vfox use --global nodejs@24.17.0
npm config set registry https://registry.npmmirror.com
git clone -b pdf-add git@github.com:linghengqian/kiss-translator.git
cd ./kiss-translator/
npm run build:chrome
# Import the folder `\\wsl.localhost\Ubuntu-26.04\home\lingh\TwinklingLiftWorks\git\public\kiss-translator\build\chrome` into the Microsoft Edge browser.
```
- <img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/b1975900-788a-429f-8155-7e5a0b975824" />
- <img width="2880" height="1696" alt="image" src="https://github.com/user-attachments/assets/3610d98a-820c-4514-b914-bdb1d60f5906" />

