### PR TITLE
fix: skip scroll anchoring on non-scrollable documents

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -415,6 +415,16 @@ export class Translator {
   #restoreViewportAnchor(anchor) {
     if (!anchor?.element?.isConnected) return;
 
+    const scrollingElement = document.scrollingElement || document.documentElement;
+    if (!scrollingElement) return;
+
+    const overflowY = window.getComputedStyle(scrollingElement).overflowY;
+    const canScrollDocument =
+      scrollingElement.scrollHeight > scrollingElement.clientHeight &&
+      overflowY !== "hidden" &&
+      overflowY !== "clip";
+    if (!canScrollDocument) return;
+
     const currentTop = anchor.element.getBoundingClientRect().top;
     const offset = currentTop - anchor.top;
     // 如果位移差超过 0.5 像素，则平滑滚动以补偿该差值


### PR DESCRIPTION
## Summary
- Skip viewport scroll restoration when the document root is not vertically scrollable
- Avoid calling window.scrollBy on fixed-height pages such as Twine/Harlowe games where scrolling is handled by page-specific containers

## Verification
- LSP diagnostics on src/libs/translator.js: no new errors
- Built Firefox extension with PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm build:firefox
- Manually verified the packaged Firefox build fixes the Twine scrolling issue