### PR TITLE
feat: 新增划词翻译双击触发模式

### DIFF
--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -2751,6 +2751,14 @@ export const I18N = {
     ko: `선택 트리거`,
     tr: `Tetikleyiciyi Seçin`,
   },
+  trigger_dblclick: {
+    zh: `双击触发`,
+    en: `Double-click Trigger`,
+    zh_TW: `雙擊觸發`,
+    ja: `ダブルクリックトリガー`,
+    ko: `더블클릭 트리거`,
+    tr: `Çift Tıklama Tetikleyicisi`,
+  },
   tranbtn_position_mode: {
     zh: `弹出按钮位置`,
     en: `Popup Button Position`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -95,10 +95,12 @@ export const PHONIC_MAP = {
 export const OPT_TRANBOX_TRIGGER_CLICK = "click"; // 划词后，点击出现的翻译悬浮球图标再触发翻译
 export const OPT_TRANBOX_TRIGGER_HOVER = "hover"; // 划词后，鼠标悬停在悬浮球上触发翻译
 export const OPT_TRANBOX_TRIGGER_SELECT = "select"; // 划词后直接开始翻译并展现结果面板
+export const OPT_TRANBOX_TRIGGER_DBLCLICK = "dblclick"; // 双击自动选中单词时直接翻译（不响应拖拽选区，减少复制误触）
 export const OPT_TRANBOX_TRIGGER_ALL = [
   OPT_TRANBOX_TRIGGER_CLICK,
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
+  OPT_TRANBOX_TRIGGER_DBLCLICK,
 ];
 // 划词后弹出按钮的定位模式
 export const OPT_TRANBOX_BTN_POSITION_FIXED = "fixed"; // 沿用当前逻辑，固定显示在选区右下角

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -8,6 +8,7 @@ import {
   OPT_TRANBOX_BTN_POSITION_MOUSE,
   OPT_TRANBOX_TRIGGER_HOVER,
   OPT_TRANBOX_TRIGGER_SELECT,
+  OPT_TRANBOX_TRIGGER_DBLCLICK,
   OPT_TRANBOX_INTERACT_CLICK,
   OPT_TRANBOX_INTERACT_DBLCLICK,
 } from "../config";
@@ -313,7 +314,10 @@ export default function useSelectionController({
         );
       }
 
-      if (triggerMode === OPT_TRANBOX_TRIGGER_SELECT) {
+      if (
+        triggerMode === OPT_TRANBOX_TRIGGER_SELECT ||
+        triggerMode === OPT_TRANBOX_TRIGGER_DBLCLICK
+      ) {
         commitSelectionSnapshot(snapshot);
         return;
       }
@@ -447,13 +451,22 @@ export default function useSelectionController({
   }, [triggerMode]);
 
   useEffect(() => {
-    const eventName = isMobile ? "touchend" : "mouseup";
+    // 双击触发模式下监听 dblclick：仅在浏览器双击自动选词时触发，
+    // 拖拽选择不会派发 dblclick，从而避免复制等操作时的误触。
+    let eventName;
+    if (triggerMode === OPT_TRANBOX_TRIGGER_DBLCLICK) {
+      eventName = "dblclick";
+    } else if (isMobile) {
+      eventName = "touchend";
+    } else {
+      eventName = "mouseup";
+    }
 
     window.addEventListener(eventName, handleSelectionEvent);
     return () => {
       window.removeEventListener(eventName, handleSelectionEvent);
     };
-  }, [handleSelectionEvent]);
+  }, [handleSelectionEvent, triggerMode]);
 
   useEffect(() => {
     if (!hideClickAway) return;

--- a/src/hooks/useSelectionController.test.js
+++ b/src/hooks/useSelectionController.test.js
@@ -119,6 +119,16 @@ async function dispatchWindowMouseup(delay = 200) {
   });
 }
 
+async function dispatchWindowDblclick() {
+  await act(async () => {
+    window.dispatchEvent(
+      new MouseEvent("dblclick", { bubbles: true, button: 0 })
+    );
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+  });
+}
+
 async function dispatchPanelMouseup(target, composedPath) {
   await act(async () => {
     const event = new MouseEvent("mouseup", {
@@ -425,6 +435,39 @@ describe("useSelectionController", () => {
 
     expect(controller.state.text).toBe("selected");
     expect(controller.state.textContext).toBe("Panel selected word context.");
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("opens the box immediately on double-click in dblclick mode", async () => {
+    const controller = renderController({ triggerMode: "dblclick" });
+    const pageParagraph = createParagraph("The library is open.");
+
+    currentSelection = makeSelection("library", pageParagraph);
+    await dispatchWindowDblclick();
+
+    expect(controller.state.text).toBe("library");
+    expect(controller.state.textContext).toBe("The library is open.");
+    expect(controller.state.showBox).toBe(true);
+    expect(controller.state.showBtn).toBe(false);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("ignores plain mouseup selections in dblclick mode", async () => {
+    const controller = renderController({ triggerMode: "dblclick" });
+    const pageParagraph = createParagraph("The library is open.");
+
+    currentSelection = makeSelection("library", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.text).toBe("");
+    expect(controller.state.showBox).toBe(false);
+    expect(controller.state.showBtn).toBe(false);
 
     act(() => {
       controller.root.unmount();


### PR DESCRIPTION
issue #914 

新增「双击触发」模式，仅在浏览器原生双击自动选词时触发翻译，
拖拽选区和复制操作不会误触弹出翻译框。

- 新增 OPT_TRANBOX_TRIGGER_DBLCLICK 常量，加入 OPT_TRANBOX_TRIGGER_ALL
- 双击模式下将全局事件监听切换为 dblclick，拖拽选区不触发翻译
- 选词后直接弹出翻译框，无需点击悬浮球（与「选中触发」行为一致）
- 新增 zh/en/zh_TW/ja/ko/tr 六语言 i18n 文案
- 新增单元测试：双击立即打开翻译框；双击模式下 mouseup 事件无效

<img width="1960" height="1354" alt="PixPin_2026-07-18_20-19-57" src="https://github.com/user-attachments/assets/95d358fa-f6f6-426f-8aaa-19bccc451359" />