### PR TITLE
fix: 门控失准断句响应并按原文全局重锚定时间轴

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -915,7 +915,7 @@ export const apiSubtitle = async ({
     chunkSign,
     fromLang,
     toLang,
-    segVer: 5,
+    segVer: 3,
     promptSig: await getPromptCacheSig(apiSetting, PROMPT_CACHE_SCOPE_SUBTITLE),
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -915,7 +915,7 @@ export const apiSubtitle = async ({
     chunkSign,
     fromLang,
     toLang,
-    segVer: 4,
+    segVer: 5,
     promptSig: await getPromptCacheSig(apiSetting, PROMPT_CACHE_SCOPE_SUBTITLE),
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -915,7 +915,7 @@ export const apiSubtitle = async ({
     chunkSign,
     fromLang,
     toLang,
-    segVer: 3,
+    segVer: 4,
     promptSig: await getPromptCacheSig(apiSetting, PROMPT_CACHE_SCOPE_SUBTITLE),
     ctx: docInfo?.summary?.slice(0, 50) || "",
   };

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -70,7 +70,10 @@ import {
   detectStreamFormat,
   getStreamDelta,
 } from "../libs/stream";
-import { createSubtitleIndexAligner } from "../libs/subtitleIndexAlign";
+import {
+  createSubtitleIndexAligner,
+  reanchorIfUntrusted,
+} from "../libs/subtitleIndexAlign";
 import { kissLog } from "../libs/log";
 import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
@@ -337,8 +340,12 @@ const parseIndexSubtitleRes = (raw, events) => {
   // AI 有时在 JSON 值以 >> 开头时丢掉冒号和引号: "o">> → "o":">>
   const repaired = stripped.replace(/"([a-z_]+)">>/g, '"$1":">>');
 
+  // 响应级门控：整份 s/e 失准（长枚举计数崩坏）时按 o 文本全局重锚定。
+  const finalize = (result) =>
+    result ? (reanchorIfUntrusted(result, events) ?? result) : result;
+
   try {
-    return buildResult(JSON.parse(repaired));
+    return finalize(buildResult(JSON.parse(repaired)));
   } catch {
     try {
       const last = Math.max(
@@ -347,7 +354,7 @@ const parseIndexSubtitleRes = (raw, events) => {
         repaired.lastIndexOf("}\r")
       );
       if (last < 0) return null;
-      return buildResult(JSON.parse(repaired.slice(0, last + 1) + "]"));
+      return finalize(buildResult(JSON.parse(repaired.slice(0, last + 1) + "]")));
     } catch {
       return null;
     }
@@ -1975,17 +1982,51 @@ async function handleSubtitleStreamInternal(
   const emitted = [];
   const emittedKeys = new Set();
 
+  // 滑动窗口监测草稿的 id 消耗与文本词数比值，失准后停止向上转发，
+  // 避免崩坏响应把提前数分钟的错误字幕流式推上播放器。
+  // 比值检测预设事件≈单词（ASR 词级轨）；行级人工轨一个事件多词，比值天然
+  // 偏低，参与监测会误伤健康草稿，直接停用。
+  const avgWordsPerEvent = events?.length
+    ? events.reduce(
+        (acc, e) =>
+          acc + String(e?.text || "").split(/\s+/).filter(Boolean).length,
+        0
+      ) / events.length
+    : 1;
+  const ratioWin = [];
+  let draftSuppressed = false;
+  const trackDraftDrift = (subtitle) => {
+    if (draftSuppressed || avgWordsPerEvent > 1.5) return;
+    const words = String(subtitle.text || "")
+      .split(/\s+/)
+      .filter(Boolean).length;
+    // CJK 等不空格文本分不出词，不参与监测，保持草稿照常上屏。
+    if (words < 3) return;
+    const ids = Math.max(1, (subtitle._ei ?? 0) - (subtitle._si ?? 0) + 1);
+    ratioWin.push([ids, words]);
+    if (ratioWin.length > 10) ratioWin.shift();
+    if (ratioWin.length === 10) {
+      const idSum = ratioWin.reduce((acc, [n]) => acc + n, 0);
+      const wordSum = ratioWin.reduce((acc, [, n]) => acc + n, 0);
+      const ratio = idSum / wordSum;
+      if (ratio < 0.8 || ratio > 1.25) draftSuppressed = true;
+    }
+  };
+
   const appendSubtitles = (subtitles, isFinal = false) => {
     const fresh = [];
     for (const subtitle of subtitles || []) {
       const key = `${subtitle._si}:${subtitle._ei}`;
       if (emittedKeys.has(key)) continue;
       emittedKeys.add(key);
+      // 抑制只拦 onSubtitleChunk 转发；emitted 必须完整收集，
+      // 最终解析失败时它是兜底返回值，缺句会造成字幕永久丢失。
       emitted.push(subtitle);
+      trackDraftDrift(subtitle);
       fresh.push(subtitle);
     }
 
-    if (fresh.length) {
+    if (fresh.length && !draftSuppressed) {
       // 只有完整句子对象闭合后才上抛，避免半句字幕污染播放器时间轴。
       onSubtitleChunk({ subtitles: fresh, isFinal });
     }

--- a/src/apis/trans.subtitle.test.js
+++ b/src/apis/trans.subtitle.test.js
@@ -217,4 +217,72 @@ describe("handleSubtitle", () => {
       },
     ]);
   });
+
+  const runawayEvents = Array.from({ length: 200 }, (_, i) => ({
+    start: i * 1000,
+    end: i * 1000 + 1000,
+    text: `w${i}`,
+  }));
+  // 持续压缩响应：每段 10 词只声称 7 个 id，模拟长枚举下的计数崩坏。
+  const runawayBody = (count) =>
+    Array.from({ length: count }, (_, k) => ({
+      s: 7 * k,
+      e: 7 * k + 6,
+      o: Array.from({ length: 10 }, (_, j) => `w${k * 10 + j}`).join(" "),
+      t: `译${k}`,
+    }));
+
+  test("reanchors a runaway response wholesale on the non-stream path", async () => {
+    fetchData.mockResolvedValueOnce({
+      choices: [{ message: { content: JSON.stringify(runawayBody(20)) } }],
+    });
+
+    const result = await handleSubtitle({
+      events: runawayEvents,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+    });
+
+    expect(result).toHaveLength(20);
+    result.forEach((sub, k) => {
+      expect(sub.start).toBe(k * 10 * 1000);
+      expect(sub.end).toBe((k * 10 + 9) * 1000 + 1000);
+      expect(sub._si).toBe(7 * k);
+      expect(sub._reanchored).toBe(true);
+    });
+  });
+
+  test("suppresses runaway streaming drafts and reanchors the final result", async () => {
+    const body = runawayBody(16);
+    async function* streamChunks() {
+      for (let k = 0; k < body.length; k++) {
+        const prefix = k === 0 ? "[" : ",";
+        const suffix = k === body.length - 1 ? "]" : "";
+        yield JSON.stringify({
+          choices: [
+            { delta: { content: prefix + JSON.stringify(body[k]) + suffix } },
+          ],
+        });
+      }
+    }
+    fetchStream.mockReturnValueOnce(streamChunks());
+
+    const onSubtitleChunk = jest.fn();
+    const result = await handleSubtitle({
+      events: runawayEvents,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+      onSubtitleChunk,
+    });
+
+    // 第 10 段填满监测窗口即判失准，其后的草稿全部被抑制。
+    expect(onSubtitleChunk).toHaveBeenCalledTimes(9);
+    expect(result).toHaveLength(16);
+    result.forEach((sub, k) => {
+      expect(sub.start).toBe(k * 10 * 1000);
+      expect(sub._reanchored).toBe(true);
+    });
+  });
 });

--- a/src/libs/subtitleIndexAlign.js
+++ b/src/libs/subtitleIndexAlign.js
@@ -172,9 +172,12 @@ const GATE = {
   winLo: 0.8,
   winHi: 1.25,
   cumDrift: 80, // 任一前缀的累计词数亏空阈值
-  spacedRatio: 0.6, // 词分隔守卫：六成以上段的 o 要能分出 3 词，挡住 CJK
+  spacedRatio: 0.6, // 词分隔守卫：能分出 3 词的段需占六成词量，挡住 CJK
   backtrack: 40, // 重锚定游标允许的回溯词数，需覆盖模型交错重发段的回跳幅度
   forward: 200, // 重锚定单步向前搜索上限；重复口头禅的远处假匹配不得拖走游标
+  shortBack: 10, // 短段（<3 词）回溯窗口：真实感叹词就贴在游标附近
+  shortForward: 40, // 短段前向窗口
+  shortOneDist: 8, // 单词短段的最大可信锚定距离
   maxMisses: 5, // 连续锚定失败上限，超出后放弃剩余段
   accept: 0.7, // 验收下限：锚定段占比与锚定词覆盖率
 };
@@ -183,8 +186,11 @@ const GATE = {
  * 检测整份断句响应的 s/e 是否整体失准（长枚举下模型计数崩坏，实测比值可低至 0.71
  * 且持续十分钟不自愈），失准则按 o 文本做游标单调的全局重锚定。
  * 返回 null 表示响应可信或重锚定未达验收标准，调用方保持原结果；
- * 返回数组则为替换结果：锚定段带 _aei（锚定终点事件索引，供尾句重试判定覆盖范围）
- * 与 _reanchored 标记（provider 据此清理失准草稿），_si/_ei 保留模型原始值。
+ * 返回数组则为替换结果：锚定段带 _aei（锚定终点事件索引，供尾句重试判定覆盖范围）、
+ * _reanchored 标记与 _alo/_ahi（本响应事件时间范围，provider 据此清理失准草稿），
+ * _si/_ei 保留模型原始值。不足 3 词的短段无法用探针可靠锚定，在游标近旁就近
+ * 锚定，找不到或歧义时整段丢弃（实测幻影短段可提前语音 160 秒，错误时间上屏
+ * 比丢一个感叹词更糟）。
  * @param {Array<Object>} segments parseIndexSubtitleRes 构建的字幕段。
  * @param {Array<Object>} events 当前请求的事件列表。
  * @returns {Array<Object>|null}
@@ -211,8 +217,12 @@ export const reanchorIfUntrusted = (segments = [], events = []) => {
 
   const totalO = stats.reduce((acc, s) => acc + s.oTok, 0);
   if (totalO < GATE.minWords) return null;
-  const spacedCount = stats.filter((s) => s.oTok >= 3).length;
-  if (spacedCount / segments.length < GATE.spacedRatio) return null;
+  // 分隔度按词量而非段数统计：话痨响应的大量单词感叹段不稀释守卫，CJK 段依旧不达标。
+  const spacedWords = stats.reduce(
+    (acc, s) => acc + (s.oTok >= 3 ? s.oTok : 0),
+    0
+  );
+  if (spacedWords / totalO < GATE.spacedRatio) return null;
 
   // 三路并联门控。整体比值会被健康前缀稀释（实测崩坏响应混算后仅 0.857），
   // 滑动窗口与前缀累计亏空负责补位。
@@ -248,14 +258,91 @@ export const reanchorIfUntrusted = (segments = [], events = []) => {
   let anchoring = true;
   let anchoredSegs = 0;
   let anchoredWords = 0;
+  let judgedSegs = 0;
+  let judgedWords = 0;
   let prevEndPos = -1;
+  let prevAnchored = null;
+
+  // 锚定段统一出口。模型常先重发感叹词再重发整句：同 start 且被当前段整体
+  // 覆盖的上一锚定段以长段为准，移除并回滚其计数。
+  const pushAnchored = (sub, L, startIdx, endIdx) => {
+    const cue = {
+      ...sub,
+      start: events[startIdx].start,
+      end: events[endIdx].end,
+      _aei: endIdx,
+      _reanchored: true,
+    };
+    if (
+      prevAnchored &&
+      prevAnchored.startMs === cue.start &&
+      prevAnchored.aei <= endIdx
+    ) {
+      out.splice(prevAnchored.at, 1);
+      anchoredSegs -= 1;
+      anchoredWords -= prevAnchored.L;
+      judgedSegs -= 1;
+      judgedWords -= prevAnchored.L;
+    }
+    out.push(cue);
+    prevAnchored = { at: out.length - 1, startMs: cue.start, aei: endIdx, L };
+    anchoredSegs += 1;
+    anchoredWords += L;
+    judgedSegs += 1;
+    judgedWords += L;
+  };
 
   for (let i = 0; i < segments.length; i++) {
     const sub = segments[i];
     const { oTokens } = stats[i];
     const L = oTokens.length;
-    if (!anchoring || L < 3) {
+    if (!anchoring) {
       out.push(sub);
+      judgedSegs += 1;
+      judgedWords += L;
+      continue;
+    }
+
+    if (L < 3) {
+      // 短段只在游标近旁锚定；无词可验的纯符号段保持原样且不参与验收。
+      if (!L) {
+        out.push(sub);
+        continue;
+      }
+      // 一字母 token 探针过弱（如 "A."），任何位置都可能撞上，直接丢弃。
+      if (L === 1 && oTokens[0].length < 2) continue;
+      let st = -1;
+      let bestDist = Infinity;
+      let tied = false;
+      const lo = Math.max(0, cursor - GATE.shortBack);
+      const hi = Math.min(table.length - L, cursor + GATE.shortForward);
+      for (let pos = lo; pos <= hi; pos++) {
+        if (!matchAt(pos, oTokens)) continue;
+        const dist = Math.abs(pos - cursor);
+        if (dist < bestDist) {
+          bestDist = dist;
+          st = pos;
+          tied = false;
+        } else if (dist === bestDist) {
+          tied = true;
+        }
+      }
+      // 找不到、等距歧义、落入已消费区（重复重发）或单词段离游标过远都丢弃，
+      // 不动游标也不影响 miss 预算。
+      if (
+        st < 0 ||
+        tied ||
+        st <= prevEndPos ||
+        (L === 1 && bestDist > GATE.shortOneDist)
+      ) {
+        continue;
+      }
+      const endPos = st + L - 1;
+      const startIdx = table[st].ei;
+      pushAnchored(sub, L, startIdx, Math.max(startIdx, table[endPos].ei));
+      cursor = endPos + 1;
+      prevEndPos = endPos;
+      misses = 0;
       continue;
     }
 
@@ -283,6 +370,8 @@ export const reanchorIfUntrusted = (segments = [], events = []) => {
 
     if (st === -1) {
       out.push(sub);
+      judgedSegs += 1;
+      judgedWords += L;
       if (++misses >= GATE.maxMisses) anchoring = false;
       continue;
     }
@@ -308,26 +397,31 @@ export const reanchorIfUntrusted = (segments = [], events = []) => {
     }
 
     const startIdx = table[st].ei;
-    const endIdx = Math.max(startIdx, table[endPos].ei);
-    out.push({
-      ...sub,
-      start: events[startIdx].start,
-      end: events[endIdx].end,
-      _aei: endIdx,
-      _reanchored: true,
-    });
-    anchoredSegs += 1;
-    anchoredWords += L;
+    pushAnchored(sub, L, startIdx, Math.max(startIdx, table[endPos].ei));
     cursor = endPos + 1;
     prevEndPos = endPos;
     misses = 0;
   }
 
+  // 验收分母只含真正接受评判的段：丢弃的短段与重复段不计（话痨响应的感叹词
+  // 不再稀释通过率），保留原样的失败长段计入，防止大量实质 miss 仍然放行。
   if (
-    anchoredSegs / segments.length < GATE.accept ||
-    anchoredWords / totalO < GATE.accept
+    !judgedSegs ||
+    anchoredSegs / judgedSegs < GATE.accept ||
+    anchoredWords / Math.max(1, judgedWords) < GATE.accept
   ) {
     return null;
+  }
+
+  // 携带整个响应的事件时间范围：草稿清扫若只按输出 cue 的 min/max，首尾短段
+  // 被丢弃时会留缝放过缝隙里的幻影草稿。
+  const rangeLo = events[0].start;
+  const rangeHi = events[events.length - 1].end;
+  for (const cue of out) {
+    if (cue._reanchored) {
+      cue._alo = rangeLo;
+      cue._ahi = rangeHi;
+    }
   }
   return out;
 };

--- a/src/libs/subtitleIndexAlign.js
+++ b/src/libs/subtitleIndexAlign.js
@@ -20,13 +20,7 @@ const tokenize = (text) =>
 
 const clamp = (n, lo, hi) => Math.max(lo, Math.min(n, hi));
 
-/**
- * 创建字幕索引对齐器。构建时一次性拍平事件词表，realign 为纯函数、无游标，
- * 同一输入永远得到同一结果（流式乱序、重复输出与二次解析都依赖这一点）。
- * @param {Array<Object>} events 字幕事件列表（{text, start, end}）。
- * @returns {{realign: Function}} realign(s, e, o) 返回 {startIdx, endIdx} 或 null。
- */
-export const createSubtitleIndexAligner = (events = []) => {
+const buildWordTable = (events = []) => {
   const table = [];
   const eventStartPos = [];
   for (let ei = 0; ei < events.length; ei++) {
@@ -36,14 +30,26 @@ export const createSubtitleIndexAligner = (events = []) => {
       table.push({ w, ei });
     }
   }
+  return { table, eventStartPos };
+};
 
-  const matchAt = (pos, tokens) => {
-    if (pos < 0 || pos + tokens.length > table.length) return false;
-    for (let k = 0; k < tokens.length; k++) {
-      if (table[pos + k].w !== tokens[k]) return false;
-    }
-    return true;
-  };
+const makeMatchAt = (table) => (pos, tokens) => {
+  if (pos < 0 || pos + tokens.length > table.length) return false;
+  for (let k = 0; k < tokens.length; k++) {
+    if (table[pos + k].w !== tokens[k]) return false;
+  }
+  return true;
+};
+
+/**
+ * 创建字幕索引对齐器。构建时一次性拍平事件词表，realign 为纯函数、无游标，
+ * 同一输入永远得到同一结果（流式乱序、重复输出与二次解析都依赖这一点）。
+ * @param {Array<Object>} events 字幕事件列表（{text, start, end}）。
+ * @returns {{realign: Function}} realign(s, e, o) 返回 {startIdx, endIdx} 或 null。
+ */
+export const createSubtitleIndexAligner = (events = []) => {
+  const { table, eventStartPos } = buildWordTable(events);
+  const matchAt = makeMatchAt(table);
 
   /**
    * 用 o 原文纠正模型声称的事件索引范围。
@@ -155,4 +161,173 @@ export const createSubtitleIndexAligner = (events = []) => {
   };
 
   return { realign };
+};
+
+const GATE = {
+  minSegs: 10, // 段数太少统计不稳，不启用门控
+  minWords: 150, // 文本词量太小统计不稳，不启用门控
+  wholeRatio: 0.15, // 整响应「声称词数/文本词数」偏差阈值
+  winSize: 10, // 滑动窗口段数，识别被健康前缀稀释的局部崩坏
+  winMinWords: 80,
+  winLo: 0.8,
+  winHi: 1.25,
+  cumDrift: 80, // 任一前缀的累计词数亏空阈值
+  spacedRatio: 0.6, // 词分隔守卫：六成以上段的 o 要能分出 3 词，挡住 CJK
+  backtrack: 40, // 重锚定游标允许的回溯词数，需覆盖模型交错重发段的回跳幅度
+  forward: 200, // 重锚定单步向前搜索上限；重复口头禅的远处假匹配不得拖走游标
+  maxMisses: 5, // 连续锚定失败上限，超出后放弃剩余段
+  accept: 0.7, // 验收下限：锚定段占比与锚定词覆盖率
+};
+
+/**
+ * 检测整份断句响应的 s/e 是否整体失准（长枚举下模型计数崩坏，实测比值可低至 0.71
+ * 且持续十分钟不自愈），失准则按 o 文本做游标单调的全局重锚定。
+ * 返回 null 表示响应可信或重锚定未达验收标准，调用方保持原结果；
+ * 返回数组则为替换结果：锚定段带 _aei（锚定终点事件索引，供尾句重试判定覆盖范围）
+ * 与 _reanchored 标记（provider 据此清理失准草稿），_si/_ei 保留模型原始值。
+ * @param {Array<Object>} segments parseIndexSubtitleRes 构建的字幕段。
+ * @param {Array<Object>} events 当前请求的事件列表。
+ * @returns {Array<Object>|null}
+ */
+export const reanchorIfUntrusted = (segments = [], events = []) => {
+  if (segments.length < GATE.minSegs || !events.length) return null;
+
+  const { table, eventStartPos } = buildWordTable(events);
+  if (!table.length) return null;
+  const matchAt = makeMatchAt(table);
+  const eventEndPos = (ei) =>
+    ei + 1 < events.length ? eventStartPos[ei + 1] : table.length;
+
+  const stats = segments.map((sub) => {
+    const cs = clamp(Number(sub._si) || 0, 0, events.length - 1);
+    const ce = clamp(Number(sub._ei) || 0, cs, events.length - 1);
+    const oTokens = tokenize(sub.text);
+    return {
+      oTokens,
+      oTok: oTokens.length,
+      claimedTok: Math.max(0, eventEndPos(ce) - eventStartPos[cs]),
+    };
+  });
+
+  const totalO = stats.reduce((acc, s) => acc + s.oTok, 0);
+  if (totalO < GATE.minWords) return null;
+  const spacedCount = stats.filter((s) => s.oTok >= 3).length;
+  if (spacedCount / segments.length < GATE.spacedRatio) return null;
+
+  // 三路并联门控。整体比值会被健康前缀稀释（实测崩坏响应混算后仅 0.857），
+  // 滑动窗口与前缀累计亏空负责补位。
+  const totalClaimed = stats.reduce((acc, s) => acc + s.claimedTok, 0);
+  let tripped = Math.abs(totalClaimed / totalO - 1) > GATE.wholeRatio;
+  let cum = 0;
+  for (let i = 0; i < stats.length && !tripped; i++) {
+    cum += stats[i].claimedTok - stats[i].oTok;
+    if (Math.abs(cum) >= GATE.cumDrift) {
+      tripped = true;
+      break;
+    }
+    if (i >= GATE.winSize - 1) {
+      let winO = 0;
+      let winC = 0;
+      for (let k = i - GATE.winSize + 1; k <= i; k++) {
+        winO += stats[k].oTok;
+        winC += stats[k].claimedTok;
+      }
+      if (winO >= GATE.winMinWords) {
+        const ratio = winC / winO;
+        if (ratio < GATE.winLo || ratio > GATE.winHi) tripped = true;
+      }
+    }
+  }
+  if (!tripped) return null;
+
+  // 游标单调重锚定：从上一段锚定终点接续向前找。
+  // miss 不动游标，避免幻觉段拖歪整条链；连续 miss 过多则放弃剩余段。
+  const out = [];
+  let cursor = 0;
+  let misses = 0;
+  let anchoring = true;
+  let anchoredSegs = 0;
+  let anchoredWords = 0;
+  let prevEndPos = -1;
+
+  for (let i = 0; i < segments.length; i++) {
+    const sub = segments[i];
+    const { oTokens } = stats[i];
+    const L = oTokens.length;
+    if (!anchoring || L < 3) {
+      out.push(sub);
+      continue;
+    }
+
+    const probes = [0, 1, 2]
+      .filter((off) => off + 3 <= L)
+      .map((off) => [off, oTokens.slice(off, off + 3)]);
+    // 取离游标最近的候选：顺序文本的真实位置就在游标附近，
+    // 重复口头禅落在回溯区或远处的假匹配都会因距离更远而落选；等距偏向顺流方向。
+    let st = -1;
+    let bestDist = Infinity;
+    const lo = Math.max(0, cursor - GATE.backtrack);
+    const hi = Math.min(table.length - L, cursor + GATE.forward);
+    for (let pos = lo; pos <= hi && bestDist > 0; pos++) {
+      for (const [off, probe] of probes) {
+        if (matchAt(pos + off, probe)) {
+          const dist = Math.abs(pos - cursor);
+          if (dist < bestDist || (dist === bestDist && st < cursor)) {
+            bestDist = dist;
+            st = pos;
+          }
+          break;
+        }
+      }
+    }
+
+    if (st === -1) {
+      out.push(sub);
+      if (++misses >= GATE.maxMisses) anchoring = false;
+      continue;
+    }
+
+    const tail = oTokens.slice(-3);
+    const expected = st + L - tail.length;
+    let endPos = st + L - 1;
+    let tailDone = false;
+    for (let d = 0; d <= 4 && !tailDone; d++) {
+      const js = d === 0 ? [expected] : [expected - d, expected + d];
+      for (const j of js) {
+        if (j >= st && matchAt(j, tail)) {
+          endPos = j + tail.length - 1;
+          tailDone = true;
+          break;
+        }
+      }
+    }
+
+    // 模型重复输出的段会锚到已消费的位置，保留先到者。
+    if (st <= prevEndPos && prevEndPos - st + 1 > (endPos - st + 1) / 2) {
+      continue;
+    }
+
+    const startIdx = table[st].ei;
+    const endIdx = Math.max(startIdx, table[endPos].ei);
+    out.push({
+      ...sub,
+      start: events[startIdx].start,
+      end: events[endIdx].end,
+      _aei: endIdx,
+      _reanchored: true,
+    });
+    anchoredSegs += 1;
+    anchoredWords += L;
+    cursor = endPos + 1;
+    prevEndPos = endPos;
+    misses = 0;
+  }
+
+  if (
+    anchoredSegs / segments.length < GATE.accept ||
+    anchoredWords / totalO < GATE.accept
+  ) {
+    return null;
+  }
+  return out;
 };

--- a/src/libs/subtitleIndexAlign.test.js
+++ b/src/libs/subtitleIndexAlign.test.js
@@ -325,6 +325,115 @@ describe("reanchorIfUntrusted", () => {
     expect(out[16]._reanchored).toBeUndefined();
   });
 
+  test("anchors drifted short interjections near the cursor", () => {
+    const w = words(220);
+    w[40] = "okay";
+    const events = wordEvents(w);
+    const txt = (a, len) => w.slice(a, a + len).join(" ");
+    const segs = [];
+    for (let k = 0; k < 4; k++) segs.push(seg(7 * k, 7 * k + 6, txt(k * 10, 10)));
+    // 声称漂移到词 28（28s），真实位置在词 40（40s）。
+    segs.push(seg(28, 28, "Okay."));
+    for (let k = 4; k < 20; k++)
+      segs.push(seg(7 * k, 7 * k + 6, txt(k * 10 + 1, 10)));
+    const out = reanchorIfUntrusted(segs, events);
+
+    const short = out.find((s) => s.text === "Okay.");
+    expect(short.start).toBe(40 * 1000);
+    expect(short._aei).toBe(40);
+    expect(short._reanchored).toBe(true);
+    expect(short._alo).toBe(0);
+    expect(short._ahi).toBe(220 * 1000);
+    expect(out[5].start).toBe(41 * 1000);
+  });
+
+  test("drops hallucinated shorts instead of emitting them raw", () => {
+    const events = wordEvents(words(200));
+    const segs = compressed(20);
+    for (let k = 0; k < 6; k++) segs.splice(10, 0, seg(70, 70, "zzz"));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(20);
+    expect(out.every((s) => s._reanchored)).toBe(true);
+    // 连续被丢弃的短段不烧 miss 预算，后续句子照常锚定。
+    expect(out[10].start).toBe(100 * 1000);
+  });
+
+  test("acceptance ignores dropped shorts in a chatty response", () => {
+    const events = wordEvents(words(200));
+    const segs = compressed(20);
+    // 10 个幻觉短段：按旧分母 20/30 会低于验收线整体回退。
+    for (let k = 0; k < 10; k++) segs.splice(2 * k, 0, seg(7 * k, 7 * k, "zzz"));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(20);
+    expect(out.every((s) => s._reanchored)).toBe(true);
+  });
+
+  test("gate spacing guard uses word mass, not segment count", () => {
+    const events = wordEvents(words(200));
+    // 30/42 的段是单词感叹段：按段数统计分隔度不足 0.6，按词量 120/150 达标。
+    const segs = compressed(12);
+    for (let k = 0; k < 30; k++) segs.push(seg(84 + k, 84 + k, "zzz"));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(12);
+    expect(out.every((s) => s._reanchored)).toBe(true);
+  });
+
+  test("prefers the sentence when a short re-emission shares its start", () => {
+    const w = words(200);
+    w[40] = "okay";
+    const events = wordEvents(w);
+    const txt = (a, len) => w.slice(a, a + len).join(" ");
+    const segs = [];
+    for (let k = 0; k < 4; k++) segs.push(seg(7 * k, 7 * k + 6, txt(k * 10, 10)));
+    segs.push(seg(28, 28, "Okay."));
+    segs.push(seg(29, 36, txt(40, 10)));
+    for (let k = 5; k < 20; k++)
+      segs.push(seg(7 * k, 7 * k + 6, txt(k * 10, 10)));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(20);
+    expect(out.filter((s) => s.text === "Okay.")).toHaveLength(0);
+    expect(out.find((s) => s.text === txt(40, 10)).start).toBe(40 * 1000);
+  });
+
+  test("drops ambiguous, distant or weak-probe shorts", () => {
+    const build = (mutate, shortText = "Okay.") => {
+      const w = words(200);
+      mutate(w);
+      const txt = (a, len) => w.slice(a, a + len).join(" ");
+      const segs = [];
+      for (let k = 0; k < 4; k++)
+        segs.push(seg(7 * k, 7 * k + 6, txt(k * 10, 10)));
+      segs.push(seg(28, 28, shortText));
+      for (let k = 4; k < 20; k++)
+        segs.push(seg(7 * k, 7 * k + 6, txt(k * 10, 10)));
+      return reanchorIfUntrusted(segs, wordEvents(w));
+    };
+
+    // 游标两侧等距双候选：歧义丢弃。
+    const ambiguous = build((w) => {
+      w[38] = "okay";
+      w[42] = "okay";
+    });
+    expect(ambiguous.filter((s) => s.text === "Okay.")).toHaveLength(0);
+
+    // 唯一候选但离游标超出单词段可信距离：丢弃。
+    const distant = build((w) => {
+      w[55] = "okay";
+    });
+    expect(distant.filter((s) => s.text === "Okay.")).toHaveLength(0);
+
+    // 一字母 token 探针过弱：即使近旁存在也丢弃。
+    const weak = build((w) => {
+      w[41] = "a";
+    }, "A.");
+    expect(weak.filter((s) => s.text === "A.")).toHaveLength(0);
+    expect(weak).toHaveLength(20);
+  });
+
   test("is deterministic", () => {
     const events = wordEvents(words(400));
     const segs = compressed(40);

--- a/src/libs/subtitleIndexAlign.test.js
+++ b/src/libs/subtitleIndexAlign.test.js
@@ -1,4 +1,7 @@
-import { createSubtitleIndexAligner } from "./subtitleIndexAlign";
+import {
+  createSubtitleIndexAligner,
+  reanchorIfUntrusted,
+} from "./subtitleIndexAlign";
 
 const wordEvents = (words) =>
   words.map((text, i) => ({ text, start: i * 1000, end: i * 1000 + 1000 }));
@@ -192,5 +195,142 @@ describe("createSubtitleIndexAligner", () => {
     const first = a.realign(...args);
     expect(a.realign(...args)).toEqual(first);
     expect(b.realign(...args)).toEqual(first);
+  });
+});
+
+describe("reanchorIfUntrusted", () => {
+  const words = (n, from = 0) =>
+    Array.from({ length: n }, (_, i) => `w${from + i}`);
+  const textOf = (from, len) => words(len, from).join(" ");
+  const seg = (s, e, text) => ({ text, _si: s, _ei: e });
+  // 持续压缩响应：每段 10 词只声称 7 个 id，比值 0.7，模拟长枚举计数崩坏。
+  const compressed = (count) =>
+    Array.from({ length: count }, (_, k) =>
+      seg(7 * k, 7 * k + 6, textOf(k * 10, 10))
+    );
+
+  test("returns null for healthy responses and for tiny volume", () => {
+    const events = wordEvents(words(400));
+    const healthy = Array.from({ length: 40 }, (_, k) =>
+      seg(k * 10, k * 10 + 9, textOf(k * 10, 10))
+    );
+
+    expect(reanchorIfUntrusted(healthy, events)).toBeNull();
+    expect(reanchorIfUntrusted(healthy.slice(0, 8), events)).toBeNull();
+  });
+
+  test("returns null for episodic bounded drift (phase-1 territory)", () => {
+    const events = wordEvents(words(200));
+    const segs = Array.from({ length: 20 }, (_, k) =>
+      seg(k * 10, k * 10 + 9, textOf(k * 10, 10))
+    );
+    segs[5] = seg(45, 54, textOf(50, 10));
+    segs[6] = seg(65, 74, textOf(60, 10));
+
+    expect(reanchorIfUntrusted(segs, events)).toBeNull();
+  });
+
+  test("re-anchors a sustained compressed response", () => {
+    const events = wordEvents(words(400));
+    const out = reanchorIfUntrusted(compressed(40), events);
+
+    expect(out).toHaveLength(40);
+    out.forEach((sub, k) => {
+      expect(sub.start).toBe(k * 10 * 1000);
+      expect(sub.end).toBe((k * 10 + 9) * 1000 + 1000);
+      expect(sub._si).toBe(7 * k);
+      expect(sub._aei).toBe(k * 10 + 9);
+      expect(sub._reanchored).toBe(true);
+    });
+  });
+
+  test("catches a degraded tail hidden by a healthy prefix", () => {
+    const events = wordEvents(words(300));
+    // 整体比值 0.85 恰好擦过整响应阈值，靠滑动窗口补位识别。
+    const segs = Array.from({ length: 30 }, (_, k) =>
+      k < 15
+        ? seg(k * 10, k * 10 + 9, textOf(k * 10, 10))
+        : seg(150 + 7 * (k - 15), 156 + 7 * (k - 15), textOf(k * 10, 10))
+    );
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).not.toBeNull();
+    expect(out[29].start).toBe(290 * 1000);
+    expect(out[29]._reanchored).toBe(true);
+  });
+
+  test("returns null for unspaced CJK responses", () => {
+    const events = wordEvents(words(200));
+    const segs = Array.from({ length: 150 }, (_, k) =>
+      seg(k, k, "这是一段没有空格的中文字幕文本")
+    );
+
+    expect(reanchorIfUntrusted(segs, events)).toBeNull();
+  });
+
+  test("a hallucinated segment misses without derailing the chain", () => {
+    const events = wordEvents(words(200));
+    const segs = compressed(20);
+    segs[10] = seg(70, 76, "zzz yyy xxx qqq ppp");
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).not.toBeNull();
+    expect(out[10]._reanchored).toBeUndefined();
+    expect(out[11].start).toBe(110 * 1000);
+    expect(out[11]._reanchored).toBe(true);
+  });
+
+  test("abandons after five consecutive misses and rejects the pass", () => {
+    const events = wordEvents(words(300));
+    const segs = compressed(30);
+    for (let k = 10; k < 15; k++) {
+      segs[k] = seg(7 * k, 7 * k + 6, `bad${k} bogus${k} nope${k} nah${k}`);
+    }
+
+    expect(reanchorIfUntrusted(segs, events)).toBeNull();
+  });
+
+  test("drops duplicate re-emissions overlapping the previous span", () => {
+    const events = wordEvents(words(200));
+    const segs = compressed(16);
+    segs.splice(6, 0, seg(40, 46, textOf(52, 8)));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(16);
+    expect(out[6].start).toBe(60 * 1000);
+  });
+
+  test("keeps a literally repeated back-to-back sentence", () => {
+    const w = words(200);
+    // 说话人原样重复上一句：词 60-69 与 50-59 完全相同。
+    for (let i = 0; i < 10; i++) w[60 + i] = `w${50 + i}`;
+    const events = wordEvents(w);
+    const segs = compressed(20);
+    segs[6] = seg(42, 48, textOf(50, 10));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).toHaveLength(20);
+    expect(out[5].start).toBe(50 * 1000);
+    expect(out[6].start).toBe(60 * 1000);
+    expect(out[6]._reanchored).toBe(true);
+  });
+
+  test("keeps a context-leak tail segment raw", () => {
+    const events = wordEvents(words(160));
+    const segs = compressed(16);
+    segs.push(seg(112, 118, "aaa bbb ccc ddd eee"));
+    const out = reanchorIfUntrusted(segs, events);
+
+    expect(out).not.toBeNull();
+    expect(out[16]._reanchored).toBeUndefined();
+  });
+
+  test("is deterministic", () => {
+    const events = wordEvents(words(400));
+    const segs = compressed(40);
+
+    expect(reanchorIfUntrusted(segs, events)).toEqual(
+      reanchorIfUntrusted(segs, events)
+    );
   });
 });

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -23,6 +23,7 @@ import {
   genFlatEvents,
   getFromLang,
   normalizeTimedTextEvents,
+  replaceReanchoredRange,
 } from "./youtubeSubtitleProcessing.js";
 import {
   CONTROLS_SELECTOR,
@@ -696,6 +697,12 @@ export class YouTubeCaptionProvider {
         progressed
       );
       this.#startManager();
+      // 流式草稿可能已提前启动 manager；首块最终结果（含重锚定替换）需强制重刷。
+      this.#managerInstance?.appendSubtitles(managedSubtitles);
+      this.#subtitleListManager?.setBilingualSubtitles(
+        this.#subtitles,
+        this.#progressed
+      );
       this.#managerInstance?.repairChunkTranslations(managedSubtitles);
     } catch (error) {
       if (error?.name === "AbortError") return;
@@ -717,6 +724,9 @@ export class YouTubeCaptionProvider {
       this.#progressed = progressed;
       return [];
     }
+
+    // 整体重锚定的最终结果先清掉时间范围内的失准草稿，再走常规合并。
+    replaceReanchoredRange(this.#subtitles, subtitles);
 
     const existed = new Map(
       this.#subtitles.map((sub, index) => [`${sub.start}:${sub.end}`, index])

--- a/src/subtitle/YouTubeCaptionProvider.test.js
+++ b/src/subtitle/YouTubeCaptionProvider.test.js
@@ -59,6 +59,7 @@ jest.mock("./youtubeSubtitleProcessing.js", () => ({
   genFlatEvents: jest.fn(),
   getFromLang: () => "en",
   normalizeTimedTextEvents: jest.fn(),
+  replaceReanchoredRange: jest.fn(),
 }));
 
 jest.mock("./youtubeAiSegmentation.js", () => ({
@@ -69,6 +70,7 @@ jest.mock("./BilingualSubtitleManager.js", () => ({
   BilingualSubtitleManager: class {
     start = jest.fn();
     destroy = jest.fn();
+    appendSubtitles = jest.fn();
     repairChunkTranslations = jest.fn();
   },
 }));

--- a/src/subtitle/YouTubeSubtitleList.js
+++ b/src/subtitle/YouTubeSubtitleList.js
@@ -1079,14 +1079,14 @@ export class YouTubeSubtitleList {
    * 利用二分检索算法 (O(log N)) 在有序的字幕缓存数组中快速定位匹配目标时间轴的 DOM 节点，
    * 随后定向修改译文 textContent 并显示。由于无需重画周边节点，性能极佳。
    *
-   * @param {object} subtitleUpdate - 含有 { start, translation } 的更新分片数据
+   * @param {object} subtitleUpdate - 含有 { start, end, text, translation } 的更新分片数据
    */
   updateSingleSubtitle(subtitleUpdate) {
     if (!this.subtitleListEl) return;
 
-    const { start, translation } = subtitleUpdate;
+    const { start, end, text, translation } = subtitleUpdate;
     // 对有序的双语字幕数组进行二分精确匹配
-    const targetIndex = this._findSubtitleIndexByStart(start);
+    const targetIndex = this._findSubtitleIndexByStart(start, end, text);
 
     if (targetIndex === -1) return;
 
@@ -1109,22 +1109,43 @@ export class YouTubeSubtitleList {
 
   /**
    * 根据字幕开始时间定位字幕索引。
-   * 翻译更新事件只携带 start 时间；字幕数组按 start 升序排列，因此这里用二分查找避免线性扫描。
+   * 字幕数组按 start 升序排列，先二分再在同 start 相邻段内用 end/text 精确命中：
+   * 断句模型会重发与整句同一 start 的感叹词短段，只按 start 匹配会把译文写到相邻
+   * 条目上；条目被最终断句替换后 end/text 已变的迟到更新同样不能落到别的句子上，
+   * 宁可丢弃等预翻译循环重译。
    * @param {number} start 字幕开始时间（毫秒）
+   * @param {number} [end] 字幕结束时间（毫秒），与 text 一起精确命中
+   * @param {string} [text] 字幕原文，与 end 一起精确命中
    * @returns {number} 匹配的字幕索引，未找到返回 -1
    */
-  _findSubtitleIndexByStart(start) {
+  _findSubtitleIndexByStart(start, end, text) {
+    const subs = this.bilingualSubtitles;
     let left = 0;
-    let right = this.bilingualSubtitles.length - 1;
+    let right = subs.length - 1;
+    let hit = -1;
 
     while (left <= right) {
       const mid = Math.floor((left + right) / 2);
-      const sub = this.bilingualSubtitles[mid];
-      if (sub.start === start) return mid;
+      const sub = subs[mid];
+      if (sub.start === start) {
+        hit = mid;
+        break;
+      }
       if (sub.start > start) right = mid - 1;
       else left = mid + 1;
     }
+    if (hit === -1) return -1;
+    // 不带判别字段的旧调用保持按 start 命中。
+    if (end === undefined && text === undefined) return hit;
 
+    let lo = hit;
+    while (lo > 0 && subs[lo - 1].start === start) lo--;
+    let hi = hit;
+    while (hi + 1 < subs.length && subs[hi + 1].start === start) hi++;
+
+    for (let i = lo; i <= hi; i++) {
+      if (subs[i].end === end && subs[i].text === text) return i;
+    }
     return -1;
   }
 

--- a/src/subtitle/YouTubeSubtitleList.test.js
+++ b/src/subtitle/YouTubeSubtitleList.test.js
@@ -218,6 +218,61 @@ describe("YouTubeSubtitleList", () => {
     manager.destroy();
   });
 
+  test("routes translation updates to the exact same-start subtitle", async () => {
+    const videoEl = createVideoElement();
+    const manager = new YouTubeSubtitleList(videoEl);
+    // 断句模型重发的感叹词与整句共用同一 start，只按 start 匹配会互相错写译文。
+    const interjection = { start: 33000, end: 33500, text: "Okay." };
+    const sentence = {
+      start: 33000,
+      end: 36000,
+      text: "Well, we can see that it is eleven characters long.",
+    };
+
+    manager.initialize([interjection, sentence], [], 100);
+
+    manager.updateSingleSubtitle({ ...interjection, translation: "好。" });
+    manager.updateSingleSubtitle({
+      ...sentence,
+      translation: "我们可以看到它有 11 个字符长。",
+    });
+
+    expect(interjection.translation).toBe("好。");
+    expect(sentence.translation).toBe("我们可以看到它有 11 个字符长。");
+
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.destroy();
+  });
+
+  test("drops stale updates whose end/text no longer match any same-start cue", async () => {
+    const videoEl = createVideoElement();
+    const manager = new YouTubeSubtitleList(videoEl);
+    const sentence = {
+      start: 33000,
+      end: 36000,
+      text: "Okay, so we can move on now.",
+    };
+
+    manager.initialize([sentence], [], 100);
+
+    // 已被最终断句丢弃的重发短段迟到的译文，不得落到同 start 的幸存句子上。
+    manager.updateSingleSubtitle({
+      start: 33000,
+      end: 33500,
+      text: "Okay.",
+      translation: "好。",
+    });
+    expect(sentence.translation).toBeUndefined();
+
+    manager.updateSingleSubtitle({ ...sentence, translation: "好，那我们继续。" });
+    expect(sentence.translation).toBe("好，那我们继续。");
+
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.destroy();
+  });
+
   test("jumps only when clicking the time label", async () => {
     const videoEl = createVideoElement();
     const manager = new YouTubeSubtitleList(videoEl);

--- a/src/subtitle/youtubeAiSegmentation.js
+++ b/src/subtitle/youtubeAiSegmentation.js
@@ -150,7 +150,12 @@ export async function aiSegment({
         }));
       }
 
-      const maxEi = Math.max(...result.map((s) => s._ei ?? -1));
+      // 重锚定响应只认 _aei 为覆盖终点：未锚定段的原始 _ei 不可信，
+      // 虚高值会骗过尾句重试；未重锚定的响应维持原语义。
+      const isReanchored = result.some((s) => s._reanchored);
+      const maxEi = Math.max(
+        ...result.map((s) => (isReanchored ? (s._aei ?? -1) : (s._ei ?? -1)))
+      );
 
       if (maxEi >= 0 && maxEi < speechEvents.length - 1) {
         const tailEvents = speechEvents.slice(maxEi + 1);

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -1,4 +1,5 @@
 import {
+  aiSegment,
   createAiChunkScheduler,
   eventsToSubtitles,
 } from "./youtubeAiSegmentation";
@@ -347,5 +348,76 @@ describe("createAiChunkScheduler", () => {
       progressed: 66,
       chunkNum: 2,
     });
+  });
+});
+
+describe("aiSegment tail retry", () => {
+  const chunkEvents = Array.from({ length: 12 }, (_, i) => ({
+    start: i * 1000,
+    end: i * 1000 + 1000,
+    text: `w${i}`,
+  }));
+  const baseArgs = {
+    videoId: "v",
+    fromLang: "en",
+    toLang: "zh-CN",
+    segApiSetting: {},
+    docInfo: {},
+    formatSubtitles: jest.fn(() => []),
+    clearSegmentTranslation: false,
+    setting: {},
+  };
+
+  test("skips tail retry when reanchored coverage reaches the chunk end", async () => {
+    const apiSubtitle = jest.fn(() =>
+      Promise.resolve([
+        {
+          start: 0,
+          end: 12000,
+          text: "x",
+          _si: 0,
+          _ei: 7,
+          _aei: 11,
+          _reanchored: true,
+        },
+      ])
+    );
+
+    await aiSegment({ ...baseArgs, chunkEvents, apiSubtitle });
+
+    expect(apiSubtitle).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries the tail from the raw end when not reanchored", async () => {
+    const apiSubtitle = jest.fn(() =>
+      Promise.resolve([{ start: 0, end: 8000, text: "x", _si: 0, _ei: 7 }])
+    );
+
+    await aiSegment({ ...baseArgs, chunkEvents, apiSubtitle });
+
+    expect(apiSubtitle).toHaveBeenCalledTimes(2);
+    expect(apiSubtitle.mock.calls[1][0].events).toHaveLength(4);
+  });
+
+  test("ignores raw _ei of unanchored segments in a reanchored response", async () => {
+    const apiSubtitle = jest.fn(() =>
+      Promise.resolve([
+        { start: 0, end: 8000, text: "x", _si: 0, _ei: 11 },
+        {
+          start: 0,
+          end: 8000,
+          text: "y",
+          _si: 3,
+          _ei: 5,
+          _aei: 7,
+          _reanchored: true,
+        },
+      ])
+    );
+
+    await aiSegment({ ...baseArgs, chunkEvents, apiSubtitle });
+
+    expect(apiSubtitle).toHaveBeenCalledTimes(2);
+    expect(apiSubtitle.mock.calls[1][0].events).toHaveLength(4);
   });
 });

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -522,7 +522,8 @@ export function splitEventsIntoChunks(flatEvents, chunkLength = 1000) {
 /**
  * 用整体重锚定后的最终结果替换其时间范围内的失准流式草稿。
  * 必须就地变异 subtitles：数组引用被播放器 manager 与字幕列表持有，不能重建。
- * 删除范围取新结果的 [最早 start, 最晚 end)，半开区间保护相邻分块的首句。
+ * 删除范围优先取锚定段携带的响应事件范围 _alo/_ahi（首尾短段被丢弃时不留缝），
+ * 缺省回退新结果的 [最早 start, 最晚 end)，半开区间保护相邻分块的首句。
  *
  * @param {Array<object>} subtitles 当前已合并的字幕数组。
  * @param {Array<object>} incoming 新到达的字幕条目。
@@ -534,8 +535,10 @@ export function replaceReanchoredRange(subtitles, incoming) {
   let lo = Infinity;
   let hi = -Infinity;
   for (const sub of incoming) {
-    if (sub.start < lo) lo = sub.start;
-    if (sub.end > hi) hi = sub.end;
+    const s = sub._alo ?? sub.start;
+    const e = sub._ahi ?? sub.end;
+    if (s < lo) lo = s;
+    if (e > hi) hi = e;
   }
 
   for (let i = subtitles.length - 1; i >= 0; i--) {

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -518,3 +518,30 @@ export function splitEventsIntoChunks(flatEvents, chunkLength = 1000) {
 
   return eventChunks;
 }
+
+/**
+ * 用整体重锚定后的最终结果替换其时间范围内的失准流式草稿。
+ * 必须就地变异 subtitles：数组引用被播放器 manager 与字幕列表持有，不能重建。
+ * 删除范围取新结果的 [最早 start, 最晚 end)，半开区间保护相邻分块的首句。
+ *
+ * @param {Array<object>} subtitles 当前已合并的字幕数组。
+ * @param {Array<object>} incoming 新到达的字幕条目。
+ * @returns {void}
+ */
+export function replaceReanchoredRange(subtitles, incoming) {
+  if (!incoming?.some((sub) => sub._reanchored)) return;
+
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const sub of incoming) {
+    if (sub.start < lo) lo = sub.start;
+    if (sub.end > hi) hi = sub.end;
+  }
+
+  for (let i = subtitles.length - 1; i >= 0; i--) {
+    const { start } = subtitles[i];
+    if (start >= lo && start < hi) {
+      subtitles.splice(i, 1);
+    }
+  }
+}

--- a/src/subtitle/youtubeSubtitleProcessing.test.js
+++ b/src/subtitle/youtubeSubtitleProcessing.test.js
@@ -3,6 +3,7 @@ import {
   formatSubtitles,
   genFlatEvents,
   normalizeTimedTextEvents,
+  replaceReanchoredRange,
   splitEventsIntoChunks,
 } from "./youtubeSubtitleProcessing.js";
 
@@ -45,6 +46,33 @@ describe("youtubeSubtitleProcessing", () => {
     };
 
     expect(normalizeTimedTextEvents([event, { ...event }])).toHaveLength(1);
+  });
+
+  test("replaces stale cues inside a reanchored incoming range in place", () => {
+    const cue = (start, end, extra = {}) => ({ start, end, ...extra });
+    const list = [
+      cue(0, 900),
+      cue(1000, 1800),
+      cue(2500, 3000),
+      cue(5000, 5800),
+    ];
+    const incoming = [
+      cue(1000, 2000, { _reanchored: true }),
+      cue(2000, 5000),
+    ];
+
+    replaceReanchoredRange(list, incoming);
+
+    // 半开区间：范围内的失准草稿被清掉，恰好落在 endMs 的下一分块首句保留。
+    expect(list).toEqual([cue(0, 900), cue(5000, 5800)]);
+  });
+
+  test("keeps the list untouched when incoming has no reanchored cues", () => {
+    const list = [{ start: 1000, end: 2000 }];
+
+    replaceReanchoredRange(list, [{ start: 500, end: 3000 }]);
+
+    expect(list).toEqual([{ start: 1000, end: 2000 }]);
   });
 
   test("generates flat events with start and end timestamps", () => {

--- a/src/subtitle/youtubeSubtitleProcessing.test.js
+++ b/src/subtitle/youtubeSubtitleProcessing.test.js
@@ -67,6 +67,19 @@ describe("youtubeSubtitleProcessing", () => {
     expect(list).toEqual([cue(0, 900), cue(5000, 5800)]);
   });
 
+  test("purges the entire response range carried on reanchored cues", () => {
+    const cue = (start, end, extra = {}) => ({ start, end, ...extra });
+    const list = [cue(300, 900), cue(1500, 2400), cue(6200, 6900)];
+    const incoming = [
+      cue(1000, 2000, { _reanchored: true, _alo: 200, _ahi: 6000 }),
+    ];
+
+    replaceReanchoredRange(list, incoming);
+
+    // 清扫范围取 _alo/_ahi 的 [200, 6000)：首段短句被丢弃留下的缝隙草稿一并清除。
+    expect(list).toEqual([cue(6200, 6900)]);
+  });
+
   test("keeps the list untouched when incoming has no reanchored cues", () => {
     const list = [{ start: 1000, end: 2000 }];
 


### PR DESCRIPTION
#888 处理的是断句模型 s/e 索引偏离几个到二十个词的局部漂移,逐段在声称位置附近就近校正。实测发现更严重的失控形态:分包长度调大(如 20000)时,单次响应要维护数千个递增编号,模型计数整体崩坏。一个 30 分钟视频的实测响应里,128 段只消耗了七成 id,字幕从 15 分钟处起越来越提前,最多超前语音 230 秒,持续十分钟不自愈,直到下一响应才复位。这种量级的漂移就近校正追不回,需要响应级处理。自测阶段又发现两处残留问题:重锚定放行的短段成为幻影字幕,同 start 字幕的译文会写错条目,一并修复。

改动内容

1. 响应级失准门控( 93bec89 )

解析完成后统计整份响应「声称消耗词数」与「o 文本词数」:整体比值偏差超 0.15、任一 10 段滑动窗口比值越出 0.8~1.25、前缀累计亏空达 80 词,三者任一命中即判定该响应的 id 整体不可信。声称词数按事件词表统计而非 e−s+1,整句轨同样适用;段数或词量不足、词分隔度不够(CJK)时门控不启用。

2. 游标单调全局重锚定( 93bec89 )

失准响应放弃模型 id,按输出顺序用每段 o 的词序列在词表上接续锚定:候选取离游标最近(回溯 40 词、前向上限 200 词,等距偏顺流方向),尾部词组在 ±4 内修正终点,重复重发段保留先到者;锚定失败保持原时间且不动游标,连续 5 次失败放弃剩余段。锚定段占比与词覆盖率任一低于 0.7 则整体回退,保持原结果。

3. 流式草稿抑制与最终替换( 93bec89 )

流式阶段以 10 段滑动窗口监测草稿失准,命中后停止向播放器转发,内部收集不受影响,最终解析失败时的兜底数组仍然完整;监测只对词级 ASR 轨启用,行级人工轨一个事件多词,比值天然偏低,不参与监测。重锚定结果到达时,provider 按其时间范围原地清除失准草稿再合并,数组引用保持不变;首块最终结果到达时强制刷新 manager 与字幕列表。

4. 尾句重试与缓存( 93bec89 )

重锚定响应的尾句重试只认锚定终点 _aei,不受未锚定段虚高 _ei 干扰。

5. 短段就近重锚定与丢弃( aa63e8b )

重锚定原先对不足 3 词的短段直接放行原始时间,实测一个多感叹词的视频里 27 条 "Okay." 这类短段提前语音 28 到 165 秒上屏,成为幻影字幕。现在短段在游标近旁(回溯 10 词、前向 40 词)取最近匹配锚定,成功后照常推进游标;找不到、等距歧义、单词段距离超 8 词或落入已消费区(模型重发)的整段丢弃。验收比率只统计参与评判的段,被丢弃的短段不再稀释通过率;词分隔守卫改按词量占比统计,多感叹词的英文响应不再漏判。重锚定结果携带响应事件范围 _alo/_ahi,草稿清扫覆盖整个响应而非输出 cue 的 min/max。

6. 译文更新精确匹配同 start 字幕( 4401dbf )

断句模型会重发与整句同一 start 的感叹词短段,字幕列表的译文更新只按 start 二分定位,碰撞时译文写到相邻条目,整句会显示成「好。」。更新负载本就携带 end 与原文,现在在同 start 相邻段内用两者精确命中;命中不了的迟到更新(条目已被最终断句替换或丢弃)直接放弃等预翻译重译,不再回落到任意条目。

影响范围

- 调大分包长度的 AI 断句用户:整包崩坏的响应被检测并整体重建时间轴。实测案例一 124 条纠正、0 条误锚;案例二 656/658 条主轨正确、27 条幻影短段全部消除(25 丢弃、1 锚回、1 为重发段按设计丢弃)
- 默认设置用户:实测英文与日文正常视频门控零触发,行为与 #888 完全一致
- 流式观感:失准响应的草稿在检测点后暂停上屏,最终结果返回时一次性替换为正确时间轴
- 同 start 字幕的译文归属:恢复正确,不再互相错写
- 缓存:沿用 #888 升至 3 的 segVer,不再重复递增,正式版用户只经历一次缓存失效