### PR TITLE
Unify translation segment parsing for XML and line responses

### DIFF
--- a/src/apis/index.openaiXml.test.js
+++ b/src/apis/index.openaiXml.test.js
@@ -1,0 +1,90 @@
+jest.mock("query-string", () => ({
+  stringify: (obj) => new URLSearchParams(obj).toString(),
+}));
+
+jest.mock("../libs/fetch", () => ({
+  fetchData: jest.fn(),
+  fetchStream: jest.fn(),
+  fnPolyfill: jest.fn(),
+}));
+
+jest.mock("@streamparser/json", () => ({
+  JSONParser: jest.fn(),
+}));
+
+jest.mock("../libs/browser", () => ({
+  isBuiltinAIAvailable: true,
+  isBg: () => false,
+}));
+
+jest.mock("../libs/docInfo", () => ({
+  getDocInfo: () => ({}),
+}));
+
+import { apiTranslate } from "./index";
+import { fetchData, fetchStream } from "../libs/fetch";
+import { DEFAULT_API_LIST, OPT_TRANS_OPENAI } from "../config";
+
+const getOpenAiApiSetting = () => ({
+  ...DEFAULT_API_LIST.find((api) => api.apiType === OPT_TRANS_OPENAI),
+  apiSlug: "openai_xml_test",
+  key: "test-key",
+  model: "deepseek-v4-flash",
+  useBatchFetch: true,
+  useStream: false,
+  batchInterval: 0,
+  batchSize: 10,
+  batchLength: 10000,
+  fetchInterval: 0,
+  fetchLimit: 1,
+  httpTimeout: 1000,
+});
+
+describe("apiTranslate OpenAI XML", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns trText for non-stream batched OpenAI-compatible XML response", async () => {
+    fetchData.mockResolvedValueOnce({
+      id: "a729d491-11e8-4a8c-bb6a-c780329e1f99",
+      object: "chat.completion",
+      created: 1782580528,
+      model: "deepseek-v4-flash",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content:
+              '<root>\n    <t id="0" sourceLanguage="en">敏捷的棕色狐狸跳过了懒惰的狗。</t>\n</root>',
+          },
+          logprobs: null,
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 544,
+        completion_tokens: 30,
+        total_tokens: 574,
+      },
+    });
+
+    const result = await apiTranslate({
+      text: "The quick brown fox jumps over the lazy dog.",
+      fromLang: "en",
+      toLang: "zh-CN",
+      apiSetting: getOpenAiApiSetting(),
+      useCache: false,
+      usePool: false,
+    });
+
+    expect(fetchStream).not.toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).stream).toBe(false);
+    expect(result).toMatchObject({
+      trText: "敏捷的棕色狐狸跳过了懒惰的狗。",
+      srLang: "en",
+    });
+  });
+});

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -61,6 +61,7 @@ import {
   parseAITerms,
 } from "../libs/utils";
 import { decodeHTMLEntities } from "../libs/html";
+import { parseCompleteTranslationSegments } from "../libs/aiResponseParser";
 import {
   parseStreamingSegments,
   createStreamingJsonParser,
@@ -74,7 +75,6 @@ import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
 import { parseBilingualVtt } from "../subtitle/vtt";
 import { getDocInfo } from "../libs/docInfo";
-import { trustedTypesHelper } from "../libs/trustedTypes";
 
 const keyMap = new Map();
 const urlMap = new Map();
@@ -253,63 +253,18 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   // 剥离 Markdown 常用的 ```json...``` 代码块包裹
   let content = stripMarkdownCodeBlock(raw).trim();
 
-  // 1. 尝试以 JSON 格式提取与纠错
-  try {
-    // 查找 JSON 有效的起始与结束位置，能过滤掉 JSON 块前后的引导语或杂音文本
-    const start = content.search(/(\{|\[)/);
-    const end = content.lastIndexOf(content.includes("}") ? "}" : "]");
-
-    if (start > -1 && end > -1) {
-      const jsonStr = content.substring(start, end + 1);
-      const parsed = JSON.parse(jsonStr);
-
-      const list = Array.isArray(parsed)
-        ? parsed
-        : parsed.translations || (parsed.result ? [parsed.result] : [parsed]);
-
-      if (
-        list.length > 0 &&
-        (list[0].text !== undefined || list[0].translations)
-      ) {
-        return list.map((item) => [
-          decodeHTMLEntities(String(item.text || "")),
-          String(item.sourceLanguage || ""),
-        ]);
-      }
-    }
-  } catch (e) {
-    // 忽略异常，平滑降级到 XML 尝试
+  // JSON/XML/LINE 三种聚合格式统一交给共享字符串解析器处理。
+  // 这里不再直接使用 DOMParser 解析 XML，避免浏览器 Trusted Types / DOMPurify
+  // 清洗自定义标签后导致非流式路径拿不到 <t> 译文。
+  const structuredSegments = parseCompleteTranslationSegments(content, {
+    decodeText: decodeHTMLEntities,
+  });
+  if (structuredSegments.length > 0) {
+    return structuredSegments.map((segment) => segment.translation);
   }
 
-  // 2. 尝试以 XML 标签格式解析 (如 <t>...</t> 或 <seg>...</seg> 块)
-  const xmlTagPattern = /<(t|item|seg)\b/i;
-  if (xmlTagPattern.test(content)) {
-    try {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(
-        trustedTypesHelper.createHTML(content),
-        "text/html"
-      );
-      const elements = doc.querySelectorAll("t, item, seg");
-
-      if (elements.length > 0) {
-        return Array.from(elements).map((el) => [
-          el.innerHTML.trim(),
-          el.getAttribute("sourceLanguage") || "",
-        ]);
-      }
-    } catch (e) {
-      // 忽略，降级到纯文本多级备用
-    }
-  }
-
-  // 3. 兜底策略：纯文本单行/带序号和管道符按行切割解析 (例如 "1 | 译文" 格式)
+  // 兜底策略：纯文本按行切割解析
   return content.split("\n").map((line) => {
-    const pipeMatch = line.match(/^\d+\s*\|\s*(.*)/);
-    if (pipeMatch) {
-      return [decodeHTMLEntities(pipeMatch[1].trim()), ""];
-    }
-
     const text = decodeHTMLEntities(line.replace(/<br\s*\/?>/gi, "\n").trim());
     return [text, ""];
   });

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -18,6 +18,7 @@ jest.mock("../libs/docInfo", () => ({
 import { handleTranslate } from "./trans";
 import { DEFAULT_API_LIST, OPT_TRANS_OPENAI } from "../config";
 import { fetchData, fetchStream } from "../libs/fetch";
+import { trustedTypesHelper } from "../libs/trustedTypes";
 
 const getApiSetting = (apiType) => ({
   ...DEFAULT_API_LIST.find((api) => api.apiType === apiType),
@@ -51,6 +52,7 @@ async function collectAsyncGenerator(generator) {
 describe("handleTranslate", () => {
   afterEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   test("falls back to non-stream request when stream reader is unsupported", async () => {
@@ -91,7 +93,158 @@ describe("handleTranslate", () => {
     expect(result).toEqual([
       {
         id: 0,
-        result: [JSON.stringify([{ text: "你好", sourceLanguage: "en" }]), ""],
+        result: ["你好", "en"],
+      },
+    ]);
+  });
+
+  test("parses non-stream OpenAI XML content and ignores reasoning content", async () => {
+    fetchData.mockResolvedValueOnce({
+      choices: [
+        {
+          finish_reason: "stop",
+          index: 0,
+          logprobs: null,
+          message: {
+            content:
+              '<root>\n    <t id="0" sourceLanguage="en">敏捷的棕色狐狸跳过了懒惰的狗。</t>\n</root>',
+            reasoning_content:
+              "This reasoning text should not be parsed as translation.",
+            role: "assistant",
+          },
+        },
+      ],
+      created: 1782579027,
+      id: "021782579025384c63a6ac480f44318ff02bbee696f61102e5957",
+      model: "doubao-seed-2-0-mini-260428",
+      object: "chat.completion",
+    });
+
+    const result = await collectAsyncGenerator(
+      handleTranslate(["The quick brown fox jumps over the lazy dog."], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...getApiSetting(OPT_TRANS_OPENAI),
+          useStream: false,
+          useBatchFetch: true,
+        },
+        usePool: false,
+      })
+    );
+
+    expect(fetchStream).not.toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).stream).toBe(false);
+    expect(result).toEqual([
+      {
+        id: 0,
+        result: ["敏捷的棕色狐狸跳过了懒惰的狗。", "en"],
+      },
+    ]);
+  });
+
+  test("parses non-stream OpenAI-compatible XML content from DeepSeek-style response", async () => {
+    fetchData.mockResolvedValueOnce({
+      id: "a729d491-11e8-4a8c-bb6a-c780329e1f99",
+      object: "chat.completion",
+      created: 1782580528,
+      model: "deepseek-v4-flash",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content:
+              '<root>\n    <t id="0" sourceLanguage="en">敏捷的棕色狐狸跳过了懒惰的狗。</t>\n</root>',
+          },
+          logprobs: null,
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 544,
+        completion_tokens: 30,
+        total_tokens: 574,
+        prompt_tokens_details: {
+          cached_tokens: 512,
+        },
+        prompt_cache_hit_tokens: 512,
+        prompt_cache_miss_tokens: 32,
+      },
+      system_fingerprint: "fp_8b330d02d0_prod0820_fp8_kvcache_20260402",
+    });
+
+    const result = await collectAsyncGenerator(
+      handleTranslate(["The quick brown fox jumps over the lazy dog."], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...getApiSetting(OPT_TRANS_OPENAI),
+          useStream: false,
+          useBatchFetch: true,
+        },
+        usePool: false,
+      })
+    );
+
+    expect(fetchStream).not.toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).stream).toBe(false);
+    expect(result).toEqual([
+      {
+        id: 0,
+        result: ["敏捷的棕色狐狸跳过了懒惰的狗。", "en"],
+      },
+    ]);
+  });
+
+  test("parses OpenAI XML content before sanitized DOM fallback", async () => {
+    const createHTMLSpy = jest
+      .spyOn(trustedTypesHelper, "createHTML")
+      .mockReturnValue("");
+
+    fetchData.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content:
+              '<root>\n    <t id="0" sourceLanguage="en">敏捷的棕色狐狸跳过了懒惰的狗。</t>\n</root>',
+          },
+        },
+      ],
+    });
+
+    const result = await collectAsyncGenerator(
+      handleTranslate(["The quick brown fox jumps over the lazy dog."], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...getApiSetting(OPT_TRANS_OPENAI),
+          useStream: false,
+          useBatchFetch: true,
+        },
+        usePool: false,
+      })
+    );
+
+    expect(createHTMLSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 0,
+        result: ["敏捷的棕色狐狸跳过了懒惰的狗。", "en"],
       },
     ]);
   });

--- a/src/libs/aiResponseParser.js
+++ b/src/libs/aiResponseParser.js
@@ -1,0 +1,216 @@
+const identity = (value) => value;
+
+// 所有结构化解析器统一输出 `{ id, translation }`，再按 id 排序。
+// `order` 只用于同一个 id 重复出现时保持模型原始输出顺序，不对外暴露。
+const sortSegments = (segments) =>
+  segments
+    .slice()
+    .sort((a, b) => a.id - b.id || a.order - b.order)
+    .map(({ order, ...segment }) => segment);
+
+/**
+ * 将不同 AI 提示词格式返回的单条译文对象归一化为统一结构。
+ *
+ * 该函数同时被完整 JSON 解析和流式 JSON 增量解析复用，避免两条路径对字段别名的支持不一致。
+ * `fallbackId` 只用于非流式完整 JSON 数组中模型省略 id 的兼容场景；流式增量解析会传入 NaN，
+ * 强制要求模型返回 id，防止流式上屏时把无 id 的片段误归到第 0 段。
+ *
+ * @param {Object} item 模型返回的单条译文对象
+ * @param {number} fallbackId 缺少 id 字段时使用的后备段落序号
+ * @param {Object} options 解析选项
+ * @param {Function} options.decodeText 译文文本解码函数，非流式 JSON 会用它还原 HTML 实体
+ * @returns {{id: number, translation: [string, string]}|null} 归一化后的段落；格式无效时返回 null
+ */
+export const normalizeTranslationItem = (
+  item,
+  fallbackId = 0,
+  { decodeText = identity } = {}
+) => {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  // 兼容历史 JSON prompt 与流式 JSON parser 的两种字段名：
+  // `text` 是当前默认聚合 JSON prompt 的主字段，`translation` 是部分流式/旧格式的别名。
+  const rawText =
+    item.text !== undefined
+      ? item.text
+      : item.translation !== undefined
+        ? item.translation
+        : undefined;
+  if (rawText === undefined) {
+    return null;
+  }
+
+  // id 必须最终是整数。流式路径依赖 id 做段落映射和去重，不能接受无法映射的片段。
+  const rawId = item.id ?? fallbackId;
+  const id = Number(rawId);
+  if (!Number.isInteger(id)) {
+    return null;
+  }
+
+  return {
+    id,
+    translation: [
+      decodeText(String(rawText || "")),
+      // `sourceLanguage` 是 XML/JSON 默认字段，`src` 是自定义接口和旧格式中常见的短字段。
+      String(item.sourceLanguage || item.src || ""),
+    ],
+  };
+};
+
+/**
+ * 从完整字符串中解析 JSON 聚合翻译结果。
+ *
+ * 非流式响应有时会在 JSON 前后混入说明文字或 Markdown 残留，因此这里先截取首个 `{`/`[`
+ * 到最后一个 `}`/`]` 的范围，再尝试 JSON.parse。流式 JSON 不使用这个函数做增量解析，
+ * 但会复用 `normalizeTranslationItem()` 处理已完成对象。
+ *
+ * @param {string} content 完整模型输出
+ * @param {Object} options 解析选项
+ * @param {Function} options.decodeText 译文文本解码函数
+ * @returns {Array<{id: number, translation: [string, string]}>} 解析出的段落列表
+ */
+export const parseJsonTranslationSegments = (
+  content,
+  { decodeText = identity } = {}
+) => {
+  const start = content.search(/(\{|\[)/);
+  const end = Math.max(content.lastIndexOf("}"), content.lastIndexOf("]"));
+  if (start < 0 || end < 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(content.substring(start, end + 1));
+    // 兼容三类完整 JSON 输出：
+    // 1. 数组：[{ id, text }]
+    // 2. 包装对象：{ translations: [{ id, text }] }
+    // 3. 单对象：{ id, text }
+    const list = Array.isArray(parsed)
+      ? parsed
+      : parsed.translations || (parsed.result ? [parsed.result] : [parsed]);
+
+    if (!Array.isArray(list) || list.length === 0) {
+      return [];
+    }
+
+    const segments = list
+      .map((item, index) =>
+        normalizeTranslationItem(item, index, { decodeText })
+      )
+      .filter(Boolean)
+      .map((segment, order) => ({ ...segment, order }));
+
+    return sortSegments(segments);
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * 从原始字符串中解析 XML 风格聚合翻译片段。
+ *
+ * 这里故意不使用 DOMParser / Trusted Types / DOMPurify：这些浏览器安全层可能会清洗
+ * `<root>` / `<t>` 这类自定义标签，导致真实扩展页面解析不到译文。直接扫描原始字符串
+ * 可以让流式和非流式对 XML 的行为保持一致。
+ *
+ * @param {string} content 完整或累积中的模型输出
+ * @returns {Array<{id: number, translation: [string, string]}>} 解析出的段落列表
+ */
+export const parseXmlTranslationSegments = (content) => {
+  const segments = [];
+  // 仅匹配已经闭合的标签；流式模式下未闭合片段会留到后续 chunk 再解析。
+  // 支持 t/item/seg 三种标签名，以兼容不同版本 prompt 或自定义响应格式。
+  const tagPattern = /<(t|item|seg)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+  let match;
+
+  while ((match = tagPattern.exec(content)) !== null) {
+    const attrs = match[2] || "";
+    const idMatch = attrs.match(/\bid\s*=\s*["']?(\d+)["']?/i);
+    const sourceMatch = attrs.match(/\bsourceLanguage\s*=\s*["']([^"']*)["']/i);
+    const id = idMatch ? Number(idMatch[1]) : segments.length;
+
+    if (!Number.isInteger(id)) {
+      continue;
+    }
+
+    segments.push({
+      id,
+      order: segments.length,
+      // XML/HTML 片段里的内部标签需要保留给后续渲染，例如译文中包含 <b>React</b>。
+      translation: [match[3].trim(), sourceMatch?.[1] || ""],
+    });
+  }
+
+  return sortSegments(segments);
+};
+
+/**
+ * 从行协议字符串中解析聚合翻译片段。
+ *
+ * 行协议格式为 `id | 译文`。流式解析时必须启用 `requireCompleteLine`，否则最后一行
+ * 尚未接收完整就可能被提前上屏；非流式解析则可以处理最后一行。
+ *
+ * @param {string} content 完整或累积中的模型输出
+ * @param {Object} options 解析选项
+ * @param {boolean} options.requireCompleteLine 是否只解析以换行结束的完整行
+ * @param {Function} options.decodeText 译文文本解码函数
+ * @returns {Array<{id: number, translation: [string, string]}>} 解析出的段落列表
+ */
+export const parseLineTranslationSegments = (
+  content,
+  { requireCompleteLine = false, decodeText = identity } = {}
+) => {
+  const endsWithNewline = content.endsWith("\n");
+  const lines = content.split("\n");
+  const linesToProcess =
+    requireCompleteLine && !endsWithNewline ? lines.slice(0, -1) : lines;
+  const segments = [];
+
+  for (const line of linesToProcess) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine) continue;
+
+    const pipeMatch = trimmedLine.match(/^(\d+)\s*\|\s*(.*)/);
+    if (!pipeMatch) continue;
+
+    segments.push({
+      id: Number(pipeMatch[1]),
+      order: segments.length,
+      translation: [
+        // 行协议用 <br> 表达译文内部换行，避免模型输出的换行破坏 `id | text` 行结构。
+        decodeText(pipeMatch[2].trim().replace(/<br\s*\/?>/gi, "\n")),
+        "",
+      ],
+    });
+  }
+
+  return sortSegments(segments);
+};
+
+/**
+ * 按完整响应的优先级解析结构化翻译结果。
+ *
+ * 优先级保持与 prompt 约束一致：JSON 最明确，其次 XML，最后 LINE。纯文本兜底不放在这里，
+ * 由调用方决定；非流式 `parseAIRes` 会在本函数无结果时按普通文本逐行降级。
+ *
+ * @param {string} content 完整模型输出
+ * @param {Object} options 解析选项
+ * @param {Function} options.decodeText 译文文本解码函数
+ * @returns {Array<{id: number, translation: [string, string]}>} 解析出的段落列表
+ */
+export const parseCompleteTranslationSegments = (
+  content,
+  { decodeText = identity } = {}
+) => {
+  const jsonSegments = parseJsonTranslationSegments(content, { decodeText });
+  if (jsonSegments.length > 0) return jsonSegments;
+
+  const xmlSegments = parseXmlTranslationSegments(content);
+  // 注意：XML 解析故意不传入 decodeText(decodeHTMLEntities)
+  // 因为 decodeHTMLEntities 底层使用 textContent 会剥离掉译文保留的富文本标签(如 <b>)，应保持原样
+  if (xmlSegments.length > 0) return xmlSegments;
+
+  return parseLineTranslationSegments(content, { decodeText });
+};

--- a/src/libs/aiResponseParser.test.js
+++ b/src/libs/aiResponseParser.test.js
@@ -1,0 +1,85 @@
+import {
+  normalizeTranslationItem,
+  parseCompleteTranslationSegments,
+  parseJsonTranslationSegments,
+  parseLineTranslationSegments,
+  parseXmlTranslationSegments,
+} from "./aiResponseParser";
+
+describe("aiResponseParser", () => {
+  test("normalizes translation item field aliases", () => {
+    expect(
+      normalizeTranslationItem({
+        id: "2",
+        translation: "译文",
+        src: "en",
+      })
+    ).toEqual({
+      id: 2,
+      translation: ["译文", "en"],
+    });
+  });
+
+  test("parses JSON array responses", () => {
+    expect(
+      parseJsonTranslationSegments(
+        '[{"id":0,"text":"你好","sourceLanguage":"en"}]'
+      )
+    ).toEqual([{ id: 0, translation: ["你好", "en"] }]);
+  });
+
+  test("parses JSON translations wrapper responses", () => {
+    expect(
+      parseJsonTranslationSegments(
+        '{"translations":[{"id":1,"translation":"世界","src":"en"}]}'
+      )
+    ).toEqual([{ id: 1, translation: ["世界", "en"] }]);
+  });
+
+  test("parses single JSON object responses", () => {
+    expect(
+      parseJsonTranslationSegments(
+        '{"id":0,"text":"单条译文","sourceLanguage":"en"}'
+      )
+    ).toEqual([{ id: 0, translation: ["单条译文", "en"] }]);
+  });
+
+  test("parses XML segments by id and keeps inner HTML", () => {
+    expect(
+      parseXmlTranslationSegments(
+        '<root><t id="1" sourceLanguage="en">世界</t><t id="0" sourceLanguage="en">你好 <b>React</b></t></root>'
+      )
+    ).toEqual([
+      { id: 0, translation: ["你好 <b>React</b>", "en"] },
+      { id: 1, translation: ["世界", "en"] },
+    ]);
+  });
+
+  test("parses LINE protocol and restores br line breaks", () => {
+    expect(
+      parseLineTranslationSegments("0 | 第一行<br>第二行\n1 | 世界")
+    ).toEqual([
+      { id: 0, translation: ["第一行\n第二行", ""] },
+      { id: 1, translation: ["世界", ""] },
+    ]);
+  });
+
+  test("skips incomplete LINE tail when requested", () => {
+    expect(
+      parseLineTranslationSegments("0 | 完整\n1 | 未完成", {
+        requireCompleteLine: true,
+      })
+    ).toEqual([{ id: 0, translation: ["完整", ""] }]);
+  });
+
+  test("parses complete responses in JSON, XML, then LINE order", () => {
+    expect(parseCompleteTranslationSegments("0 | 行协议")).toEqual([
+      { id: 0, translation: ["行协议", ""] },
+    ]);
+    expect(
+      parseCompleteTranslationSegments(
+        '<root><t id="0" sourceLanguage="en">XML译文</t></root>'
+      )
+    ).toEqual([{ id: 0, translation: ["XML译文", "en"] }]);
+  });
+});

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -20,6 +20,11 @@ import {
   OPT_TRANS_CLAUDE,
   OPT_TRANS_EPHONEAI,
 } from "../config";
+import {
+  normalizeTranslationItem,
+  parseLineTranslationSegments,
+  parseXmlTranslationSegments,
+} from "./aiResponseParser";
 
 /**
  * 创建 Server-Sent Events (SSE) 协议数据流解析器
@@ -167,46 +172,26 @@ export function* parseStreamingSegments(content, processedIds) {
   if (!content) return;
 
   // 1. 尝试解析 XML 格式：<t id="0" sourceLanguage="en">译文</t>
-  const xmlRegex =
-    /<(t|item|seg)\s+id="(\d+)"(?:\s+sourceLanguage="([^"]*)")?[^>]*>([\s\S]*?)<\/\1>/gi;
-  let match;
-  let hasXml = false;
-  while ((match = xmlRegex.exec(content)) !== null) {
-    hasXml = true;
-    const id = parseInt(match[2], 10);
-    if (!processedIds.has(id)) {
-      processedIds.add(id);
-      const sourceLanguage = match[3] || "";
-      const translation = [match[4].trim(), sourceLanguage];
-      yield { id, translation };
-    }
-  }
-
-  // 若成功解析到了任意符合 XML 闭合标签的文本，则跳过 Line 协议解析
-  if (hasXml) return;
-
-  // 2. 尝试解析 Line 协议格式：ID | 译文文本
-  const endsWithNewline = content.endsWith("\n");
-  const lines = content.split("\n");
-  // 如果当前累积包不以换行符结尾，说明最后一行可能尚未写完，切掉最后一行以防解析错乱
-  const linesToProcess = endsWithNewline ? lines : lines.slice(0, -1);
-
-  for (const line of linesToProcess) {
-    const trimmedLine = line.trim();
-    if (!trimmedLine) continue;
-
-    const pipeMatch = trimmedLine.match(/^(\d+)\s*\|\s*(.*)/);
-    if (pipeMatch) {
-      const id = parseInt(pipeMatch[1], 10);
+  // XML/LINE 的具体字符串解析规则与非流式共用，流式层只负责 processedIds 去重和增量 yield。
+  const xmlSegments = parseXmlTranslationSegments(content);
+  if (xmlSegments.length > 0) {
+    for (const { id, translation } of xmlSegments) {
       if (!processedIds.has(id)) {
         processedIds.add(id);
-        // 行协议中，大模型换行会被替换成 <br> 以防止破坏行协议结构，在此还原换行符
-        const translation = [
-          pipeMatch[2].trim().replace(/<br\s*\/?>/gi, "\n"),
-          "",
-        ];
         yield { id, translation };
       }
+    }
+    return;
+  }
+
+  // 2. 尝试解析 Line 协议格式：ID | 译文文本
+  // 流式累积文本的最后一行可能还没接收完整，因此必须只解析完整行。
+  for (const { id, translation } of parseLineTranslationSegments(content, {
+    requireCompleteLine: true,
+  })) {
+    if (!processedIds.has(id)) {
+      processedIds.add(id);
+      yield { id, translation };
     }
   }
 }
@@ -229,20 +214,14 @@ export function createStreamingJsonParser() {
 
   // 当解析器提取出一个完整对象时触发
   parser.onValue = ({ value }) => {
-    if (
-      value &&
-      typeof value === "object" &&
-      typeof value.id === "number" &&
-      (typeof value.text === "string" || typeof value.translation === "string")
-    ) {
-      const id = value.id;
-      const translation = value.text || value.translation || "";
-      const sourceLanguage = value.sourceLanguage || value.src || "";
-      pending.push({ id, translation: [translation, sourceLanguage] });
+    // JSON 增量解析仍由 @streamparser/json 负责，但单条对象字段归一化与非流式 JSON 共用。
+    const segment = normalizeTranslationItem(value, NaN);
+    if (segment) {
+      pending.push(segment);
     }
   };
 
-  parser.onError = () => { };
+  parser.onError = () => {};
 
   return {
     /**

--- a/src/libs/stream.test.js
+++ b/src/libs/stream.test.js
@@ -6,6 +6,7 @@ import {
   createSSEParser,
   createStreamingSubtitleParser,
   getStreamDelta,
+  parseStreamingSegments,
 } from "./stream";
 import { OPT_TRANS_EPHONEAI } from "../config";
 
@@ -44,6 +45,28 @@ describe("getStreamDelta", () => {
     };
 
     expect(getStreamDelta(chunk, OPT_TRANS_EPHONEAI)).toBe("hello");
+  });
+});
+
+describe("parseStreamingSegments", () => {
+  test("parses XML segments and skips processed ids", () => {
+    const processedIds = new Set([0]);
+    const result = [
+      ...parseStreamingSegments(
+        '<root><t id="0" sourceLanguage="en">你好</t><t id="1" sourceLanguage="en">世界</t></root>',
+        processedIds
+      ),
+    ];
+
+    expect(result).toEqual([{ id: 1, translation: ["世界", "en"] }]);
+  });
+
+  test("parses complete LINE segments only", () => {
+    const result = [
+      ...parseStreamingSegments("0 | 第一行<br>第二行\n1 | 未完成", new Set()),
+    ];
+
+    expect(result).toEqual([{ id: 0, translation: ["第一行\n第二行", ""] }]);
   });
 });
 


### PR DESCRIPTION
修复在禁用流式传输时，获取不到XML译文的bug。
统一了AI译文解析函数。