### PR TITLE
Handle Firefox Xray TypedArray errors in GM streams

### DIFF
--- a/src/libs/requestStream.js
+++ b/src/libs/requestStream.js
@@ -33,8 +33,9 @@ async function* fetchStreamGM(
   { method = "GET", headers, body, timeout, signal } = {}
 ) {
   const asyncQueue = createAsyncQueue();
-  const parseSSE = createSSEParser();
+  let parseSSE = createSSEParser();
   let readerStarted = false;
+  let readerFallbackError = null;
   let pushedChunk = false;
   let lastResponseTextLength = 0;
   let settled = false;
@@ -53,6 +54,11 @@ async function* fetchStreamGM(
     settled = true;
     asyncQueue.error(error);
   };
+
+  const isXrayTypedArrayError = (error) =>
+    String(error?.message || error).includes(
+      "Accessing TypedArray data over Xrays"
+    );
 
   const getResponseText = (event = {}) => {
     if (typeof event.responseText === "string") return event.responseText;
@@ -148,8 +154,9 @@ async function* fetchStreamGM(
       }
 
       readerStarted = true;
+      let reader;
       try {
-        const reader = response.getReader();
+        reader = response.getReader();
         const decoder = new TextDecoder();
         while (true) {
           const { done: readerDone, value } = await reader.read();
@@ -162,6 +169,17 @@ async function* fetchStreamGM(
           }
         }
       } catch (e) {
+        if (!pushedChunk && isXrayTypedArrayError(e)) {
+          readerStarted = false;
+          readerFallbackError = e;
+          parseSSE = createSSEParser();
+          try {
+            await reader?.cancel?.();
+          } catch {
+            // The broken cross-realm reader may also reject cancellation.
+          }
+          return;
+        }
         fail(e);
         return;
       }
@@ -173,7 +191,10 @@ async function* fetchStreamGM(
 
       pushResponseTextDelta(event, true);
       if (!pushedChunk) {
-        fail(new Error("GM stream response is not readable."));
+        fail(
+          readerFallbackError ||
+            new Error("GM stream response is not readable.")
+        );
         return;
       }
       finish();

--- a/src/libs/requestStream.test.js
+++ b/src/libs/requestStream.test.js
@@ -162,6 +162,108 @@ describe("requestStream in userscript", () => {
     await expect(done).resolves.toEqual({ value: undefined, done: true });
   });
 
+  test("falls back to responseText when Firefox blocks a TypedArray over Xrays", async () => {
+    let decoderCount = 0;
+    global.TextDecoder = class {
+      constructor() {
+        this.isStreamDecoder = decoderCount++ === 1;
+      }
+
+      decode() {
+        if (this.isStreamDecoder) {
+          throw new Error(
+            "Accessing TypedArray data over Xrays is slow, and forbidden in order to encourage performant code."
+          );
+        }
+        return "";
+      }
+    };
+    const cancel = jest.fn(() => Promise.resolve());
+    const reader = {
+      read: jest.fn().mockResolvedValueOnce({
+        done: false,
+        value: new Uint8Array([100]),
+      }),
+      cancel,
+    };
+
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    await requestDetails.onloadstart({
+      response: { getReader: () => reader },
+    });
+    requestDetails.onprogress({ responseText: "data: one\n\n" });
+
+    await expect(first).resolves.toEqual({ value: "one", done: false });
+
+    const second = iterator.next();
+    requestDetails.onprogress({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+    await expect(second).resolves.toEqual({ value: "two", done: false });
+
+    const done = iterator.next();
+    requestDetails.onload({
+      responseText: "data: one\n\ndata: two\n\n",
+    });
+    await expect(done).resolves.toEqual({ value: undefined, done: true });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves the Xray error when responseText fallback is unavailable", async () => {
+    let decoderCount = 0;
+    global.TextDecoder = class {
+      constructor() {
+        this.isStreamDecoder = decoderCount++ === 1;
+      }
+
+      decode() {
+        if (this.isStreamDecoder) {
+          throw new Error("Accessing TypedArray data over Xrays is forbidden");
+        }
+        return "";
+      }
+    };
+    const reader = {
+      read: jest.fn().mockResolvedValueOnce({
+        done: false,
+        value: new Uint8Array([100]),
+      }),
+      cancel: jest.fn(() => Promise.resolve()),
+    };
+
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    await requestDetails.onloadstart({
+      response: { getReader: () => reader },
+    });
+    requestDetails.onload({});
+
+    await expect(first).rejects.toThrow(
+      "Accessing TypedArray data over Xrays is forbidden"
+    );
+  });
+
+  test("does not hide non-Xray readable stream errors", async () => {
+    const reader = {
+      read: jest.fn().mockRejectedValueOnce(new Error("stream read failed")),
+    };
+
+    const iterator = requestStream("https://example.test/stream", {});
+    const first = iterator.next();
+    await waitForRequestDetails();
+
+    await requestDetails.onloadstart({
+      response: { getReader: () => reader },
+    });
+
+    await expect(first).rejects.toThrow("stream read failed");
+  });
+
   test("converts second-based timeout values before passing them to GM", async () => {
     const iterator = requestStream(
       "https://example.test/stream",


### PR DESCRIPTION
在 Firefox + Violentmonkey 环境下开启流式翻译时，抛出：
Accessing TypedArray data over Xrays is slow, and forbidden in order to encourage performant code.


详见：
https://github.com/fishjar/kiss-translator/pull/886