### PR TITLE
fix: 纠正 AI 断句索引漂移导致的字幕不同步

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -915,7 +915,7 @@ export const apiSubtitle = async ({
     chunkSign,
     fromLang,
     toLang,
-    segVer: 2,
+    segVer: 3,
     promptSig: await getPromptCacheSig(apiSetting, PROMPT_CACHE_SCOPE_SUBTITLE),
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -70,6 +70,7 @@ import {
   detectStreamFormat,
   getStreamDelta,
 } from "../libs/stream";
+import { createSubtitleIndexAligner } from "../libs/subtitleIndexAlign";
 import { kissLog } from "../libs/log";
 import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
@@ -306,6 +307,8 @@ const geminiText = (parts) =>
     : "";
 
 const parseIndexSubtitleRes = (raw, events) => {
+  // 对齐器只建一次词表：buildResult 在截断修复兜底时可能执行两次。
+  const aligner = createSubtitleIndexAligner(events);
   const buildResult = (data) => {
     if (!Array.isArray(data) || !data.length) return null;
     const result = [];
@@ -315,11 +318,14 @@ const parseIndexSubtitleRes = (raw, events) => {
       if (!Number.isInteger(s) || !Number.isInteger(e)) continue;
       const startIdx = Math.max(0, Math.min(s, events.length - 1));
       const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
+      const text = String(seg.o ?? seg.original ?? "");
+      const fixed = aligner.realign(s, e, text);
       result.push({
-        start: events[startIdx].start,
-        end: events[endIdx].end,
-        text: String(seg.o ?? seg.original ?? ""),
+        start: events[fixed?.startIdx ?? startIdx].start,
+        end: events[fixed?.endIdx ?? endIdx].end,
+        text,
         translation: String(seg.t ?? seg.translation ?? ""),
+        // _si/_ei 保留模型原始索引：去重键与尾句重试语义依赖它们。
         _si: s,
         _ei: e,
       });

--- a/src/apis/trans.subtitle.test.js
+++ b/src/apis/trans.subtitle.test.js
@@ -182,4 +182,39 @@ describe("handleSubtitle", () => {
     expect(fetchStream).not.toHaveBeenCalled();
     expect(fetchData).toHaveBeenCalledTimes(1);
   });
+
+  test("realigns drifted indices on the non-stream path", async () => {
+    const driftEvents = Array.from({ length: 10 }, (_, i) => ({
+      start: i * 1000,
+      end: i * 1000 + 1000,
+      text: `w${i}`,
+    }));
+    fetchData.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify([{ s: 4, e: 6, o: "w1 w2 w3", t: "译文" }]),
+          },
+        },
+      ],
+    });
+
+    const result = await handleSubtitle({
+      events: driftEvents,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+    });
+
+    expect(result).toEqual([
+      {
+        start: 1000,
+        end: 4000,
+        text: "w1 w2 w3",
+        translation: "译文",
+        _si: 4,
+        _ei: 6,
+      },
+    ]);
+  });
 });

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -25,6 +25,7 @@ import {
   parseLineTranslationSegments,
   parseXmlTranslationSegments,
 } from "./aiResponseParser";
+import { createSubtitleIndexAligner } from "./subtitleIndexAlign";
 
 /**
  * 创建 Server-Sent Events (SSE) 协议数据流解析器
@@ -256,9 +257,10 @@ export function createStreamingJsonParser() {
  *
  * @param {Object} item 模型已经输出完整的字幕句子对象。
  * @param {Array<Object>} events 当前请求中传给模型的原始字幕事件。
+ * @param {Object} [aligner] 索引对齐器，用 o 原文纠正模型漂移的 s/e 索引。
  * @returns {Object|null} 可渲染字幕；字段不完整时返回 null。
  */
-const mapSubtitleItemToCue = (item, events = []) => {
+const mapSubtitleItemToCue = (item, events = [], aligner) => {
   const s = Number(item?.s ?? item?.start_id);
   const e = Number(item?.e ?? item?.end_id);
   if (!Number.isInteger(s) || !Number.isInteger(e) || events.length === 0) {
@@ -267,11 +269,14 @@ const mapSubtitleItemToCue = (item, events = []) => {
 
   const startIdx = Math.max(0, Math.min(s, events.length - 1));
   const endIdx = Math.max(startIdx, Math.min(e, events.length - 1));
+  const text = String(item.o ?? item.original ?? "");
+  const fixed = aligner?.realign(s, e, text);
   return {
-    start: events[startIdx].start,
-    end: events[endIdx].end,
-    text: String(item.o ?? item.original ?? ""),
+    start: events[fixed?.startIdx ?? startIdx].start,
+    end: events[fixed?.endIdx ?? endIdx].end,
+    text,
     translation: String(item.t ?? item.translation ?? ""),
+    // _si/_ei 必须保留模型原始索引：去重键与尾句重试语义都依赖它们。
     _si: s,
     _ei: e,
   };
@@ -291,6 +296,7 @@ export function createStreamingSubtitleParser(events = []) {
   let jsonStarted = false;
   let scanIndex = 0;
   const emittedKeys = new Set();
+  const aligner = createSubtitleIndexAligner(events);
 
   /**
    * 从当前 buffer 中查找 JSON 正文的起点。
@@ -385,7 +391,7 @@ export function createStreamingSubtitleParser(events = []) {
     for (const objectString of objectStrings) {
       try {
         const item = JSON.parse(objectString);
-        const subtitle = mapSubtitleItemToCue(item, events);
+        const subtitle = mapSubtitleItemToCue(item, events, aligner);
         if (!subtitle) continue;
 
         const key = `${subtitle._si}:${subtitle._ei}`;

--- a/src/libs/stream.test.js
+++ b/src/libs/stream.test.js
@@ -147,4 +147,39 @@ describe("createStreamingSubtitleParser", () => {
     ).toHaveLength(1);
     expect(parser.end()).toEqual([]);
   });
+
+  describe("index realignment", () => {
+    const driftEvents = Array.from({ length: 10 }, (_, i) => ({
+      start: i * 1000,
+      end: i * 1000 + 1000,
+      text: `w${i}`,
+    }));
+
+    test("corrects drifted s/e times while _si/_ei keep raw values", () => {
+      const parser = createStreamingSubtitleParser(driftEvents);
+
+      expect(parser.write('[{"s":4,"e":6,"o":"w1 w2 w3","t":"译文"}]')).toEqual(
+        [
+          {
+            start: 1000,
+            end: 4000,
+            text: "w1 w2 w3",
+            translation: "译文",
+            _si: 4,
+            _ei: 6,
+          },
+        ]
+      );
+    });
+
+    test("still deduplicates by raw s/e after realignment", () => {
+      const parser = createStreamingSubtitleParser(driftEvents);
+
+      expect(
+        parser.write(
+          '[{"s":4,"e":6,"o":"w1 w2 w3","t":"译文"},{"s":4,"e":6,"o":"w1 w2 w3","t":"译文"}]'
+        )
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/src/libs/subtitleIndexAlign.js
+++ b/src/libs/subtitleIndexAlign.js
@@ -1,0 +1,158 @@
+/**
+ * @file subtitleIndexAlign.js
+ * @description 字幕索引重对齐模块。断句模型返回的 s/e 事件索引偶尔与其 o 原文漂移
+ * （±20 词以内），导致时间轴错位。本模块把事件文本拍平成词表，用 o 的词序列在
+ * 声称位置附近就近搜索，保守地纠正事件索引；匹配失败或存在歧义时返回 null，
+ * 由调用方保持原始行为（误纠正比不纠正更糟）。
+ */
+
+const WINDOW = 32;
+
+// 正则必须写字面量：Babel 只转译字面量，运行时 new RegExp 的 \p{L} 在旧目标环境会抛错。
+const tokenize = (text) =>
+  String(text)
+    .toLowerCase()
+    .replace(/[’‘]/g, "'")
+    .replace(/[-‐–—]/g, " ")
+    .split(/\s+/)
+    .map((t) => t.replace(/[^\p{L}\p{N}]/gu, ""))
+    .filter(Boolean);
+
+const clamp = (n, lo, hi) => Math.max(lo, Math.min(n, hi));
+
+/**
+ * 创建字幕索引对齐器。构建时一次性拍平事件词表，realign 为纯函数、无游标，
+ * 同一输入永远得到同一结果（流式乱序、重复输出与二次解析都依赖这一点）。
+ * @param {Array<Object>} events 字幕事件列表（{text, start, end}）。
+ * @returns {{realign: Function}} realign(s, e, o) 返回 {startIdx, endIdx} 或 null。
+ */
+export const createSubtitleIndexAligner = (events = []) => {
+  const table = [];
+  const eventStartPos = [];
+  for (let ei = 0; ei < events.length; ei++) {
+    // 无词事件（如纯符号）前向填充为下一个词的位置，保证声称位置可定位。
+    eventStartPos[ei] = table.length;
+    for (const w of tokenize(String(events[ei]?.text ?? ""))) {
+      table.push({ w, ei });
+    }
+  }
+
+  const matchAt = (pos, tokens) => {
+    if (pos < 0 || pos + tokens.length > table.length) return false;
+    for (let k = 0; k < tokens.length; k++) {
+      if (table[pos + k].w !== tokens[k]) return false;
+    }
+    return true;
+  };
+
+  /**
+   * 用 o 原文纠正模型声称的事件索引范围。
+   * @param {number} s 模型声称的起始事件索引。
+   * @param {number} e 模型声称的结束事件索引。
+   * @param {string} o 模型输出的原文文本。
+   * @returns {{startIdx: number, endIdx: number}|null} 纠正后的索引；无需或无法纠正时为 null。
+   */
+  const realign = (s, e, o) => {
+    const oTokens = tokenize(o);
+    const L = oTokens.length;
+    if (L < 2 || table.length === 0) return null;
+
+    const cs = clamp(s, 0, events.length - 1);
+    const ce = clamp(e, cs, events.length - 1);
+
+    // 快路径：声称范围的词序列与 o 完全一致，无需纠正。
+    const claimed = [];
+    for (let p = eventStartPos[cs]; p < table.length && table[p].ei <= ce; p++) {
+      claimed.push(table[p].w);
+    }
+    if (claimed.length === L && claimed.every((w, i) => w === oTokens[i])) {
+      return null;
+    }
+
+    const claimedPos = clamp(eventStartPos[cs], 0, table.length - 1);
+    const tail = oTokens.slice(-Math.min(3, L));
+    const offsets = L === 2 ? [0] : [0, 1, 2].filter((off) => off + 3 <= L);
+    const candidates = new Map();
+
+    for (const offset of offsets) {
+      const probe =
+        L === 2 ? oTokens.slice(0, 2) : oTokens.slice(offset, offset + 3);
+      const lo = Math.max(0, claimedPos - WINDOW);
+      const hi = Math.min(table.length - probe.length, claimedPos + WINDOW);
+      for (let pos = lo; pos <= hi; pos++) {
+        if (!matchAt(pos, probe)) continue;
+        const startPos = pos - offset;
+        if (startPos < 0) continue;
+        const endPos0 = startPos + L - 1;
+        // o 词数越过词表末尾多为上下文泄漏或幻觉，绝不夹取到表尾，直接放弃。
+        if (endPos0 >= table.length) continue;
+
+        // 尾锚：o 中部多词/少词时用末尾词组就近修正 endPos，按离期望位置最近优先。
+        // 尾锚不得越过句首（j >= startPos），否则重复模式会产生倒挂区间。
+        const expectedTailStart = startPos + L - tail.length;
+        let tailOK = false;
+        let endPos = endPos0;
+        for (let d = 0; d <= 4 && !tailOK; d++) {
+          const js =
+            d === 0
+              ? [expectedTailStart]
+              : [expectedTailStart - d, expectedTailStart + d];
+          for (const j of js) {
+            if (j >= startPos && matchAt(j, tail)) {
+              tailOK = true;
+              endPos = j + tail.length - 1;
+              break;
+            }
+          }
+        }
+
+        const cand = {
+          startPos,
+          endPos,
+          tailOK,
+          offset,
+          dist: Math.abs(startPos - claimedPos),
+        };
+        // tailOK 只取决于 startPos，同一起点的后续 offset 候选必然重复，首个（最小 offset）即最优。
+        if (!candidates.has(startPos)) {
+          candidates.set(startPos, cand);
+        }
+      }
+    }
+
+    const all = [...candidates.values()];
+    if (!all.length) return null;
+    // 二词短语（如 in the）极易多处撞车，仅唯一候选可信。
+    if (L === 2 && all.length > 1) return null;
+
+    const tailCands = all.filter((c) => c.tailOK);
+    let pick = null;
+    if (tailCands.length) {
+      // 首词命中比 offset 回退可信：先按是否 offset-0 分组，组内按离声称位置最近。
+      tailCands.sort(
+        (a, b) => (a.offset > 0) - (b.offset > 0) || a.dist - b.dist
+      );
+      const [top, second] = tailCands;
+      // 同组同距视为歧义，宁可不纠正。
+      if (
+        second &&
+        (top.offset > 0) === (second.offset > 0) &&
+        top.dist === second.dist
+      ) {
+        return null;
+      }
+      pick = top;
+    } else {
+      // 无尾锚时只接受唯一、首词命中且足够长的候选。
+      if (all.length !== 1 || all[0].offset !== 0 || L < 3) return null;
+      pick = all[0];
+    }
+
+    const startIdx = table[pick.startPos].ei;
+    const endIdx = Math.max(startIdx, table[pick.endPos].ei);
+    if (startIdx === cs && endIdx === ce) return null;
+    return { startIdx, endIdx };
+  };
+
+  return { realign };
+};

--- a/src/libs/subtitleIndexAlign.test.js
+++ b/src/libs/subtitleIndexAlign.test.js
@@ -1,0 +1,196 @@
+import { createSubtitleIndexAligner } from "./subtitleIndexAlign";
+
+const wordEvents = (words) =>
+  words.map((text, i) => ({ text, start: i * 1000, end: i * 1000 + 1000 }));
+
+const seqWords = (n) => Array.from({ length: n }, (_, i) => `w${i}`);
+
+describe("createSubtitleIndexAligner", () => {
+  test("returns null when claimed range already matches o (fast path)", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(50)));
+
+    expect(realign(10, 14, "w10 w11 w12 w13 w14")).toBeNull();
+  });
+
+  test("corrects positive and negative drift", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(50)));
+
+    expect(realign(15, 19, "w10 w11 w12 w13 w14")).toEqual({
+      startIdx: 10,
+      endIdx: 14,
+    });
+    expect(realign(3, 7, "w15 w16 w17 w18 w19")).toEqual({
+      startIdx: 15,
+      endIdx: 19,
+    });
+  });
+
+  test("corrects drift +20 inside window, returns null beyond window", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(50)));
+
+    expect(realign(30, 34, "w10 w11 w12 w13 w14")).toEqual({
+      startIdx: 10,
+      endIdx: 14,
+    });
+    expect(realign(45, 49, "w5 w6 w7 w8 w9")).toBeNull();
+  });
+
+  test("returns null for short o or empty events", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(10)));
+    const empty = createSubtitleIndexAligner([]);
+
+    expect(realign(0, 0, "w0")).toBeNull();
+    expect(realign(0, 1, "")).toBeNull();
+    expect(empty.realign(0, 1, "w0 w1")).toBeNull();
+  });
+
+  test("normalizes case, punctuation, apostrophes, hyphens and numbers", () => {
+    const punct = createSubtitleIndexAligner(
+      wordEvents(["foo", "bar", "hello", "world", "baz", "qux"])
+    );
+    expect(punct.realign(0, 1, "Hello, WORLD!")).toEqual({
+      startIdx: 2,
+      endIdx: 3,
+    });
+
+    const apos = createSubtitleIndexAligner(
+      wordEvents(["a", "b", "don't", "stop", "me", "now", "c", "d"])
+    );
+    expect(apos.realign(0, 2, "Don’t stop me")).toEqual({
+      startIdx: 2,
+      endIdx: 4,
+    });
+
+    const hyphen = createSubtitleIndexAligner(
+      wordEvents(["it", "is", "well", "known", "that", "x"])
+    );
+    expect(hyphen.realign(0, 1, "well-known")).toEqual({
+      startIdx: 2,
+      endIdx: 3,
+    });
+
+    const nums = createSubtitleIndexAligner(
+      wordEvents(["numbers", "are", "22,", "25,", "26,", "and", "29,", "ok"])
+    );
+    expect(nums.realign(0, 4, "22, 25, 26, and 29.")).toEqual({
+      startIdx: 2,
+      endIdx: 6,
+    });
+  });
+
+  test("prefers the twin phrase nearest to claim, null when equidistant", () => {
+    const phrase = ["the", "quick", "brown", "fox", "jumps"];
+    const near = seqWords(50);
+    near.splice(5, 5, ...phrase);
+    near.splice(34, 5, ...phrase);
+    const nearAligner = createSubtitleIndexAligner(wordEvents(near));
+    expect(nearAligner.realign(7, 11, "the quick brown fox jumps")).toEqual({
+      startIdx: 5,
+      endIdx: 9,
+    });
+
+    const mid = seqWords(50);
+    mid.splice(5, 5, ...phrase);
+    mid.splice(35, 5, ...phrase);
+    const midAligner = createSubtitleIndexAligner(wordEvents(mid));
+    expect(midAligner.realign(20, 24, "the quick brown fox jumps")).toBeNull();
+  });
+
+  test("handles first word rewritten by model via offset probes", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(30)));
+
+    expect(realign(12, 16, "zzz w11 w12 w13 w14")).toEqual({
+      startIdx: 10,
+      endIdx: 14,
+    });
+    expect(realign(12, 16, "zzz w11 w12 w13 yyy")).toBeNull();
+  });
+
+  test("returns null when o spills past the table end (context leak)", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(20)));
+
+    expect(realign(15, 19, "w15 w16 w17 w18 w19 aaa bbb ccc")).toBeNull();
+  });
+
+  test("tail anchor refines endPos and endIdx never drops below startIdx", () => {
+    const { realign } = createSubtitleIndexAligner(wordEvents(seqWords(30)));
+
+    // o 中部多插一词：尾锚在 ±4 内命中，endIdx 收敛到 15 而非 16。
+    expect(realign(13, 19, "w10 w11 w12 zzz w13 w14 w15")).toEqual({
+      startIdx: 10,
+      endIdx: 15,
+    });
+    // o 末尾少一词：唯一 offset-0 候选走兜底，endIdx 近似到 14。
+    expect(realign(12, 17, "w10 w11 w12 w13 w15")).toEqual({
+      startIdx: 10,
+      endIdx: 14,
+    });
+
+    // 重复模式使尾锚落在起点之前：该尾锚被拒绝，唯一 offset-0 候选走词数兜底。
+    const loop = createSubtitleIndexAligner(
+      wordEvents(["b", "c", "d", "a", "b", "c", "x"])
+    );
+    expect(loop.realign(1, 4, "a b c d")).toEqual({ startIdx: 3, endIdx: 6 });
+  });
+
+  test("rejects two-word o when multiple candidates exist in window", () => {
+    const words = seqWords(30);
+    words.splice(8, 2, "in", "the");
+    words.splice(20, 2, "in", "the");
+    const { realign } = createSubtitleIndexAligner(wordEvents(words));
+
+    expect(realign(12, 13, "in the")).toBeNull();
+  });
+
+  test("prefers exact-prefix candidate over a closer offset probe", () => {
+    const words = seqWords(40);
+    words.splice(18, 4, "b", "c", "d", "e");
+    words.splice(25, 5, "a", "b", "c", "d", "e");
+    const { realign } = createSubtitleIndexAligner(wordEvents(words));
+
+    // offset-1 巧合（起点 17）离声称位置更近，但 offset-0 真句（起点 25）优先。
+    expect(realign(19, 23, "a b c d e")).toEqual({ startIdx: 25, endIdx: 29 });
+  });
+
+  test("supports multi-word events at event granularity", () => {
+    const events = [
+      { text: "hello world how", start: 0, end: 3000 },
+      { text: "are you", start: 3000, end: 5000 },
+      { text: "doing today my friend", start: 5000, end: 9000 },
+    ];
+    const { realign } = createSubtitleIndexAligner(events);
+
+    expect(realign(1, 2, "are you doing today my friend")).toBeNull();
+    expect(realign(0, 1, "are you doing today my friend")).toEqual({
+      startIdx: 1,
+      endIdx: 2,
+    });
+  });
+
+  test("forward-fills positions across symbol-only events", () => {
+    const { realign } = createSubtitleIndexAligner(
+      wordEvents(["hello", "♪♪", "world", "again", "fine"])
+    );
+
+    expect(realign(1, 2, "world again")).toEqual({ startIdx: 2, endIdx: 3 });
+  });
+
+  test("returns null for unsegmented CJK o", () => {
+    const { realign } = createSubtitleIndexAligner(
+      wordEvents(["你好", "世界", "朋友"])
+    );
+
+    expect(realign(0, 1, "你好世界")).toBeNull();
+  });
+
+  test("is deterministic across calls and instances", () => {
+    const events = wordEvents(seqWords(50));
+    const a = createSubtitleIndexAligner(events);
+    const b = createSubtitleIndexAligner(events);
+    const args = [15, 19, "w10 w11 w12 w13 w14"];
+
+    const first = a.realign(...args);
+    expect(a.realign(...args)).toEqual(first);
+    expect(b.realign(...args)).toEqual(first);
+  });
+});


### PR DESCRIPTION
背景

AI 断句接口的输入是带编号的事件列表 [{id, text}],模型返回 [{s, e, o, t}],插件用 events[s].start 和 events[e].end 给每句字幕定时间,句子文本直接用模型输出的 o。

实测发现模型返回的 s/e 偶尔和它自己输出的 o 文本对不上。用一个 22 分钟英文自动字幕视频核对,329 条 cue 里有 24 条的索引偏离 o 文本真实位置 1 到 20 个词,对应字幕比语音提前或滞后 2 到 5 秒,分布在 8 个片段,每段持续几句后自行恢复。文本是对的,时间是错的,观感就是字幕不同步。解析层(parseIndexSubtitleRes 和 mapSubtitleItemToCue)此前不校验 s/e 与 o 是否一致。

改动内容

1. 新增词表对齐器 src/libs/subtitleIndexAlign.js( 4bf3bb8 )

把事件文本拍平成词表,用 o 的词序列在模型声称位置前后 32 词内重新锚定 s/e。策略保守:首词三连词命中并有末尾词组佐证才纠正;多候选距离并列、二词短语多处命中、词数越过词表末尾等歧义情况一律返回 null,保持原行为。纯函数无内部状态,同一输入永远同一输出,保证流式草稿和最终解析产出相同时间,provider 按 start:end 合并时能正确覆盖草稿。

2. 两条解析路径接入( 4bf3bb8 )

parseIndexSubtitleRes(trans.js)和 mapSubtitleItemToCue(stream.js)取时间前先尝试对齐。_si/_ei 保留模型原始值,流式去重键和尾句重试的语义不变。

3. 字幕缓存版本 segVer 升至 3( 4bf3bb8 )

旧缓存里的字幕带着错误时间轴,升版本使其失效重取。

4. 补充测试( 4bf3bb8 )

对齐器 19 个用例,覆盖漂移纠正、归一化、歧义拒绝、CJK 回退、确定性;流式与非流式解析各补充漂移用例。

影响范围

- 使用 AI 断句的用户:索引漂移的字幕时间被自动纠正。实测视频 24 条漂移 cue 修复 20 条,另有 10 条起点正确但提前消失的 cue 终点被修正,其余 300 条正常 cue 零改动,无误纠正
- 未启用 AI 断句的用户:不受影响,内置断句和统计断句路径未改动
- CJK 等不空格语言:对齐器分不出词序列时返回 null,行为与之前一致
- 所有 AI 断句用户:segVer 升级后已看过的视频会重新请求断句,旧缓存不再复用