### PR TITLE
feat: add switches for fab and context menus

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -312,6 +312,17 @@ async function addContextMenus(contextMenuType = 1) {
   }
 }
 
+function getEffectiveContextMenuType({
+  contextMenusEnabled = true,
+  contextMenuType = 1,
+} = {}) {
+  const menuType = Number(contextMenuType);
+  if (contextMenusEnabled === false || ![1, 2].includes(menuType)) {
+    return 0;
+  }
+  return menuType;
+}
+
 /**
  * 动态更新浏览器的 CSP (Content Security Policy) 和跨域 Origin 修改策略。
  * 利用 Chrome MV3 declarativeNetRequest (DNR) 动态配置规则，
@@ -470,10 +481,17 @@ browser.runtime.onInstalled.addListener(async (details) => {
     registerMsgDisplayScript();
   }
 
-  const { contextMenuType, csplist, orilist, subrulesList } =
-    await getSettingWithDefault();
+  const {
+    contextMenusEnabled,
+    contextMenuType,
+    csplist,
+    orilist,
+    subrulesList,
+  } = await getSettingWithDefault();
 
-  addContextMenus(contextMenuType);
+  addContextMenus(
+    getEffectiveContextMenuType({ contextMenusEnabled, contextMenuType })
+  );
   updateCspRules({ csplist, orilist });
   trySyncAllSubRules({ subrulesList });
 });
@@ -485,6 +503,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
 browser.runtime.onStartup.addListener(async () => {
   const {
     clearCache,
+    contextMenusEnabled,
     contextMenuType,
     subrulesList,
     csplist,
@@ -503,7 +522,9 @@ browser.runtime.onStartup.addListener(async () => {
   }
 
   // REVIEW: 针对“Firefox 重启后菜单消失”的系统 Bug，此处在启动时必须重新添加一次 addContextMenus
-  addContextMenus(contextMenuType);
+  addContextMenus(
+    getEffectiveContextMenuType({ contextMenusEnabled, contextMenuType })
+  );
 
   updateCspRules({ csplist, orilist });
   trySyncSettingAndRules();

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1854,6 +1854,13 @@ export const I18N = {
     ja: `フローティングボタンを隠す`,
     ko: `플로팅 버튼 숨기기`,
   },
+  show_fab_button: {
+    zh: `显示悬浮按钮`,
+    en: `Show Fab Button`,
+    zh_TW: `顯示浮動按鈕`,
+    ja: `フローティングボタンを表示`,
+    ko: `플로팅 버튼 표시`,
+  },
   fab_click_action: {
     zh: `单击悬浮按钮动作`,
     en: `Single Click Fab Action`,
@@ -2238,6 +2245,13 @@ export const I18N = {
     zh_TW: `右鍵選單`,
     ja: `コンテキストメニュー`,
     ko: `컨텍스트 메뉴`,
+  },
+  context_menu_type: {
+    zh: `右键菜单类型`,
+    en: `Context Menu Type`,
+    zh_TW: `右鍵選單類型`,
+    ja: `コンテキストメニュータイプ`,
+    ko: `컨텍스트 메뉴 유형`,
   },
   hide_context_menus: {
     zh: `隐藏右键菜单`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -235,7 +235,8 @@ export const DEFAULT_SETTING = {
   // injectWebfix: true, // 是否注入修复补丁(作废)
   // detectRemote: false, // 是否使用远程语言检测 （从rule移回）
   // contextMenus: true, // 是否添加右键菜单(作废)
-  contextMenuType: 1, // 鼠标右键上下文菜单形式 (0: 禁用, 1: 精简, 2: 完整菜单)
+  contextMenusEnabled: true, // 是否启用鼠标右键上下文菜单
+  contextMenuType: 1, // 鼠标右键上下文菜单形式 (0: 旧版禁用值, 1: 精简, 2: 完整菜单)
   // transTag: DEFAULT_TRANS_TAG, // 译文元素标签(移至rule，作废)
   // transOnly: false, // 是否仅显示译文(移至rule，作废)
   // transTitle: false, // 是否同时翻译页面标题(移至rule，作废)

--- a/src/hooks/useTranboxShortcuts.js
+++ b/src/hooks/useTranboxShortcuts.js
@@ -55,8 +55,8 @@ export default function useTranboxShortcuts({
 
     try {
       const menuCommandIds = [];
-      // 当 contextMenuType 不为 0 时（表明启用菜单项），注册“翻译选中文字”菜单项
-      contextMenuType !== 0 &&
+      // 当 contextMenuType 为有效菜单类型时，注册“翻译选中文字”菜单项
+      [1, 2].includes(Number(contextMenuType)) &&
         menuCommandIds.push(
           GM.registerMenuCommand?.(
             langMap("translate_selected_text"),

--- a/src/libs/translatorManager.js
+++ b/src/libs/translatorManager.js
@@ -611,8 +611,17 @@ export default class TranslatorManager {
    */
   #registerMenus() {
     if (!globalThis.GM) return;
-    const { contextMenuType, uiLang } = this._translator.setting;
-    if (contextMenuType === 0) return;
+    const {
+      contextMenusEnabled = true,
+      contextMenuType,
+      uiLang,
+    } = this._translator.setting;
+    if (
+      contextMenusEnabled === false ||
+      ![1, 2].includes(Number(contextMenuType))
+    ) {
+      return;
+    }
 
     const i18n = newI18n(uiLang || "zh");
 

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -135,11 +135,8 @@ export default function Settings() {
     e.preventDefault();
     let { name, value } = e.target;
 
-    // 特定联动：若是浏览器扩展模式，且修改了右键菜单或CSP规则列表，立即向后台 content script / background 发送同步消息
+    // 特定联动：若是浏览器扩展模式，且修改了 CSP 规则列表，立即向后台 content script / background 发送同步消息
     switch (name) {
-      case "contextMenuType":
-        isExt && sendBgMsg(MSG_CONTEXT_MENUS, value);
-        break;
       case "csplist":
         isExt && sendBgMsg(MSG_UPDATE_CSP, { csplist: value });
         break;
@@ -153,10 +150,16 @@ export default function Settings() {
     });
   };
 
-  const updateContextMenuType = (value) => {
-    const nextContextMenuType = Number(value);
-    isExt && sendBgMsg(MSG_CONTEXT_MENUS, nextContextMenuType);
-    updateSetting({ contextMenuType: nextContextMenuType });
+  const updateContextMenus = ({ enabled, type } = {}) => {
+    const nextEnabled =
+      typeof enabled === "boolean" ? enabled : isContextMenuEnabled;
+    const nextContextMenuType = Number(type ?? contextMenuDisplayType);
+    isExt &&
+      sendBgMsg(MSG_CONTEXT_MENUS, nextEnabled ? nextContextMenuType : 0);
+    updateSetting({
+      contextMenusEnabled: nextEnabled,
+      contextMenuType: nextContextMenuType,
+    });
   };
 
   // 清除本地网络请求翻译缓存
@@ -186,6 +189,7 @@ export default function Settings() {
     clearCache,
     newlineLength = TRANS_NEWLINE_LENGTH,
     httpTimeout = DEFAULT_HTTP_TIMEOUT,
+    contextMenusEnabled = true,
     contextMenuType = 1,
     touchModes = [2],
     blacklist = DEFAULT_BLACKLIST.join(",\n"),
@@ -201,8 +205,10 @@ export default function Settings() {
   const { isHide = false, fabClickAction = 0 } = fab || {};
   const isFabHidden = isHide === true || isHide === "true";
   const normalizedContextMenuType = Number(contextMenuType);
-  const isContextMenuEnabled = [1, 2].includes(normalizedContextMenuType);
-  const contextMenuDisplayType = isContextMenuEnabled
+  const hasContextMenuType = [1, 2].includes(normalizedContextMenuType);
+  const isContextMenuEnabled =
+    contextMenusEnabled !== false && hasContextMenuType;
+  const contextMenuDisplayType = hasContextMenuType
     ? normalizedContextMenuType
     : 1;
 
@@ -391,7 +397,7 @@ export default function Settings() {
                     name="contextMenuEnabled"
                     checked={isContextMenuEnabled}
                     onChange={(e) =>
-                      updateContextMenuType(e.target.checked ? 1 : 0)
+                      updateContextMenus({ enabled: e.target.checked })
                     }
                   />
                 }
@@ -407,7 +413,9 @@ export default function Settings() {
                 name="contextMenuType"
                 value={contextMenuDisplayType}
                 label={i18n("context_menu_type")}
-                onChange={(e) => updateContextMenuType(e.target.value)}
+                onChange={(e) =>
+                  updateContextMenus({ enabled: true, type: e.target.value })
+                }
                 disabled={!isContextMenuEnabled}
               >
                 <MenuItem value={1}>{i18n("simple_context_menus")}</MenuItem>

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -6,6 +6,8 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import MenuItem from "@mui/material/MenuItem";
 import Link from "@mui/material/Link";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
 import { useSetting } from "../../hooks/Setting";
 import { useI18n } from "../../hooks/I18n";
 import { useAlert } from "../../hooks/Alert";
@@ -151,6 +153,12 @@ export default function Settings() {
     });
   };
 
+  const updateContextMenuType = (value) => {
+    const nextContextMenuType = Number(value);
+    isExt && sendBgMsg(MSG_CONTEXT_MENUS, nextContextMenuType);
+    updateSetting({ contextMenuType: nextContextMenuType });
+  };
+
   // 清除本地网络请求翻译缓存
   const handleClearCache = () => {
     try {
@@ -191,6 +199,12 @@ export default function Settings() {
   } = setting;
   // 解构 FAB 悬浮球的显隐状态及点击后的默认交互行为
   const { isHide = false, fabClickAction = 0 } = fab || {};
+  const isFabHidden = isHide === true || isHide === "true";
+  const normalizedContextMenuType = Number(contextMenuType);
+  const isContextMenuEnabled = [1, 2].includes(normalizedContextMenuType);
+  const contextMenuDisplayType = isContextMenuEnabled
+    ? normalizedContextMenuType
+    : 1;
 
   return (
     <Box>
@@ -249,20 +263,18 @@ export default function Settings() {
             </Grid>
             {/* 是否全局隐藏内容页面右侧的悬浮查词小图标 FAB */}
             <Grid item xs={12} sm={12} md={6} lg={3}>
-              <TextField
-                select
-                fullWidth
-                size="small"
-                name="isHide"
-                value={isHide}
-                label={i18n("hide_fab_button")}
-                onChange={(e) => {
-                  updateFab({ isHide: e.target.value });
-                }}
-              >
-                <MenuItem value={false}>{i18n("show")}</MenuItem>
-                <MenuItem value={true}>{i18n("hide")}</MenuItem>
-              </TextField>
+              <FormControlLabel
+                control={
+                  <Switch
+                    name="isHide"
+                    checked={!isFabHidden}
+                    onChange={(e) => {
+                      updateFab({ isHide: !e.target.checked });
+                    }}
+                  />
+                }
+                label={i18n("show_fab_button")}
+              />
             </Grid>
             {/* 点击悬浮球时触发的行为 (直接展示菜单或立即启动全文双语翻译) */}
             <Grid item xs={12} sm={12} md={6} lg={3}>
@@ -274,6 +286,7 @@ export default function Settings() {
                 value={fabClickAction}
                 label={i18n("fab_click_action")}
                 onChange={(e) => updateFab({ fabClickAction: e.target.value })}
+                disabled={isFabHidden}
               >
                 <MenuItem value={0}>{i18n("fab_click_menu")}</MenuItem>
                 <MenuItem value={1}>{i18n("fab_click_translate")}</MenuItem>
@@ -370,6 +383,21 @@ export default function Settings() {
                 ))}
               </TextField>
             </Grid>
+            {/* 浏览器右键上下文菜单启用开关 */}
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    name="contextMenuEnabled"
+                    checked={isContextMenuEnabled}
+                    onChange={(e) =>
+                      updateContextMenuType(e.target.checked ? 1 : 0)
+                    }
+                  />
+                }
+                label={i18n("context_menus")}
+              />
+            </Grid>
             {/* 浏览器右键上下文菜单的展示层级 */}
             <Grid item xs={12} sm={12} md={6} lg={3}>
               <TextField
@@ -377,11 +405,11 @@ export default function Settings() {
                 fullWidth
                 size="small"
                 name="contextMenuType"
-                value={contextMenuType}
-                label={i18n("context_menus")}
-                onChange={handleChange}
+                value={contextMenuDisplayType}
+                label={i18n("context_menu_type")}
+                onChange={(e) => updateContextMenuType(e.target.value)}
+                disabled={!isContextMenuEnabled}
               >
-                <MenuItem value={0}>{i18n("hide_context_menus")}</MenuItem>
                 <MenuItem value={1}>{i18n("simple_context_menus")}</MenuItem>
                 <MenuItem value={2}>{i18n("secondary_context_menus")}</MenuItem>
               </TextField>

--- a/src/views/Selection/index.js
+++ b/src/views/Selection/index.js
@@ -8,6 +8,7 @@ import useTranboxShortcuts from "../../hooks/useTranboxShortcuts";
  * 划词翻译交互整体入口组件
  *
  * @param {Object} props
+ * @param {boolean} props.contextMenusEnabled - 是否启用浏览器右键菜单
  * @param {string} props.contextMenuType - 浏览器右键菜单的类型/配置
  * @param {Object} props.tranboxSetting - 划词翻译框的相关设置项
  * @param {Array} props.transApis - 启用的翻译 API 配置列表
@@ -15,6 +16,7 @@ import useTranboxShortcuts from "../../hooks/useTranboxShortcuts";
  * @param {Object} props.langDetector - 语种检测器的状态配置项
  */
 export default function Selection({
+  contextMenusEnabled = true,
   contextMenuType,
   tranboxSetting,
   transApis,
@@ -22,6 +24,12 @@ export default function Selection({
   uiLang,
   langDetector,
 }) {
+  const normalizedContextMenuType = Number(contextMenuType);
+  const effectiveContextMenuType =
+    contextMenusEnabled === false || ![1, 2].includes(normalizedContextMenuType)
+      ? 0
+      : normalizedContextMenuType;
+
   // 1. 初始化并管理划词翻译框（TranBox）的各种展示和交互状态（如宽高、位置、极简模式、点击外部关闭等）
   const {
     boxSize,
@@ -66,7 +74,7 @@ export default function Selection({
     setShowBox,
     handleOpenTranbox,
     handleToggleTranbox,
-    contextMenuType,
+    contextMenuType: effectiveContextMenuType,
     uiLang,
   });
 


### PR DESCRIPTION
## Summary
- Replace the floating FAB visibility dropdown with a direct Show Fab Button switch while keeping the existing `isHide` storage shape.
- Split context menu settings into an enable switch plus a separate menu type selector.
- Add localized labels for the new controls.

## Validation
- `prettier --check src/views/Options/Setting.js src/config/i18n.js`
- `zx src/scripts/build-task.mjs --target=chrome`

## Note
- `react-app-rewired test --watchAll=false --findRelatedTests src/views/Options/Setting.js` currently fails before this change is exercised because `src/views/Options/index.test.js` mocks `../../libs/log` without exporting `LogLevel`, causing `src/config/setting.js` to throw while reading `LogLevel.INFO.value`.