### PR TITLE
Preserve pending hover translations on retrigger

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -1163,6 +1163,10 @@ export class Translator {
     }
 
     if (this.#processedNodes.has(targetNode)) {
+      const hasPendingTranslation = Array.from(
+        this.#findTranslationWrappers(targetNode)
+      ).some((wrapper) => !this.#translationNodes.has(wrapper));
+      if (hasPendingTranslation) return;
       this.#cleanupDirectTranslations(targetNode);
     } else {
       this.#processNode(targetNode);

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -636,6 +636,48 @@ describe("Translator rule styles", () => {
     ).toBeNull();
   });
 
+  test("keeps a pending translation-only hover request visible when retriggered", async () => {
+    let resolveTranslation;
+    apiTranslate.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTranslation = resolve;
+        })
+    );
+    document.body.innerHTML =
+      '<main id="root"><p id="target">Hello hover</p></main>';
+    const target = document.getElementById("target");
+
+    createTranslator(
+      {
+        transOpen: "false",
+        transOnly: "true",
+      },
+      {
+        preInit: true,
+        mouseHoverSetting: {
+          useMouseHover: true,
+          mouseHoverKey: [],
+          mouseHoverKey2: [],
+        },
+      }
+    );
+
+    await hoverNode(target);
+    await hoverNode(target);
+    resolveTranslation({ trText: "Delayed translation", isSame: false });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const wrapper = document.querySelector(`.${Translator.KISS_CLASS.warpper}`);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.isConnected).toBe(true);
+    expect(
+      wrapper.querySelector(`.${Translator.KISS_CLASS.inner}`).textContent
+    ).toBe("Delayed translation");
+    expect(target.contains(wrapper)).toBe(true);
+  });
+
   test("shows mouse hover bubble without inserting translation wrappers", async () => {
     document.body.innerHTML =
       '<main id="root"><p id="target">Hello hover</p></main>';


### PR DESCRIPTION
开启隐藏原文时，触发鼠标悬停翻译后，结果尚未返回时再次触发，导致原文和译文都不显示。

https://github.com/fishjar/kiss-translator/issues/879
https://github.com/fishjar/kiss-translator/issues/872