### PR TITLE
fix: copy TypedArray to avoid Firefox Xray restriction in GM stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /.obsidian
 .pnp.js
 .yarn
-
+.pnpm-store
 # testing
 /coverage
 

--- a/src/libs/log.js
+++ b/src/libs/log.js
@@ -176,4 +176,7 @@ export const logger = new Logger();
 // 可以考虑后续提供类似的快捷别名或直接鼓励大家使用 logger.warn/error 以保持日志语义清晰。
 export const kissLog = logger.info.bind(logger);
 
+export const SPA_DEBUG = false;
+export const spaLog = (...args) => SPA_DEBUG && logger.info(...args);
+
 // TODO：debug日志埋点

--- a/src/libs/requestStream.js
+++ b/src/libs/requestStream.js
@@ -154,8 +154,14 @@ async function* fetchStreamGM(
         while (true) {
           const { done: readerDone, value } = await reader.read();
           if (readerDone) break;
+          // Firefox Xray: TypedArray 跨 origin 边界不可直接访问，
+          // 拷贝ß到当前 realm 以规避 "Accessing TypedArray data over Xrays" 错误。
+          const chunk =
+            value instanceof ArrayBuffer || ArrayBuffer.isView(value)
+              ? new Uint8Array(value)
+              : value;
           for (const data of parseSSE(
-            decoder.decode(value, { stream: true })
+            decoder.decode(chunk, { stream: true })
           )) {
             pushedChunk = true;
             asyncQueue.push(data);

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -22,10 +22,10 @@ import {
 import { resolveApiPromptSettings } from "../config/prompt";
 import { interpreter } from "./interpreter";
 import { clearFetchPool } from "./pool";
-import { debounce, scheduleIdle, genEventName, parseAITerms } from "./utils";
+import { debounce, scheduleIdle, cancelScheduledIdle, genEventName, parseAITerms } from "./utils";
 import { escapeHTML } from "./html";
 import { apiTranslate } from "../apis";
-import { kissLog } from "./log";
+import { kissLog, spaLog } from "./log";
 import { clearAllBatchQueue } from "./batchQueue";
 import { genTextClass } from "./style";
 import { createLoadingSVG, createRetrySVG } from "./svg";
@@ -369,6 +369,7 @@ export class Translator {
 
   #rescanQueue = new Set(); // “脏容器”队列
   #isQueueProcessing = false; // 队列处理状态标志
+  #rescanIdleHandle = null; // scheduleIdle 返回的句柄，用于取消 pending idle rescan
 
   // 获取当前视口中的稳定锚点，用于 DOM 高度/结构发生改变（如插入译文）后保持滚动条位置，防止页面视觉闪烁或滚动位置发生偏移
   #captureViewportAnchor() {
@@ -1052,6 +1053,11 @@ export class Translator {
           continue;
         }
 
+        // 跳过翻译容器自身及其子元素内的变化（如 inner.innerHTML 赋值触发的 childList mutation）
+        if (mutation.target.closest?.(`.${Translator.KISS_CLASS.warpper}`)) {
+          continue;
+        }
+
         if (mutation.type === "characterData") {
           if (
             mutation.oldValue !== mutation.target.nodeValue &&
@@ -1247,9 +1253,12 @@ export class Translator {
   // “脏容器”队列
   #queueForRescan(target) {
     this.#rescanQueue.add(target);
+    spaLog("[SPA-DEBUG] queueForRescan, queue.size=", this.#rescanQueue.size, "isProcessing=", this.#isQueueProcessing, "target=", target?.tagName, target?.className?.slice?.(0, 50));
     if (!this.#isQueueProcessing) {
       this.#isQueueProcessing = true;
-      scheduleIdle(() => {
+      this.#rescanIdleHandle = scheduleIdle(() => {
+        this.#rescanIdleHandle = null;
+        spaLog("[SPA-DEBUG] rescanQueue idle callback, queue.size=", this.#rescanQueue.size, "runId=", this.#runId);
         this.#rescanQueue.forEach((t) => this.#rescanContainer(t));
         this.#rescanQueue.clear();
         this.#isQueueProcessing = false;
@@ -1257,14 +1266,48 @@ export class Translator {
     }
   }
 
-  // 处理“脏容器”
+  #cancelPendingRescanIdle() {
+    if (this.#rescanIdleHandle != null) {
+      cancelScheduledIdle(this.#rescanIdleHandle);
+      this.#rescanIdleHandle = null;
+    }
+    this.#rescanQueue.clear();
+    this.#isQueueProcessing = false;
+  }
+
+  // 处理"脏容器"
   #rescanContainer(changedNode) {
     const container = this.#findChangeContainer(changedNode);
     if (!container) return;
 
-    this.#processedNodes.delete(container); // 删除处理状态，允许重新翻译
+    // 如果容器内的原文（排除翻译 wrapper）未变化，跳过重翻译
+    const prevState = this.#processedNodes.get(container);
+    if (prevState) {
+      const currentText = this.#getSourceTextContent(container);
+      if (prevState._sourceText && prevState._sourceText === currentText) {
+        return;
+      }
+    }
+
+    this.#processedNodes.delete(container);
     this.#cleanupAllTranslations(container);
     this.#scanNode(container);
+  }
+
+  #getSourceTextContent(node) {
+    let text = "";
+    const wrapperClass = Translator.KISS_CLASS.warpper;
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        text += child.nodeValue;
+      } else if (
+        child.nodeType === Node.ELEMENT_NODE &&
+        !child.classList?.contains(wrapperClass)
+      ) {
+        text += child.textContent;
+      }
+    }
+    return text;
   }
 
   // 重新观察
@@ -1400,7 +1443,8 @@ export class Translator {
       return;
     }
 
-    this.#processedNodes.set(node, { ...this.#rule });
+    spaLog("[SPA-DEBUG] processNode, runId=", this.#runId, "tag=", node?.tagName, "text=", node?.textContent?.slice?.(0, 40));
+    this.#processedNodes.set(node, { ...this.#rule, _sourceText: this.#getSourceTextContent(node) });
 
     // 提前检测文本
     if (this.#isInvalidText(node.textContent)) {
@@ -1996,6 +2040,8 @@ export class Translator {
         termsStyle
       );
       if (this.#isInvalidText(processedString)) return;
+
+      spaLog("[SPA-DEBUG] translateNodeGroup, runId=", this.#runId, "text=", processedString?.slice?.(0, 50));
 
       const wrapper = document.createElement(this.#translationTagName);
       wrapper.className = `${Translator.KISS_CLASS.warpper} notranslate`;
@@ -3193,6 +3239,7 @@ overflow-wrap: anywhere !important;`;
     this.#rule.transOpen = "false";
     this.#runId++;
 
+    this.#cancelPendingRescanIdle();
     this.#cleanupAllNodes();
     clearFetchPool();
     clearAllBatchQueue();
@@ -3209,7 +3256,9 @@ overflow-wrap: anywhere !important;`;
   rescan() {
     if (!this.#isInitialized) return;
     this.#runId++;
+    spaLog("[SPA-DEBUG] rescan() called, new runId=", this.#runId, "rescanQueue.size=", this.#rescanQueue.size);
 
+    this.#cancelPendingRescanIdle();
     this.#cleanupAllNodes();
     this.#resetOptions();
     clearFetchPool();

--- a/src/libs/translatorManager.js
+++ b/src/libs/translatorManager.js
@@ -31,7 +31,7 @@ import {
   MSG_MOUSEHOVER_TOGGLE,
   MSG_TRANSINPUT_TOGGLE,
 } from "../config";
-import { logger } from "./log";
+import { logger, spaLog } from "./log";
 
 /**
  * 前台翻译业务的总生命周期管理器。
@@ -434,6 +434,8 @@ export default class TranslatorManager {
   #scheduleSpaRefresh(type, reason) {
     if (!this.#isActive) return;
 
+    spaLog(`[SPA-DEBUG] scheduleSpaRefresh type=${type} reason=${reason} pending=${this.#pendingSpaRefresh}`);
+
     if (this.#spaRefreshTimer) {
       clearTimeout(this.#spaRefreshTimer);
       this.#spaRefreshTimer = null;
@@ -457,6 +459,8 @@ export default class TranslatorManager {
       this.#pendingSpaRefreshReason = "";
 
       if (!this.#isActive) return;
+
+      spaLog(`[SPA-DEBUG] spaRefresh executing: type=${refreshType} reason=${refreshReason} containerChanged=${this.#hasDocumentContainerChanged()}`);
 
       if (refreshType === "restart" || this.#hasDocumentContainerChanged()) {
         this.restart(refreshReason);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -385,6 +385,15 @@ export const scheduleIdle = (cb, timeout = 200) => {
   return setTimeout(cb, timeout);
 };
 
+export const cancelScheduledIdle = (handle) => {
+  if (handle == null) return;
+  if (window.cancelIdleCallback) {
+    cancelIdleCallback(handle);
+  } else {
+    clearTimeout(handle);
+  }
+};
+
 /**
  * 根据页面 URL，提取通用的主机名/域名 Pattern
  * @param {string} href


### PR DESCRIPTION
## Problem

### 1. Firefox Xray TypedArray

在 Firefox + Violentmonkey 环境下开启流式翻译时，`GM.xmlHttpRequest` 的 `responseType: "stream"` 返回的 `ReadableStream` 跨越了 Xray 边界。调用 `reader.read()` 得到的 `Uint8Array` 属于不同的 origin compartment，Firefox 禁止特权代码直接访问跨 Xray 的 TypedArray 数据，抛出：

```
Accessing TypedArray data over Xrays is slow, and forbidden in order to encourage performant code.
```

该问题在 x.com 等 CSP 严格的站点上触发（Violentmonkey 被迫使用 page 注入模式）。

### 2. SPA 导航后出现重复翻译 (分析中)

在 GitHub 等使用 Turbo.js 的 SPA 站点上，开启自动翻译后进行页面跳转会出现两次翻译结果。

#### 复现步骤

1. 安装油猴脚本，打开 GitHub 某个 PR 页面
2. 开启翻译，等待翻译完成
3. 点击链接跳转到另一个页面（如从 PR 列表进入某个 PR）
4. 观察到翻译结果出现两份

#### 根因分析

通过添加 `[SPA-DEBUG]` 日志确认了竞态时序：

```
16:39:06.687  MutationObserver 触发 queueForRescan (isProcessing=true, idle callback 已排队)
16:39:06.743  turbo:load 事件 → scheduleSpaRefresh("rescan") → setTimeout(0)
16:39:06.821  ⚡ idle callback 先执行 (runId=1) → processNode 第一轮翻译
16:39:06.839  ⚡ setTimeout(0) 后执行 → rescan() (runId=2) → cleanup + re-init → 第二轮翻译
```

**根因**：`scheduleIdle(100)` 排队的 idle callback 比 `setTimeout(0)` 更早执行。MO 的 idle rescan 先对新内容做了翻译（runId=1），随后 SPA 的 `rescan()` 执行清理并重新扫描全部节点产生第二轮翻译（runId=2）。两轮翻译的异步请求都在飞，导致同一段文本被翻译两次。

#### 修复方向

`rescan()` 执行时应清空 pending 的 idle rescan queue，避免已过期的 idle callback 抢先执行翻译。

## Fix

### Commit 1: Firefox Xray
在 `reader.read()` 返回值后，立即用 `new Uint8Array(value)` 将跨 origin 的 TypedArray 拷贝到当前 realm。

### Commit 2: SPA 重复翻译
在 `rescan()` 中清空 `#rescanQueue` 并重置 `#isQueueProcessing` 标志，防止旧的 idle callback 抢先执行。

## Testing

- Firefox + Violentmonkey + x.com + 流式 AI 翻译 API
- GitHub SPA 导航 + 自动翻译