### PR TITLE
Improve translator workflow and application UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store/
 /.pnp
 /.obsidian
 .pnp.js
@@ -9,6 +10,7 @@
 
 # testing
 /coverage
+/tmp/
 
 # production
 /build

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 build
 public
 package.json
+testdata/subtitle-samples

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "zip": "zx src/scripts/archive.mjs",
     "build+zip": "cross-env CI=true pnpm build && pnpm zip",
     "test": "react-app-rewired test",
+    "test:subtitle-segmentation": "babel-node src/scripts/test-subtitle-segmentation.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -26,6 +26,8 @@ import {
   handleTranslate,
   handleDict,
   handleSubtitle,
+  buildSubtitleSystemPrompt,
+  formatIndexSubtitleEvents,
   handleSummarize,
   handleMicrosoftLangdetect,
 } from "./trans";
@@ -42,7 +44,6 @@ import { getDocInfo } from "../libs/docInfo";
 const PROMPT_CACHE_SALT = "prompt-cache";
 const PROMPT_CACHE_SCOPE_BATCH = "batch";
 const PROMPT_CACHE_SCOPE_NOBATCH = "nobatch";
-const PROMPT_CACHE_SCOPE_SUBTITLE = "subtitle";
 const PROMPT_CACHE_SCOPE_DICT = "dict";
 const PROMPT_CACHE_SCOPE_PLAIN = "plain";
 
@@ -66,10 +67,6 @@ function getPromptCacheFields(apiSetting = {}, promptScope) {
       apiSetting.nobatchPrompt || "",
       apiSetting.nobatchUserPrompt ?? defaultNobatchUserPrompt,
     ];
-  }
-
-  if (promptScope === PROMPT_CACHE_SCOPE_SUBTITLE) {
-    return [apiSetting.subtitlePrompt || ""];
   }
 
   if (promptScope === PROMPT_CACHE_SCOPE_DICT) {
@@ -890,7 +887,7 @@ export const apiDict = async ({
 /**
  * 专为视频外挂字幕 (Subtitle Segment) 订制的翻译处理函数。
  * 融合了视频上下文摘要，使得大模型字幕翻译语义更加贴合剧情，不会产生传统断句翻译的突兀感。
- * @param {Object} params 包含视频 ID、字幕块标识、当前切片字幕数组、上一句和下一句字幕上下文等。
+ * @param {Object} params 包含视频 ID、字幕块标识和当前切片字幕数组等。
  * @param {Function} [params.onSubtitleChunk] 字幕断句流式输出完整句子时触发的增量回调。
  * @param {AbortSignal} [params.signal] 当前字幕处理生命周期的取消信号，会下传到请求层。
  * @returns {Promise<Array<Object>>} 完整字幕断句与翻译结果。
@@ -903,21 +900,55 @@ export const apiSubtitle = async ({
   events = [],
   apiSetting,
   docInfo,
-  prevContext = "",
-  nextContext = "",
   onSubtitleChunk,
   signal,
 }) => {
   if (!events?.length) return [];
-  const cacheOpts = {
-    apiSlug: apiSetting.apiSlug,
-    videoId,
-    chunkSign,
+  const formattedEvents = formatIndexSubtitleEvents(
+    events,
+    apiSetting.subtitlePrompt
+  );
+  // chunk 哈希同时包含 AI 输入和内部时间轴，避免相同首尾时间误命中旧字幕。
+  const chunkHash = (
+    await getCacheDigest(
+      JSON.stringify(
+        formattedEvents.map((item, index) => [
+          item.id,
+          item.text,
+          events[index]?.start,
+          events[index]?.end,
+          // 新协议记录精确停顿；旧提示词仍使用 p 时继续纳入同一哈希槽位。
+          item.pauseMs || item.p || 0,
+        ])
+      ),
+      "subtitle-chunk-v4"
+    )
+  ).slice(0, 16);
+  // 对完成变量替换的最终提示词签名，动态视频上下文无需再维护独立 contextSig。
+  const renderedPrompt = buildSubtitleSystemPrompt({
+    subtitlePrompt: apiSetting.subtitlePrompt,
+    tone: apiSetting.tone,
+    from: fromLang,
+    to: toLang,
     fromLang,
     toLang,
-    segVer: 3,
-    promptSig: await getPromptCacheSig(apiSetting, PROMPT_CACHE_SCOPE_SUBTITLE),
-    ctx: docInfo?.summary?.slice(0, 50) || "",
+    docInfo,
+    aiTerms: apiSetting.aiTerms,
+  });
+  const cacheOpts = {
+    apiSlug: apiSetting.apiSlug,
+    apiType: apiSetting.apiType,
+    model: apiSetting.model,
+    videoId,
+    chunkSign,
+    chunkHash,
+    fromLang,
+    toLang,
+    segVer: 4,
+    promptSig: (await getCacheDigest(renderedPrompt, PROMPT_CACHE_SALT)).slice(
+      0,
+      16
+    ),
   };
   const cacheInput = `${URL_CACHE_SUBTITLE}?${queryString.stringify(cacheOpts)}`;
 
@@ -927,15 +958,13 @@ export const apiSubtitle = async ({
     return cache;
   }
 
-  // 2. 发起含有剧本前后文语义的字幕翻译请求
+  // 2. 发起使用视频级系统上下文的字幕断句与翻译请求。
   const subtitles = await handleSubtitle({
     events,
     from: fromLang,
     to: toLang,
     apiSetting,
     docInfo,
-    prevContext,
-    nextContext,
     onSubtitleChunk,
     signal,
   });

--- a/src/apis/index.test.js
+++ b/src/apis/index.test.js
@@ -55,12 +55,25 @@ jest.mock("./trans", () => ({
   handleTranslate: jest.fn(),
   handleDict: jest.fn(),
   handleSubtitle: jest.fn(),
+  // 字幕缓存测试只关心最终提示词和稳定事件输入，不在这里重复测试提示词模板替换。
+  buildSubtitleSystemPrompt: ({ subtitlePrompt, docInfo }) =>
+    `${subtitlePrompt || ""}\n${docInfo?.title || ""}\n${docInfo?.summary || ""}`,
+  formatIndexSubtitleEvents: (events) =>
+    events.map((event, id) => {
+      const item = { id, text: event.text };
+      // 缓存测试使用 boundary-v3 输入，正间隔挂在停顿前的事件上。
+      if (id < events.length - 1) {
+        const pauseMs = Math.round(events[id + 1].start - event.end);
+        if (pauseMs > 0) item.pauseMs = pauseMs;
+      }
+      return item;
+    }),
   handleSummarize: jest.fn(),
   handleMicrosoftLangdetect: jest.fn(),
 }));
 
-import { apiDict, apiTranslate } from "./index";
-import { handleDict, handleTranslate } from "./trans";
+import { apiDict, apiSubtitle, apiTranslate } from "./index";
+import { handleDict, handleSubtitle, handleTranslate } from "./trans";
 import { fnPolyfill } from "../libs/fetch";
 import { withTimeout } from "../libs/utils";
 import { getBatchQueue } from "../libs/batchQueue";
@@ -88,6 +101,122 @@ const getBuiltinAiApiSetting = (httpTimeout) => ({
   fetchInterval: 100,
   fetchLimit: 1,
   httpTimeout,
+});
+
+describe("apiSubtitle cache identity", () => {
+  const events = [{ start: 100, end: 900, text: "hello" }];
+
+  beforeEach(() => {
+    getHttpCachePolyfill.mockResolvedValue(null);
+    handleSubtitle.mockResolvedValue([
+      { start: 100, end: 900, text: "hello", translation: "你好" },
+    ]);
+    mockGetCacheDigest.mockImplementation(async (text, salt) =>
+      `${salt}:${text}`.padEnd(64, "a")
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("includes chunk hash and rendered prompt signature without contextSig", async () => {
+    await apiSubtitle({
+      videoId: "video-1",
+      chunkSign: "100 --> 900",
+      fromLang: "en",
+      toLang: "zh-CN",
+      events,
+      apiSetting: {
+        ...getOpenAiApiSetting("translate"),
+        subtitlePrompt: "subtitle {{title}} {{summary}}",
+      },
+      docInfo: { title: "Title A", summary: "Summary A" },
+    });
+
+    const cacheInput = getHttpCachePolyfill.mock.calls[0][0];
+    expect(cacheInput).toContain("chunkHash=");
+    expect(cacheInput).toContain("promptSig=");
+    expect(cacheInput).toContain("segVer=4");
+    expect(cacheInput).not.toContain("contextSig=");
+    expect(mockGetCacheDigest).toHaveBeenCalledWith(
+      JSON.stringify([[0, "hello", 100, 900, 0]]),
+      "subtitle-chunk-v4"
+    );
+    expect(mockGetCacheDigest).toHaveBeenCalledWith(
+      expect.stringContaining("Summary A"),
+      "prompt-cache"
+    );
+  });
+
+  test("changes cache identity when the internal timeline or rendered context changes", async () => {
+    // 分别让时间轴和动态摘要产生不同摘要值，直接验证两部分缓存身份都会变化。
+    mockGetCacheDigest.mockImplementation(async (text, salt) => {
+      if (salt === "subtitle-chunk-v4") {
+        return (text.includes("901") ? "b" : "a").repeat(64);
+      }
+      return (text.includes("Summary B") ? "d" : "c").repeat(64);
+    });
+    const apiSetting = {
+      ...getOpenAiApiSetting("translate"),
+      subtitlePrompt: "subtitle {{summary}}",
+    };
+
+    await apiSubtitle({
+      videoId: "video-1",
+      chunkSign: "100 --> 900",
+      fromLang: "en",
+      toLang: "zh-CN",
+      events,
+      apiSetting,
+      docInfo: { summary: "Summary A" },
+    });
+    await apiSubtitle({
+      videoId: "video-1",
+      chunkSign: "100 --> 901",
+      fromLang: "en",
+      toLang: "zh-CN",
+      events: [{ ...events[0], end: 901 }],
+      apiSetting,
+      docInfo: { summary: "Summary B" },
+    });
+
+    const [firstCacheInput, secondCacheInput] =
+      getHttpCachePolyfill.mock.calls.map(([cacheInput]) => cacheInput);
+    expect(firstCacheInput).not.toBe(secondCacheInput);
+    expect(firstCacheInput).toContain(`chunkHash=${"a".repeat(16)}`);
+    expect(secondCacheInput).toContain(`chunkHash=${"b".repeat(16)}`);
+    expect(firstCacheInput).toContain(`promptSig=${"c".repeat(16)}`);
+    expect(secondCacheInput).toContain(`promptSig=${"d".repeat(16)}`);
+  });
+
+  test("includes boundary-v3 pauseMs in the v4 chunk hash", async () => {
+    const pauseEvents = [
+      { start: 0, end: 400, text: "hello" },
+      { start: 1250, end: 1800, text: "world" },
+    ];
+
+    await apiSubtitle({
+      videoId: "video-pause",
+      chunkSign: "0 --> 1800",
+      fromLang: "en",
+      toLang: "zh-CN",
+      events: pauseEvents,
+      apiSetting: {
+        ...getOpenAiApiSetting("translate"),
+        subtitlePrompt: "boundary-v3 prompt",
+      },
+    });
+
+    expect(mockGetCacheDigest).toHaveBeenCalledWith(
+      JSON.stringify([
+        [0, "hello", 0, 400, 850],
+        [1, "world", 1250, 1800, 0],
+      ]),
+      "subtitle-chunk-v4"
+    );
+    expect(getHttpCachePolyfill.mock.calls[0][0]).toContain("segVer=4");
+  });
 });
 
 describe("apiTranslate BuiltinAI timeout", () => {

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -76,6 +76,10 @@ import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
 import { parseBilingualVtt } from "../subtitle/vtt";
 import { getDocInfo } from "../libs/docInfo";
+import {
+  isLegacyIndexSubtitleItem,
+  mapBoundaryItemToCue,
+} from "../subtitle/subtitleBoundaryProtocol";
 
 const keyMap = new Map();
 const urlMap = new Map();
@@ -178,7 +182,8 @@ const genUserPrompt = ({
     .replaceAll(INPUT_PLACE_TEXT, texts[0]);
 };
 
-const genSubtitlePrompt = ({
+// 统一生成最终字幕系统提示词；缓存签名与实际请求必须复用同一结果。
+export const buildSubtitleSystemPrompt = ({
   subtitlePrompt,
   tone,
   from,
@@ -204,35 +209,9 @@ const genSubtitlePrompt = ({
     .replaceAll(INPUT_PLACE_TO_LANG, toLang);
 };
 
-const normalizeSubtitleContext = (text) =>
-  String(text ?? "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 400);
-
-const buildSubtitleUserPrompt = ({
-  formattedEvents,
-  prevContext = "",
-  nextContext = "",
-}) => {
-  const mainInput = JSON.stringify(formattedEvents);
-  const prev = normalizeSubtitleContext(prevContext);
-  const next = normalizeSubtitleContext(nextContext);
-  if (!prev && !next) return mainInput;
-  const sections = [];
-  if (prev) {
-    sections.push(
-      `[Previous context (read-only, do NOT segment)]\n${JSON.stringify(prev)}`
-    );
-  }
-  sections.push(`[Main input]\n${mainInput}`);
-  if (next) {
-    sections.push(
-      `[Next context (read-only, do NOT segment)]\n${JSON.stringify(next)}`
-    );
-  }
-  return sections.join("\n\n");
-};
+// 字幕用户消息保持为纯 JSON，避免只读上下文污染模型的边界编号。
+const buildSubtitleUserPrompt = ({ formattedEvents }) =>
+  JSON.stringify(formattedEvents);
 
 /**
  * 强健的大模型翻译结果解析器 (AI Response Robust Parser)。
@@ -271,9 +250,7 @@ const parseAIRes = (raw, useBatchFetch = true) => {
   });
 };
 
-/**
- * 依据时间差计算字幕中发生的句子停顿断句等级。
- */
+/** 依据时间差计算旧版字幕输入使用的停顿等级。 */
 const getPauseLevel = (gapMs) => {
   if (!Number.isFinite(gapMs) || gapMs <= 300) return 0;
   if (gapMs <= 600) return 1;
@@ -281,21 +258,48 @@ const getPauseLevel = (gapMs) => {
   return 3;
 };
 
-const formatIndexSubtitleEvents = (events) =>
-  events.map((e, i) => {
+/**
+ * 根据提示词识别字幕断句协议，供请求格式、缓存和 Playground 共用。
+ */
+export const detectSubtitleProtocol = (prompt = "") => {
+  const normalizedPrompt = String(prompt);
+  if (/WEBVTT|MM:SS\.mmm|-->/i.test(normalizedPrompt)) return "vtt-legacy";
+  if (/\{\s*["']?s["']?\s*:/.test(normalizedPrompt)) return "index-v1";
+
+  // 自定义提示词明确描述旧 p 等级时继续发送原结构，避免静默破坏已有配置。
+  const mentionsQuotedP = /["'`]p["'`]/i.test(normalizedPrompt);
+  const mentionsPauseLevel = /pause\s+levels?|停顿等级|暫停等級/i.test(
+    normalizedPrompt
+  );
+  if (mentionsQuotedP && mentionsPauseLevel) return "boundary-v2";
+  return "boundary-v3";
+};
+
+/** 将播放器事件压缩成发送给 AI 的稳定索引 JSON 结构。 */
+export const formatIndexSubtitleEvents = (events, prompt = "") => {
+  const protocol = detectSubtitleProtocol(prompt);
+  const usesLegacyPauseLevel =
+    protocol === "boundary-v2" ||
+    protocol === "index-v1" ||
+    protocol === "vtt-legacy";
+
+  return events.map((e, i) => {
     const item = { id: i, text: e.text };
-    if (i > 0) {
+    if (usesLegacyPauseLevel && i > 0) {
       const p = getPauseLevel(e.start - events[i - 1].end);
       if (p) item.p = p;
+    } else if (!usesLegacyPauseLevel && i < events.length - 1) {
+      // pauseMs 挂在停顿前的事件上，可直接作为该事件成为句末的边界提示。
+      const pauseMs = Math.round(events[i + 1].start - e.end);
+      if (pauseMs > 0) item.pauseMs = pauseMs;
     }
     return item;
   });
+};
 
 const usesIndexSubtitleInput = (prompt = "") => {
-  if (/\{\s*["']?s["']?\s*:/.test(prompt) && /\bid\b/i.test(prompt))
-    return true;
-  if (/WEBVTT|MM:SS\.mmm|-->/i.test(prompt)) return false;
-  return false;
+  // 只有明确声明 VTT 的旧提示词继续接收旧结构；其余字幕请求统一使用纯索引 JSON。
+  return detectSubtitleProtocol(prompt) !== "vtt-legacy";
 };
 
 const geminiText = (parts) =>
@@ -306,11 +310,28 @@ const geminiText = (parts) =>
         .join("")
     : "";
 
-const parseIndexSubtitleRes = (raw, events) => {
+const parseIndexSubtitleRes = (raw, events, fromLang = "auto") => {
   // 对齐器只建一次词表：buildResult 在截断修复兜底时可能执行两次。
   const aligner = createSubtitleIndexAligner(events);
   const buildResult = (data) => {
     if (!Array.isArray(data) || !data.length) return null;
+    const legacyItems = data.map(isLegacyIndexSubtitleItem);
+    // 同一响应混用新旧协议会使游标语义不明确，直接交给尾部恢复逻辑处理。
+    if (legacyItems.some(Boolean) && !legacyItems.every(Boolean)) return null;
+
+    if (!legacyItems[0]) {
+      const result = [];
+      let nextIndex = 0;
+      for (const item of data) {
+        const cue = mapBoundaryItemToCue(item, events, nextIndex, fromLang);
+        // 新协议一旦出现非法边界，停止接收后续对象，保留已验证的连续前缀。
+        if (!cue) break;
+        result.push(cue);
+        nextIndex = cue._ei + 1;
+      }
+      return result.length ? result : null;
+    }
+
     const result = [];
     for (const seg of data) {
       const s = Number(seg.s ?? seg.start_id);
@@ -328,6 +349,11 @@ const parseIndexSubtitleRes = (raw, events) => {
         // _si/_ei 保留模型原始索引：去重键与尾句重试语义依赖它们。
         _si: s,
         _ei: e,
+        // 仅在确实发生纠偏时记录覆盖索引，避免扩大普通结果的数据表面。
+        ...(fixed && {
+          _alignedSi: fixed.startIdx,
+          _alignedEi: fixed.endIdx,
+        }),
       });
     }
     return result.length ? result : null;
@@ -341,26 +367,26 @@ const parseIndexSubtitleRes = (raw, events) => {
     return buildResult(JSON.parse(repaired));
   } catch {
     try {
-      const last = Math.max(
-        repaired.lastIndexOf("},"),
-        repaired.lastIndexOf("}\n"),
-        repaired.lastIndexOf("}\r")
+      // 响应被截断时，从最后一个完整对象闭合处补上数组尾括号，保留可验证前缀。
+      const arrayStart = repaired.indexOf("[");
+      const lastObjectEnd = repaired.lastIndexOf("}");
+      if (arrayStart < 0 || lastObjectEnd < arrayStart) return null;
+      return buildResult(
+        JSON.parse(repaired.slice(arrayStart, lastObjectEnd + 1) + "]")
       );
-      if (last < 0) return null;
-      return buildResult(JSON.parse(repaired.slice(0, last + 1) + "]"));
     } catch {
       return null;
     }
   }
 };
 
-const parseSTRes = (raw, events = null) => {
+const parseSTRes = (raw, events = null, fromLang = "auto") => {
   if (!raw) {
     return [];
   }
 
   if (events?.length) {
-    const indexed = parseIndexSubtitleRes(raw, events);
+    const indexed = parseIndexSubtitleRes(raw, events, fromLang);
     if (indexed) return indexed;
   }
 
@@ -1004,8 +1030,6 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     customBody,
     events,
     tone,
-    prevContext,
-    nextContext,
     docInfo: externalDocInfo,
   } = args;
 
@@ -1021,7 +1045,7 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     const docInfo = externalDocInfo || getDocInfo();
 
     let baseSystemPrompt = events
-      ? genSubtitlePrompt({
+      ? buildSubtitleSystemPrompt({
           subtitlePrompt,
           from,
           to,
@@ -1047,10 +1071,8 @@ export const genTransReq = async ({ reqHook, ...args }) => {
     args.userPrompt = events
       ? buildSubtitleUserPrompt({
           formattedEvents: usesIndexSubtitleInput(subtitlePrompt)
-            ? formatIndexSubtitleEvents(events)
+            ? formatIndexSubtitleEvents(events, subtitlePrompt)
             : events,
-          prevContext,
-          nextContext,
         })
       : genUserPrompt({
           nobatchUserPrompt,
@@ -1798,8 +1820,6 @@ export const handleMicrosoftLangdetect = async (texts = []) => {
  * @param {string} params.to 目标语言代码。
  * @param {Object} params.apiSetting 字幕断句所使用的 API 配置。
  * @param {Object} [params.docInfo] 页面标题、描述和 AI 摘要等上下文。
- * @param {string} [params.prevContext] 前一个字幕分块的只读上下文。
- * @param {string} [params.nextContext] 后一个字幕分块的只读上下文。
  * @param {Function} [params.onSubtitleChunk] 流式解析到完整字幕句子时触发的回调。
  * @param {AbortSignal} [params.signal] 调用方生命周期取消信号，会下传到 fetch/fetchStream。
  * @returns {Promise<Array<Object>>} 完整字幕句子数组。
@@ -1810,8 +1830,6 @@ export const handleSubtitle = async ({
   to,
   apiSetting,
   docInfo,
-  prevContext = "",
-  nextContext = "",
   onSubtitleChunk,
   signal,
 }) => {
@@ -1827,9 +1845,9 @@ export const handleSubtitle = async ({
     events,
     from,
     to,
+    fromLang: from,
+    toLang: to,
     docInfo,
-    prevContext,
-    nextContext,
   });
 
   if (enableStream) {
@@ -1840,6 +1858,7 @@ export const handleSubtitle = async ({
         fetchInterval,
         fetchLimit,
         httpTimeout,
+        fromLang: from,
         onSubtitleChunk,
         signal,
       });
@@ -1859,8 +1878,6 @@ export const handleSubtitle = async ({
       to,
       apiSetting: { ...apiSetting, useStream: false },
       docInfo,
-      prevContext,
-      nextContext,
       signal,
     });
   }
@@ -1891,7 +1908,11 @@ export const handleSubtitle = async ({
     case OPT_TRANS_GEMINI_2:
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_OLLAMA:
-      return parseSTRes(res?.choices?.[0]?.message?.content ?? "", events);
+      return parseSTRes(
+        res?.choices?.[0]?.message?.content ?? "",
+        events,
+        from
+      );
     case OPT_TRANS_GEMINI: {
       const candidate = res?.candidates?.[0];
       const { thinkingMode } = apiSetting;
@@ -1912,9 +1933,9 @@ export const handleSubtitle = async ({
           events,
           from,
           to,
+          fromLang: from,
+          toLang: to,
           docInfo,
-          prevContext,
-          nextContext,
         });
         const retryRes = await fetchData(retryInput, retryInit, {
           useCache: false,
@@ -1926,14 +1947,15 @@ export const handleSubtitle = async ({
         if (retryRes?.candidates?.[0]?.content?.parts) {
           return parseSTRes(
             geminiText(retryRes.candidates[0].content.parts),
-            events
+            events,
+            from
           );
         }
       }
-      return parseSTRes(geminiText(candidate?.content?.parts), events);
+      return parseSTRes(geminiText(candidate?.content?.parts), events, from);
     }
     case OPT_TRANS_CLAUDE:
-      return parseSTRes(res?.content?.[0]?.text ?? "", events);
+      return parseSTRes(res?.content?.[0]?.text ?? "", events, from);
     case OPT_TRANS_CUSTOMIZE:
       return res;
     default:
@@ -1953,6 +1975,7 @@ export const handleSubtitle = async ({
  * @param {number} options.fetchInterval 请求池间隔。
  * @param {number} options.fetchLimit 请求池并发限制。
  * @param {number} options.httpTimeout 请求超时时间。
+ * @param {string} options.fromLang 源语言，用于按语言规则重建字幕原文。
  * @param {Function} options.onSubtitleChunk 新句子完成时触发的回调。
  * @param {AbortSignal} options.signal 取消信号。
  * @returns {Promise<Array<Object>>} 最终完整字幕数组。
@@ -1966,11 +1989,12 @@ async function handleSubtitleStreamInternal(
     fetchInterval,
     fetchLimit,
     httpTimeout,
+    fromLang,
     onSubtitleChunk,
     signal,
   }
 ) {
-  const parser = createStreamingSubtitleParser(events);
+  const parser = createStreamingSubtitleParser(events, { fromLang });
   let fullContent = "";
   const emitted = [];
   const emittedKeys = new Set();
@@ -2017,7 +2041,7 @@ async function handleSubtitleStreamInternal(
 
   appendSubtitles(parser.end(), false);
 
-  const finalSubtitles = parseSTRes(fullContent, events);
+  const finalSubtitles = parseSTRes(fullContent, events, fromLang);
   appendSubtitles(finalSubtitles, true);
 
   return finalSubtitles?.length

--- a/src/apis/trans.subtitle.test.js
+++ b/src/apis/trans.subtitle.test.js
@@ -15,11 +15,17 @@ jest.mock("../libs/docInfo", () => ({
   getDocInfo: () => ({}),
 }));
 
-import { handleSubtitle } from "./trans";
+import {
+  buildSubtitleSystemPrompt,
+  detectSubtitleProtocol,
+  formatIndexSubtitleEvents,
+  handleSubtitle,
+} from "./trans";
 import {
   DEFAULT_API_LIST,
   OPT_TRANS_DEEPSEEK,
   OPT_TRANS_OPENAI,
+  defaultSubtitlePrompt,
 } from "../config";
 import { fetchData } from "../libs/fetch";
 import { fetchStream } from "../libs/fetch";
@@ -45,8 +51,9 @@ describe("handleSubtitle", () => {
       choices: [
         {
           message: {
+            // 默认响应使用 boundary-v3 `{e,o,t}`，通用请求测试同时覆盖默认解析路径。
             content: JSON.stringify([
-              { s: 0, e: 1, o: "hello world", t: "你好世界" },
+              { e: 1, o: "hello world", t: "你好世界" },
             ]),
           },
         },
@@ -68,6 +75,175 @@ describe("handleSubtitle", () => {
 
     const init = fetchData.mock.calls[0][1];
     expect(JSON.parse(init.body).stream).toBe(false);
+  });
+
+  test("sends subtitle events as a pure JSON array without context wrappers", async () => {
+    await handleSubtitle({
+      events,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+      docInfo: { title: "测试标题", description: "测试简介" },
+    });
+
+    const body = JSON.parse(fetchData.mock.calls[0][1].body);
+    const userContent = body.messages.find(
+      (message) => message.role === "user"
+    ).content;
+    // 用户消息只保留事件 JSON；标题等动态上下文已经写入系统提示词。
+    expect(JSON.parse(userContent)).toEqual([
+      { id: 0, text: "hello" },
+      { id: 1, text: "world" },
+    ]);
+  });
+
+  test("sends sparse pauseMs on the event before a positive timeline gap", async () => {
+    const pauseEvents = [
+      { start: 0, end: 400, text: "Hello" },
+      { start: 400, end: 800, text: "world!" },
+      { start: 1650, end: 2200, text: "Good" },
+    ];
+
+    await handleSubtitle({
+      events: pauseEvents,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+    });
+
+    const body = JSON.parse(fetchData.mock.calls[0][1].body);
+    const userContent = body.messages.find(
+      (message) => message.role === "user"
+    ).content;
+    expect(JSON.parse(userContent)).toEqual([
+      { id: 0, text: "Hello" },
+      { id: 1, text: "world!", pauseMs: 850 },
+      { id: 2, text: "Good" },
+    ]);
+  });
+
+  test("omits pauseMs for zero, negative and final-event gaps", () => {
+    expect(
+      formatIndexSubtitleEvents([
+        { start: 0, end: 500, text: "one" },
+        { start: 500, end: 1000, text: "two" },
+        { start: 900, end: 1300, text: "three" },
+      ])
+    ).toEqual([
+      { id: 0, text: "one" },
+      { id: 1, text: "two" },
+      { id: 2, text: "three" },
+    ]);
+  });
+
+  test("keeps legacy p levels for old prompts and detects every protocol", () => {
+    const pauseEvents = [
+      { start: 0, end: 400, text: "Hello" },
+      { start: 1250, end: 1800, text: "world" },
+    ];
+    const legacyPrompt = 'Use the "p" pause level 1-3 as a hint.';
+
+    expect(formatIndexSubtitleEvents(pauseEvents, legacyPrompt)).toEqual([
+      { id: 0, text: "Hello" },
+      { id: 1, text: "world", p: 2 },
+    ]);
+    expect(detectSubtitleProtocol(legacyPrompt)).toBe("boundary-v2");
+    const indexPrompt = '{"s":0,"e":1,"t":"text"}';
+    expect(detectSubtitleProtocol(indexPrompt)).toBe("index-v1");
+    expect(formatIndexSubtitleEvents(pauseEvents, indexPrompt)).toEqual([
+      { id: 0, text: "Hello" },
+      { id: 1, text: "world", p: 2 },
+    ]);
+    expect(detectSubtitleProtocol("WEBVTT\n00:00.000 --> 00:01.000")).toBe(
+      "vtt-legacy"
+    );
+    expect(detectSubtitleProtocol(defaultSubtitlePrompt)).toBe("boundary-v3");
+  });
+
+  test("keeps raw timed events for VTT legacy prompts", async () => {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_OPENAI),
+      subtitlePrompt: "Return WEBVTT with MM:SS.mmm timestamps and --> cues.",
+    };
+
+    await handleSubtitle({
+      events,
+      from: "en",
+      to: "zh-CN",
+      apiSetting,
+    });
+
+    const body = JSON.parse(fetchData.mock.calls[0][1].body);
+    const userContent = body.messages.find(
+      (message) => message.role === "user"
+    ).content;
+    expect(JSON.parse(userContent)).toEqual(events);
+  });
+
+  test("parses default boundary-v3 anchors but rebuilds source text and timestamps", async () => {
+    fetchData.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify([
+              // 即使模型返回错误原文锚点，程序也必须按 e 游标重建最终原文。
+              { e: 0, o: "wrong source", t: "你好" },
+              { e: 1, o: "also wrong", t: "世界" },
+            ]),
+          },
+        },
+      ],
+    });
+
+    const result = await handleSubtitle({
+      events,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+    });
+
+    expect(result).toEqual([
+      {
+        start: 0,
+        end: 1000,
+        text: "hello",
+        translation: "你好",
+        _si: 0,
+        _ei: 0,
+      },
+      {
+        start: 1000,
+        end: 2000,
+        text: "world",
+        translation: "世界",
+        _si: 1,
+        _ei: 1,
+      },
+    ]);
+  });
+
+  test("keeps the complete boundary-v3 prefix from a truncated JSON array", async () => {
+    fetchData.mockResolvedValueOnce({
+      choices: [{ message: { content: '[{"e":0,"t":"你好"}' } }],
+    });
+
+    const result = await handleSubtitle({
+      events,
+      from: "en",
+      to: "zh-CN",
+      apiSetting: getApiSetting(OPT_TRANS_OPENAI),
+    });
+
+    expect(result).toEqual([
+      {
+        start: 0,
+        end: 1000,
+        text: "hello",
+        translation: "你好",
+        _si: 0,
+        _ei: 0,
+      },
+    ]);
   });
 
   test("parses OpenAI-compatible subtitle providers", async () => {
@@ -214,7 +390,59 @@ describe("handleSubtitle", () => {
         translation: "译文",
         _si: 4,
         _ei: 6,
+        _alignedSi: 1,
+        _alignedEi: 3,
       },
     ]);
+  });
+});
+
+describe("buildSubtitleSystemPrompt", () => {
+  test("documents missing pauseMs as a zero-millisecond pause", () => {
+    expect(defaultSubtitlePrompt).toContain(
+      'If "pauseMs" is missing, treat it as 0 milliseconds'
+    );
+    expect(defaultSubtitlePrompt).not.toContain('the "p" (pause level 1-3)');
+  });
+
+  test("defines hard source-length limits and exact translation alignment", () => {
+    // 默认提示词必须使用硬约束，避免模型把建议性的长度目标当作可忽略条件。
+    expect(defaultSubtitlePrompt).toContain(
+      "MUST contain no more than 15 words"
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      "MUST contain no more than 30 source characters"
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      'Build "o" first from the exact source span covered by the current "e"'
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      "Never merge two complete sentences into one subtitle segment"
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      '{"e":<last_word_id>, "o":"exact merged source text", "t":"translation"}'
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      'silently verify that every "e", "o", and "t" correspond one-to-one'
+    );
+    expect(defaultSubtitlePrompt).toContain(
+      'Then translate only the current "o" into "t"'
+    );
+  });
+
+  test("renders dynamic context before the cache signature is calculated", () => {
+    expect(
+      buildSubtitleSystemPrompt({
+        subtitlePrompt:
+          "{{title}}|{{description}}|{{summary}}|{{tone}}|{{glossary}}",
+        tone: "formal",
+        docInfo: {
+          title: "Video title",
+          description: "Video description",
+          summary: "Video summary",
+        },
+        aiTerms: "Flow: 工作流",
+      })
+    ).toContain("Video title|Video description|Video summary|formal|-");
   });
 });

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -752,6 +752,7 @@ export const defaultDictUserPrompt = `# Input Data
 > 触发【词典模式】或【纯翻译模式】的核心判定对象：
 ${INPUT_PLACE_TEXT}`;
 
+// AI 字幕默认使用 boundary-v3：模型返回句末事件 ID、原文锚点和译文，最终原文与时间轴仍由程序重建。
 export const defaultSubtitlePrompt = `# Context
 Title: ${INPUT_PLACE_TITLE}
 Description: ${INPUT_PLACE_DESCRIPTION}
@@ -766,19 +767,26 @@ Group the input word-level JSON array into readable, well-paced bilingual subtit
 
 # Output Contract
 1. STRICTLY output a valid JSON array only. No markdown formatting (e.g., do not use \`\`\`json fences), no preamble, and no postscript.
-2. Format per element: {"s":<first_word_id>, "e":<last_word_id>, "o":"merged original text", "t":"translation"}
-3. The "s" (start) and "e" (end) fields must represent inclusive, exact word IDs from the input.
-4. Completeness: Cover every single word from the input exactly once. No missing words, no overlaps, and no gaps.
+2. Format per element: {"e":<last_word_id>, "o":"exact merged source text", "t":"translation"}
+3. The "e" field must be an inclusive, exact word ID from the input and must increase strictly. The first segment starts at ID 0; every later segment starts at the previous "e" + 1.
+4. Completeness: Cover every input item exactly once. The final "e" must equal the final input ID. No missing items, overlaps, or gaps.
+5. For each segment, first determine its exact input range from the previous "e" + 1 through the current "e", then merge every source item in that range verbatim into "o". Do not paraphrase, normalize, translate, omit, or add source text in "o".
+6. Do not return start IDs, timestamps, or any extra fields. The application reconstructs them from the input.
 
 # Rules
-1. Length Constraint: Keep each subtitle segment concise for on-screen readability. The translation ("t") and original text ("o") should ideally not exceed 12 words per segment. Split longer sentences at logical break points.
-2. Segmentation: Merge words into complete sentences or logical phrases. Split at natural pauses, conjunctions, or punctuation marks to maintain a natural reading pace.
-3. Pause Indicators: Use the "p" (pause level 1-3) attribute in the input as a hint for segmentation. Higher "p" values indicate stronger sentence boundaries, but grammatical correctness and semantic coherence always take priority.
-4. Translation Quality: Translate accurately and naturally, strictly adhering to the provided Context, Tone, and Glossary.
+1. Hard Source Length Limit:
+   - For space-separated source languages, each source span MUST contain no more than 15 words; aim for 8-12 words when a natural boundary exists.
+   - For Chinese, Japanese, and other non-space-separated source languages, each source span MUST contain no more than 30 source characters.
+   - If a sentence exceeds the applicable limit, split it at a clause, comma, conjunction, or natural phrase boundary. The hard length limit takes priority over keeping a long grammatical sentence intact.
+2. Sentence Boundaries: Never merge two complete sentences into one subtitle segment. Terminal punctuation such as .?!。！？ normally ends the current segment.
+3. Pause Indicators: An optional "pauseMs" field is the timeline gap in milliseconds after the current input item. If "pauseMs" is missing, treat it as 0 milliseconds and do not infer a pause. Larger positive values indicate stronger sentence boundaries, but grammatical correctness and semantic coherence always take priority.
+4. Exact Translation Alignment: Build "o" first from the exact source span covered by the current "e", starting after the previous "e". Then translate only the current "o" into "t". The "t" field MUST NOT omit that span, translate future input items, or carry text from adjacent segments.
+5. Silent Self-Check: Before returning, silently verify that every "e", "o", and "t" correspond one-to-one, every "o" matches its exact input range, all source-length limits are satisfied, and all input items are covered exactly once. Do not output the self-check or any reasoning.
+6. Translation Quality: Keep "t" concise, accurate, and natural while strictly adhering to the provided Context, Tone, and Glossary.
 
 # Example
-Input: [{"id":0,"text":"Hello"},{"id":1,"text":"world!"},{"id":2,"text":"Good","p":2},{"id":3,"text":"morning."}]
-Output: [{"s":0,"e":1,"o":"Hello world!","t":"你好，世界！"},{"s":2,"e":3,"o":"Good morning.","t":"早上好。"}]`;
+Input: [{"id":0,"text":"Once"},{"id":1,"text":"the"},{"id":2,"text":"assets"},{"id":3,"text":"are"},{"id":4,"text":"ready,"},{"id":5,"text":"open"},{"id":6,"text":"the"},{"id":7,"text":"storyboard"},{"id":8,"text":"tab.","pauseMs":850},{"id":9,"text":"This"},{"id":10,"text":"is"},{"id":11,"text":"where"},{"id":12,"text":"everything"},{"id":13,"text":"comes"},{"id":14,"text":"together."},{"id":15,"text":"If"},{"id":16,"text":"a"},{"id":17,"text":"scene"},{"id":18,"text":"does"},{"id":19,"text":"not"},{"id":20,"text":"match"},{"id":21,"text":"your"},{"id":22,"text":"idea,"},{"id":23,"text":"regenerate"},{"id":24,"text":"it"},{"id":25,"text":"or"},{"id":26,"text":"adjust"},{"id":27,"text":"the"},{"id":28,"text":"prompt"},{"id":29,"text":"carefully"},{"id":30,"text":"until"},{"id":31,"text":"it"},{"id":32,"text":"feels"},{"id":33,"text":"right."}]
+Output: [{"e":8,"o":"Once the assets are ready, open the storyboard tab.","t":"素材准备好后，打开故事板标签页。"},{"e":14,"o":"This is where everything comes together.","t":"一切从这里开始整合。"},{"e":22,"o":"If a scene does not match your idea,","t":"如果某个场景与你的想法不符，"},{"e":33,"o":"regenerate it or adjust the prompt carefully until it feels right.","t":"请重新生成，或仔细调整提示词，直到效果合适。"}]`;
 
 const defaultRequestHook = `async (args, { url, body, headers, userMsg, method } = {}) => {
   console.log("request hook args:", { args, url, body, headers, userMsg, method });

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -253,7 +253,677 @@ async ({ res, ...args }) => {
   return { translations, modelMsg };
 }`;
 
+/** 为字幕断句工作台集中生成六种界面语言的文案映射。 */
+const subtitlePlaygroundText = (zh, en, zh_TW, ja, ko, tr) => ({
+  zh,
+  en,
+  zh_TW,
+  ja,
+  ko,
+  tr,
+});
+
+const SUBTITLE_PLAYGROUND_I18N = {
+  playground_text_translation: subtitlePlaygroundText(
+    "文本翻译",
+    "Text translation",
+    "文字翻譯",
+    "テキスト翻訳",
+    "텍스트 번역",
+    "Metin çevirisi"
+  ),
+  subtitle_segmentation: subtitlePlaygroundText(
+    "字幕断句",
+    "Subtitle segmentation",
+    "字幕斷句",
+    "字幕分割",
+    "자막 분할",
+    "Altyazı bölümleme"
+  ),
+  subtitle_playground_invalid_events: subtitlePlaygroundText(
+    "字幕文件没有有效的 events 数组",
+    "The subtitle file has no valid events array",
+    "字幕檔案沒有有效的 events 陣列",
+    "字幕ファイルに有効な events 配列がありません",
+    "자막 파일에 유효한 events 배열이 없습니다",
+    "Altyazı dosyasında geçerli bir events dizisi yok"
+  ),
+  subtitle_playground_event_limit: subtitlePlaygroundText(
+    "字幕事件数量不能超过 {max}",
+    "Subtitle events cannot exceed {max}",
+    "字幕事件數量不能超過 {max}",
+    "字幕イベント数は {max} を超えられません",
+    "자막 이벤트 수는 {max}개를 초과할 수 없습니다",
+    "Altyazı olayı sayısı {max} değerini aşamaz"
+  ),
+  subtitle_playground_missing_segments: subtitlePlaygroundText(
+    "字幕文件缺少 YouTube json3 的 segs 数据",
+    "The subtitle file is missing YouTube json3 segs data",
+    "字幕檔案缺少 YouTube json3 的 segs 資料",
+    "字幕ファイルに YouTube json3 の segs データがありません",
+    "자막 파일에 YouTube json3 segs 데이터가 없습니다",
+    "Altyazı dosyasında YouTube json3 segs verisi yok"
+  ),
+  subtitle_playground_remote_size_invalid: subtitlePlaygroundText(
+    "远程字幕样本大小校验失败",
+    "Remote subtitle sample size validation failed",
+    "遠端字幕樣本大小驗證失敗",
+    "リモート字幕サンプルのサイズ検証に失敗しました",
+    "원격 자막 샘플 크기 검증에 실패했습니다",
+    "Uzak altyazı örneği boyut doğrulaması başarısız"
+  ),
+  subtitle_playground_remote_hash_invalid: subtitlePlaygroundText(
+    "远程字幕样本哈希校验失败",
+    "Remote subtitle sample hash validation failed",
+    "遠端字幕樣本雜湊驗證失敗",
+    "リモート字幕サンプルのハッシュ検証に失敗しました",
+    "원격 자막 샘플 해시 검증에 실패했습니다",
+    "Uzak altyazı örneği karma doğrulaması başarısız"
+  ),
+  subtitle_playground_remote_index_failed: subtitlePlaygroundText(
+    "远程字幕样本索引加载失败，可以继续上传本地 JSON",
+    "Failed to load the remote sample index. You can still upload a local JSON file",
+    "遠端字幕樣本索引載入失敗，仍可上傳本機 JSON",
+    "リモート字幕サンプルの索引を読み込めませんでした。ローカル JSON は引き続きアップロードできます",
+    "원격 자막 샘플 색인을 불러오지 못했습니다. 로컬 JSON은 계속 업로드할 수 있습니다",
+    "Uzak örnek dizini yüklenemedi. Yerel bir JSON dosyası yükleyebilirsiniz"
+  ),
+  subtitle_playground_sample_load_failed: subtitlePlaygroundText(
+    "字幕样本加载失败：{message}",
+    "Failed to load subtitle sample: {message}",
+    "字幕樣本載入失敗：{message}",
+    "字幕サンプルの読み込みに失敗しました：{message}",
+    "자막 샘플을 불러오지 못했습니다: {message}",
+    "Altyazı örneği yüklenemedi: {message}"
+  ),
+  subtitle_playground_file_too_large: subtitlePlaygroundText(
+    "字幕文件不能超过 10MB",
+    "The subtitle file cannot exceed 10 MB",
+    "字幕檔案不能超過 10MB",
+    "字幕ファイルは 10 MB を超えられません",
+    "자막 파일은 10MB를 초과할 수 없습니다",
+    "Altyazı dosyası 10 MB'ı aşamaz"
+  ),
+  subtitle_playground_file_parse_failed: subtitlePlaygroundText(
+    "字幕文件解析失败：{message}",
+    "Failed to parse subtitle file: {message}",
+    "字幕檔案解析失敗：{message}",
+    "字幕ファイルの解析に失敗しました：{message}",
+    "자막 파일을 분석하지 못했습니다: {message}",
+    "Altyazı dosyası ayrıştırılamadı: {message}"
+  ),
+  subtitle_playground_ai_confirm_title: subtitlePlaygroundText(
+    "发送 AI 断句请求",
+    "Send AI segmentation requests",
+    "傳送 AI 斷句請求",
+    "AI 字幕分割リクエストを送信",
+    "AI 자막 분할 요청 보내기",
+    "AI bölümleme isteklerini gönder"
+  ),
+  subtitle_playground_ai_confirm_message: subtitlePlaygroundText(
+    "将使用 {api} / {model} 发送约 {count} 个字幕请求。样本文本会发送到当前 AI 服务。",
+    "About {count} subtitle requests will be sent using {api} / {model}. The sample text will be sent to the current AI service.",
+    "將使用 {api} / {model} 傳送約 {count} 個字幕請求。樣本文字會傳送到目前的 AI 服務。",
+    "{api} / {model} を使用して約 {count} 件の字幕リクエストを送信します。サンプルテキストは現在の AI サービスに送信されます。",
+    "{api} / {model}을 사용해 약 {count}개의 자막 요청을 보냅니다. 샘플 텍스트가 현재 AI 서비스로 전송됩니다.",
+    "{api} / {model} kullanılarak yaklaşık {count} altyazı isteği gönderilecek. Örnek metin mevcut AI hizmetine gönderilecektir."
+  ),
+  subtitle_playground_default_model: subtitlePlaygroundText(
+    "默认模型",
+    "Default model",
+    "預設模型",
+    "既定のモデル",
+    "기본 모델",
+    "Varsayılan model"
+  ),
+  subtitle_playground_continue: subtitlePlaygroundText(
+    "继续",
+    "Continue",
+    "繼續",
+    "続行",
+    "계속",
+    "Devam"
+  ),
+  subtitle_playground_test_failed: subtitlePlaygroundText(
+    "字幕断句失败：{message}",
+    "Subtitle segmentation failed: {message}",
+    "字幕斷句失敗：{message}",
+    "字幕分割に失敗しました：{message}",
+    "자막 분할에 실패했습니다: {message}",
+    "Altyazı bölümleme başarısız: {message}"
+  ),
+  subtitle_playground_prompt_global: subtitlePlaygroundText(
+    "全局字幕设置",
+    "Global subtitle settings",
+    "全域字幕設定",
+    "グローバル字幕設定",
+    "전역 자막 설정",
+    "Genel altyazı ayarları"
+  ),
+  subtitle_playground_prompt_preset: subtitlePlaygroundText(
+    "接口预设",
+    "API preset",
+    "介面預設",
+    "API プリセット",
+    "API 프리셋",
+    "API ön ayarı"
+  ),
+  subtitle_playground_prompt_custom: subtitlePlaygroundText(
+    "接口自定义",
+    "API custom",
+    "介面自訂",
+    "API カスタム",
+    "API 사용자 지정",
+    "Özel API"
+  ),
+  subtitle_playground_config_title: subtitlePlaygroundText(
+    "当前生效的断句配置",
+    "Active segmentation configuration",
+    "目前生效的斷句設定",
+    "現在有効な字幕分割設定",
+    "현재 적용 중인 자막 분할 설정",
+    "Etkin bölümleme yapılandırması"
+  ),
+  subtitle_playground_mode: subtitlePlaygroundText(
+    "模式",
+    "Mode",
+    "模式",
+    "モード",
+    "모드",
+    "Mod"
+  ),
+  subtitle_playground_api: subtitlePlaygroundText(
+    "API",
+    "API",
+    "API",
+    "API",
+    "API",
+    "API"
+  ),
+  subtitle_playground_type_model: subtitlePlaygroundText(
+    "类型 / 模型",
+    "Type / model",
+    "類型 / 模型",
+    "タイプ / モデル",
+    "유형 / 모델",
+    "Tür / model"
+  ),
+  subtitle_playground_prompt: subtitlePlaygroundText(
+    "提示词",
+    "Prompt",
+    "提示詞",
+    "プロンプト",
+    "프롬프트",
+    "İstem"
+  ),
+  subtitle_playground_api_default: subtitlePlaygroundText(
+    "接口默认",
+    "API default",
+    "介面預設",
+    "API の既定値",
+    "API 기본값",
+    "API varsayılanı"
+  ),
+  subtitle_playground_prompt_value: subtitlePlaygroundText(
+    "{prompt}（{source}）",
+    "{prompt} ({source})",
+    "{prompt}（{source}）",
+    "{prompt}（{source}）",
+    "{prompt} ({source})",
+    "{prompt} ({source})"
+  ),
+  subtitle_playground_chunk_length: subtitlePlaygroundText(
+    "Chunk 长度",
+    "Chunk length",
+    "Chunk 長度",
+    "チャンク長",
+    "청크 길이",
+    "Parça uzunluğu"
+  ),
+  subtitle_playground_estimated_chunks: subtitlePlaygroundText(
+    "预计 Chunk",
+    "Estimated chunks",
+    "預估 Chunk",
+    "推定チャンク数",
+    "예상 청크 수",
+    "Tahmini parça sayısı"
+  ),
+  subtitle_playground_target_language: subtitlePlaygroundText(
+    "目标语言",
+    "Target language",
+    "目標語言",
+    "翻訳先言語",
+    "대상 언어",
+    "Hedef dil"
+  ),
+  subtitle_playground_streaming: subtitlePlaygroundText(
+    "流式",
+    "Streaming",
+    "串流",
+    "ストリーミング",
+    "스트리밍",
+    "Akış"
+  ),
+  subtitle_playground_enabled: subtitlePlaygroundText(
+    "启用",
+    "Enabled",
+    "啟用",
+    "有効",
+    "사용",
+    "Etkin"
+  ),
+  subtitle_playground_disabled: subtitlePlaygroundText(
+    "关闭",
+    "Disabled",
+    "關閉",
+    "無効",
+    "사용 안 함",
+    "Devre dışı"
+  ),
+  subtitle_playground_protocol: subtitlePlaygroundText(
+    "协议",
+    "Protocol",
+    "協定",
+    "プロトコル",
+    "프로토콜",
+    "Protokol"
+  ),
+  subtitle_playground_legacy_compatible: subtitlePlaygroundText(
+    "兼容旧协议",
+    "Legacy protocol compatible",
+    "相容舊協定",
+    "旧プロトコル互換",
+    "이전 프로토콜 호환",
+    "Eski protokolle uyumlu"
+  ),
+  subtitle_playground_protocol_value: subtitlePlaygroundText(
+    "{protocol}（{compatibility}）",
+    "{protocol} ({compatibility})",
+    "{protocol}（{compatibility}）",
+    "{protocol}（{compatibility}）",
+    "{protocol} ({compatibility})",
+    "{protocol} ({compatibility})"
+  ),
+  subtitle_playground_statistical_mode: subtitlePlaygroundText(
+    "统计断句",
+    "Statistical segmentation",
+    "統計斷句",
+    "統計的字幕分割",
+    "통계 자막 분할",
+    "İstatistiksel bölümleme"
+  ),
+  subtitle_playground_rule_mode: subtitlePlaygroundText(
+    "规则断句",
+    "Rule-based segmentation",
+    "規則斷句",
+    "ルールベース字幕分割",
+    "규칙 기반 자막 분할",
+    "Kural tabanlı bölümleme"
+  ),
+  subtitle_playground_max_duration: subtitlePlaygroundText(
+    "最大时长",
+    "Maximum duration",
+    "最長時長",
+    "最大時間",
+    "최대 길이",
+    "Azami süre"
+  ),
+  subtitle_playground_max_words: subtitlePlaygroundText(
+    "最大词数",
+    "Maximum words",
+    "最多詞數",
+    "最大単語数",
+    "최대 단어 수",
+    "Azami kelime"
+  ),
+  subtitle_playground_min_boundary_score: subtitlePlaygroundText(
+    "最小边界评分",
+    "Minimum boundary score",
+    "最小邊界分數",
+    "最小境界スコア",
+    "최소 경계 점수",
+    "Asgari sınır puanı"
+  ),
+  subtitle_playground_min_sentence_words: subtitlePlaygroundText(
+    "最小句子词数",
+    "Minimum sentence words",
+    "最少句子詞數",
+    "文の最小単語数",
+    "문장 최소 단어 수",
+    "Asgari cümle kelimesi"
+  ),
+  subtitle_playground_source_language: subtitlePlaygroundText(
+    "源语言",
+    "Source language",
+    "來源語言",
+    "元言語",
+    "원본 언어",
+    "Kaynak dil"
+  ),
+  subtitle_playground_source_language_label: subtitlePlaygroundText(
+    "字幕源语言",
+    "Subtitle source language",
+    "字幕來源語言",
+    "字幕の元言語",
+    "자막 원본 언어",
+    "Altyazı kaynak dili"
+  ),
+  subtitle_playground_language_required: subtitlePlaygroundText(
+    "规则和统计断句不支持 AutoDetect，请选择具体的字幕源语言。",
+    "Rule-based and statistical segmentation do not support AutoDetect. Select a specific subtitle source language.",
+    "規則和統計斷句不支援 AutoDetect，請選擇具體的字幕來源語言。",
+    "ルールおよび統計的字幕分割では AutoDetect を使用できません。字幕の元言語を選択してください。",
+    "규칙 및 통계 자막 분할은 AutoDetect를 지원하지 않습니다. 자막 원본 언어를 선택하세요.",
+    "Kural tabanlı ve istatistiksel bölümleme AutoDetect'i desteklemez. Belirli bir altyazı kaynak dili seçin."
+  ),
+  subtitle_playground_long_sentence_threshold: subtitlePlaygroundText(
+    "长句阈值",
+    "Long-sentence threshold",
+    "長句門檻",
+    "長文しきい値",
+    "긴 문장 임계값",
+    "Uzun cümle eşiği"
+  ),
+  subtitle_playground_chunk_risk: subtitlePlaygroundText(
+    "当前 AI Chunk 长度高于推荐默认值 1000，长输入可能增加漏句或边界退化风险。",
+    "The current AI chunk length exceeds the recommended default of 1000. Long input may increase the risk of missing text or degraded boundaries.",
+    "目前 AI Chunk 長度高於建議預設值 1000，長輸入可能增加漏句或邊界退化風險。",
+    "現在の AI チャンク長は推奨既定値 1000 を超えています。長い入力では文の欠落や境界精度低下のリスクが高まります。",
+    "현재 AI 청크 길이가 권장 기본값 1000보다 큽니다. 긴 입력은 문장 누락이나 경계 품질 저하 위험을 높일 수 있습니다.",
+    "Geçerli AI parça uzunluğu önerilen varsayılan 1000 değerini aşıyor. Uzun girdiler eksik metin veya sınır kalitesi düşüşü riskini artırabilir."
+  ),
+  subtitle_playground_builtin_sample: subtitlePlaygroundText(
+    "内置字幕样本",
+    "Built-in subtitle sample",
+    "內建字幕樣本",
+    "内蔵字幕サンプル",
+    "내장 자막 샘플",
+    "Yerleşik altyazı örneği"
+  ),
+  subtitle_playground_select_sample: subtitlePlaygroundText(
+    "请选择远程样本",
+    "Select a remote sample",
+    "請選擇遠端樣本",
+    "リモートサンプルを選択",
+    "원격 샘플을 선택하세요",
+    "Uzak bir örnek seçin"
+  ),
+  subtitle_playground_upload_json: subtitlePlaygroundText(
+    "上传 JSON",
+    "Upload JSON",
+    "上傳 JSON",
+    "JSON をアップロード",
+    "JSON 업로드",
+    "JSON yükle"
+  ),
+  subtitle_playground_run: subtitlePlaygroundText(
+    "运行测试",
+    "Run test",
+    "執行測試",
+    "テストを実行",
+    "테스트 실행",
+    "Testi çalıştır"
+  ),
+  subtitle_playground_progress: subtitlePlaygroundText(
+    "正在处理 Chunk {completed}/{total}",
+    "Processing chunk {completed}/{total}",
+    "正在處理 Chunk {completed}/{total}",
+    "チャンク {completed}/{total} を処理中",
+    "청크 처리 중 {completed}/{total}",
+    "Parça işleniyor {completed}/{total}"
+  ),
+  subtitle_playground_source_json: subtitlePlaygroundText(
+    "原始字幕 JSON",
+    "Original subtitle JSON",
+    "原始字幕 JSON",
+    "元の字幕 JSON",
+    "원본 자막 JSON",
+    "Orijinal altyazı JSON"
+  ),
+  subtitle_playground_result: subtitlePlaygroundText(
+    "断句结果",
+    "Segmentation result",
+    "斷句結果",
+    "字幕分割結果",
+    "자막 분할 결과",
+    "Bölümleme sonucu"
+  ),
+  subtitle_playground_download: subtitlePlaygroundText(
+    "下载",
+    "Download",
+    "下載",
+    "ダウンロード",
+    "다운로드",
+    "İndir"
+  ),
+  subtitle_playground_stats_title: subtitlePlaygroundText(
+    "断句统计信息",
+    "Segmentation statistics",
+    "斷句統計資訊",
+    "字幕分割の統計",
+    "자막 분할 통계",
+    "Bölümleme istatistikleri"
+  ),
+  subtitle_playground_metric_processing: subtitlePlaygroundText(
+    "处理耗时",
+    "Processing time",
+    "處理耗時",
+    "処理時間",
+    "처리 시간",
+    "İşleme süresi"
+  ),
+  subtitle_playground_metric_raw_events: subtitlePlaygroundText(
+    "原始事件",
+    "Raw events",
+    "原始事件",
+    "元イベント",
+    "원본 이벤트",
+    "Ham olaylar"
+  ),
+  subtitle_playground_metric_canonical_events: subtitlePlaygroundText(
+    "规范化事件",
+    "Canonical events",
+    "正規化事件",
+    "正規化イベント",
+    "정규화 이벤트",
+    "Standart olaylar"
+  ),
+  subtitle_playground_metric_flat_events: subtitlePlaygroundText(
+    "Flat Events",
+    "Flat events",
+    "Flat Events",
+    "フラットイベント",
+    "플랫 이벤트",
+    "Düz olaylar"
+  ),
+  subtitle_playground_metric_filtered_non_speech: subtitlePlaygroundText(
+    "已过滤非语音片段",
+    "Filtered non-speech segments",
+    "已過濾非語音片段",
+    "除外した非音声区間",
+    "필터링된 비음성 구간",
+    "Filtrelenen konuşma dışı bölümler"
+  ),
+  subtitle_playground_metric_cues: subtitlePlaygroundText(
+    "字幕条目",
+    "Subtitle cues",
+    "字幕項目",
+    "字幕キュー",
+    "자막 큐",
+    "Altyazı öğeleri"
+  ),
+  subtitle_playground_metric_source_duration: subtitlePlaygroundText(
+    "源时间跨度",
+    "Source duration",
+    "來源時間跨度",
+    "元の時間範囲",
+    "원본 시간 범위",
+    "Kaynak süresi"
+  ),
+  subtitle_playground_metric_covered_duration: subtitlePlaygroundText(
+    "覆盖时长",
+    "Covered duration",
+    "涵蓋時長",
+    "カバー時間",
+    "포함 시간",
+    "Kapsanan süre"
+  ),
+  subtitle_playground_metric_text_coverage: subtitlePlaygroundText(
+    "文本覆盖率",
+    "Text coverage",
+    "文字涵蓋率",
+    "テキスト網羅率",
+    "텍스트 포함률",
+    "Metin kapsamı"
+  ),
+  subtitle_playground_metric_empty_cues: subtitlePlaygroundText(
+    "空字幕",
+    "Empty cues",
+    "空字幕",
+    "空の字幕",
+    "빈 자막",
+    "Boş altyazılar"
+  ),
+  subtitle_playground_metric_invalid_cues: subtitlePlaygroundText(
+    "无效字幕",
+    "Invalid cues",
+    "無效字幕",
+    "無効な字幕",
+    "유효하지 않은 자막",
+    "Geçersiz altyazılar"
+  ),
+  subtitle_playground_metric_overlaps: subtitlePlaygroundText(
+    "时间重叠",
+    "Time overlaps",
+    "時間重疊",
+    "時間の重複",
+    "시간 겹침",
+    "Zaman çakışmaları"
+  ),
+  subtitle_playground_metric_non_monotonic: subtitlePlaygroundText(
+    "时间倒退",
+    "Non-monotonic time",
+    "時間倒退",
+    "時間の逆行",
+    "시간 역행",
+    "Geri giden zaman"
+  ),
+  subtitle_playground_metric_missing_text: subtitlePlaygroundText(
+    "文本遗漏",
+    "Missing text",
+    "文字遺漏",
+    "欠落テキスト",
+    "누락 텍스트",
+    "Eksik metin"
+  ),
+  subtitle_playground_metric_duplicated_text: subtitlePlaygroundText(
+    "文本重复",
+    "Duplicated text",
+    "文字重複",
+    "重複テキスト",
+    "중복 텍스트",
+    "Yinelenen metin"
+  ),
+  subtitle_playground_metric_avg_chars: subtitlePlaygroundText(
+    "平均字符",
+    "Average characters",
+    "平均字元",
+    "平均文字数",
+    "평균 문자 수",
+    "Ortalama karakter"
+  ),
+  subtitle_playground_metric_p95_chars: subtitlePlaygroundText(
+    "P95 字符",
+    "P95 characters",
+    "P95 字元",
+    "P95 文字数",
+    "P95 문자 수",
+    "P95 karakter"
+  ),
+  subtitle_playground_metric_max_chars: subtitlePlaygroundText(
+    "最大字符",
+    "Maximum characters",
+    "最多字元",
+    "最大文字数",
+    "최대 문자 수",
+    "Azami karakter"
+  ),
+  subtitle_playground_metric_avg_words: subtitlePlaygroundText(
+    "平均词数",
+    "Average words",
+    "平均詞數",
+    "平均単語数",
+    "평균 단어 수",
+    "Ortalama kelime"
+  ),
+  subtitle_playground_metric_p95_words: subtitlePlaygroundText(
+    "P95 词数",
+    "P95 words",
+    "P95 詞數",
+    "P95 単語数",
+    "P95 단어 수",
+    "P95 kelime"
+  ),
+  subtitle_playground_metric_max_words: subtitlePlaygroundText(
+    "最大词数",
+    "Maximum words",
+    "最多詞數",
+    "最大単語数",
+    "최대 단어 수",
+    "Azami kelime"
+  ),
+  subtitle_playground_metric_avg_duration: subtitlePlaygroundText(
+    "平均时长",
+    "Average duration",
+    "平均時長",
+    "平均時間",
+    "평균 길이",
+    "Ortalama süre"
+  ),
+  subtitle_playground_metric_p95_duration: subtitlePlaygroundText(
+    "P95 时长",
+    "P95 duration",
+    "P95 時長",
+    "P95 時間",
+    "P95 길이",
+    "P95 süre"
+  ),
+  subtitle_playground_metric_max_duration: subtitlePlaygroundText(
+    "最大时长",
+    "Maximum duration",
+    "最長時長",
+    "最大時間",
+    "최대 길이",
+    "Azami süre"
+  ),
+  subtitle_playground_structure_error: subtitlePlaygroundText(
+    "结构错误：{errors}",
+    "Structure errors: {errors}",
+    "結構錯誤：{errors}",
+    "構造エラー：{errors}",
+    "구조 오류: {errors}",
+    "Yapı hataları: {errors}"
+  ),
+  subtitle_playground_readability_warning: subtitlePlaygroundText(
+    "可读性警告：超长文本 {longText}，超过 10 秒 {longDuration}，短碎片 {fragments}，泄漏的非语音字幕 {nonSpeech}",
+    "Readability warnings: long text {longText}, over 10 seconds {longDuration}, short fragments {fragments}, leaked non-speech cues {nonSpeech}",
+    "可讀性警告：過長文字 {longText}，超過 10 秒 {longDuration}，短片段 {fragments}，洩漏的非語音字幕 {nonSpeech}",
+    "可読性の警告：長すぎるテキスト {longText}、10 秒超 {longDuration}、短い断片 {fragments}、混入した非音声字幕 {nonSpeech}",
+    "가독성 경고: 너무 긴 텍스트 {longText}, 10초 초과 {longDuration}, 짧은 조각 {fragments}, 유출된 비음성 자막 {nonSpeech}",
+    "Okunabilirlik uyarıları: uzun metin {longText}, 10 saniyeyi aşan {longDuration}, kısa parçalar {fragments}, sızan konuşma dışı altyazılar {nonSpeech}"
+  ),
+  subtitle_playground_ai_stats: subtitlePlaygroundText(
+    "AI：协议 {protocol}，Chunk {chunks}，请求 {requests}，重试 {retries}，降级字幕 {fallbacks}，无效响应 {invalid}",
+    "AI: protocol {protocol}, chunks {chunks}, requests {requests}, retries {retries}, fallback cues {fallbacks}, invalid responses {invalid}",
+    "AI：協定 {protocol}，Chunk {chunks}，請求 {requests}，重試 {retries}，降級字幕 {fallbacks}，無效回應 {invalid}",
+    "AI：プロトコル {protocol}、チャンク {chunks}、リクエスト {requests}、再試行 {retries}、フォールバック字幕 {fallbacks}、無効な応答 {invalid}",
+    "AI: 프로토콜 {protocol}, 청크 {chunks}, 요청 {requests}, 재시도 {retries}, 대체 자막 {fallbacks}, 유효하지 않은 응답 {invalid}",
+    "AI: protokol {protocol}, parça {chunks}, istek {requests}, yeniden deneme {retries}, yedek altyazı {fallbacks}, geçersiz yanıt {invalid}"
+  ),
+};
+
 export const I18N = {
+  ...SUBTITLE_PLAYGROUND_I18N,
   app_name: {
     zh: `简约翻译`,
     en: `KISS Translator`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -162,7 +162,7 @@ export const DEFAULT_SUBTITLE_SETTING = {
   apiSlug: OPT_TRANS_MICROSOFT, // 默认的字幕翻译接口 (使用微软翻译)
   segSlug: "-", // 智能 AI 断句/字幕合并的算法选择 ("-" 表示禁用 AI 段落合并)
   forceSubtitleRetranslate: false, // AI 断句服务与翻译服务不同时，是否强制使用翻译服务重翻译文
-  chunkLength: 2000, // 触发 AI 翻译的单包最大字幕字符数
+  chunkLength: 1000, // 新配置默认使用更短 AI 分块；已保存的用户值仍由存储配置优先覆盖
   longSentenceThreshold: 100, // 启用基于标点规则拆分的长句判定字符长度限制
   useAlgorithmBreaker: "rule", // 字幕断句断行处理器类型 ("rule" 规则断行，"statistical" 基于时间统计特征断行)
   preTrans: 90, // 字幕翻译提前发送的时长 (毫秒)，防止接口网络延迟导致字幕不同步

--- a/src/libs/rules.js
+++ b/src/libs/rules.js
@@ -426,8 +426,7 @@ export const saveRule = async (curRule) => {
           : curRule[key] === false || curRule[key] === "false"
             ? "false"
             : DEFAULT_RULE[key];
-      newRule[key] =
-        value === globalRule[key] ? DEFAULT_RULE[key] : value;
+      newRule[key] = value === globalRule[key] ? DEFAULT_RULE[key] : value;
       return;
     }
     newRule[key] =

--- a/src/libs/rules.test.js
+++ b/src/libs/rules.test.js
@@ -110,30 +110,27 @@ describe("rules enabled state", () => {
     ["inherits the global setting", "true", "*", "true"],
     ["overrides the global setting on", "false", "true", "true"],
     ["overrides the global setting off", "true", "false", "false"],
-  ])(
-    "%s",
-    async (_, globalValue, siteValue, expectedValue) => {
-      getRulesWithDefault.mockResolvedValue([
-        {
-          pattern: "example.com",
-          selector: "article",
-          isPlainText: siteValue,
-        },
-        {
-          pattern: "*",
-          selector: "p",
-          isPlainText: globalValue,
-        },
-      ]);
+  ])("%s", async (_, globalValue, siteValue, expectedValue) => {
+    getRulesWithDefault.mockResolvedValue([
+      {
+        pattern: "example.com",
+        selector: "article",
+        isPlainText: siteValue,
+      },
+      {
+        pattern: "*",
+        selector: "p",
+        isPlainText: globalValue,
+      },
+    ]);
 
-      const rule = await matchRule("https://example.com/post", {
-        injectRules: false,
-        subrulesList: [],
-      });
+    const rule = await matchRule("https://example.com/post", {
+      injectRules: false,
+      subrulesList: [],
+    });
 
-      expect(rule.isPlainText).toBe(expectedValue);
-    }
-  );
+    expect(rule.isPlainText).toBe(expectedValue);
+  });
 
   test.each([
     ["enabled", "false", true, "true"],

--- a/src/libs/storage.test.js
+++ b/src/libs/storage.test.js
@@ -2,8 +2,14 @@ import {
   STOKEY_SETTING,
   STOKEY_SETTING_BACKUP_V1_BEFORE_V2,
   SETTINGS_VERSION_V2,
+  DEFAULT_SUBTITLE_SETTING,
 } from "../config";
 import { getSettingWithDefault, runDataMigration } from "./storage";
+
+// 存储测试不涉及流式解析，隔离 ESM-only 依赖以免 Jest 27 在加载阶段失败。
+jest.mock("@streamparser/json", () => ({ JSONParser: jest.fn() }));
+// jsdom 并非扩展页面，使用空实现避免 webextension-polyfill 在模块初始化时主动抛错。
+jest.mock("webextension-polyfill", () => ({}));
 
 const readStoredJson = (key) => JSON.parse(window.localStorage.getItem(key));
 
@@ -85,11 +91,27 @@ describe("settings storage migration", () => {
     expect(setting.transApis[0]).not.toHaveProperty("systemPrompt");
   });
 
+  test("keeps an explicitly stored subtitle chunk length", async () => {
+    // 新默认值只影响新配置；已有用户明确保存的 2000 不应被默认设置覆盖。
+    expect(DEFAULT_SUBTITLE_SETTING.chunkLength).toBe(1000);
+    window.localStorage.setItem(
+      STOKEY_SETTING,
+      JSON.stringify({
+        version: SETTINGS_VERSION_V2,
+        subtitleSetting: { chunkLength: 2000 },
+      })
+    );
+
+    const setting = await getSettingWithDefault();
+
+    expect(setting.subtitleSetting.chunkLength).toBe(2000);
+  });
+
   test("GM storage reports a clear error when GM APIs are unavailable", async () => {
     const { storage } = loadGmStorageModule();
 
     await expect(storage.get("missing-gm")).rejects.toThrow(
-      "GM storage API is not available"
+      "GM API is not available"
     );
   });
 

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -26,6 +26,10 @@ import {
   parseXmlTranslationSegments,
 } from "./aiResponseParser";
 import { createSubtitleIndexAligner } from "./subtitleIndexAlign";
+import {
+  isLegacyIndexSubtitleItem,
+  mapBoundaryItemToCue,
+} from "../subtitle/subtitleBoundaryProtocol";
 
 /**
  * 创建 Server-Sent Events (SSE) 协议数据流解析器
@@ -279,24 +283,37 @@ const mapSubtitleItemToCue = (item, events = [], aligner) => {
     // _si/_ei 必须保留模型原始索引：去重键与尾句重试语义都依赖它们。
     _si: s,
     _ei: e,
+    // 仅在发生纠偏时保留实际覆盖索引，普通旧协议结果维持原结构。
+    ...(fixed && {
+      _alignedSi: fixed.startIdx,
+      _alignedEi: fixed.endIdx,
+    }),
   };
 };
 
 /**
  * 创建字幕断句专用的流式 JSON 解析器。
  *
- * 字幕断句必须等到一个完整 `{s,e,o,t}` 对象闭合后才能稳定映射时间轴，
+ * 字幕断句必须等到一个完整 JSON 对象闭合后才能稳定映射时间轴，
  * 因此这里按对象边界增量抽取，而不是像网页段落翻译那样解析任意文本片段。
  *
  * @param {Array<Object>} events 当前字幕请求对应的原始事件列表。
+ * @param {Object} options 解析选项。
+ * @param {string} options.fromLang 源语言，用于重建 boundary-v2/v3 原文。
  * @returns {{write: Function, end: Function}} 流式写入器，每次写入返回新完成的字幕句子数组。
  */
-export function createStreamingSubtitleParser(events = []) {
+export function createStreamingSubtitleParser(
+  events = [],
+  { fromLang = "auto" } = {}
+) {
   let buffer = "";
   let jsonStarted = false;
   let scanIndex = 0;
   const emittedKeys = new Set();
   const aligner = createSubtitleIndexAligner(events);
+  let protocol = null;
+  let nextBoundaryIndex = 0;
+  let protocolInvalid = false;
 
   /**
    * 从当前 buffer 中查找 JSON 正文的起点。
@@ -390,9 +407,33 @@ export function createStreamingSubtitleParser(events = []) {
 
     for (const objectString of objectStrings) {
       try {
+        if (protocolInvalid) break;
         const item = JSON.parse(objectString);
-        const subtitle = mapSubtitleItemToCue(item, events, aligner);
-        if (!subtitle) continue;
+        const itemProtocol = isLegacyIndexSubtitleItem(item)
+          ? "index-v1"
+          : "boundary";
+        if (!protocol) protocol = itemProtocol;
+        // 流中切换协议会使开始游标失去定义，停止接受剩余对象。
+        if (protocol !== itemProtocol) {
+          protocolInvalid = true;
+          break;
+        }
+
+        const subtitle =
+          protocol === "boundary"
+            ? mapBoundaryItemToCue(item, events, nextBoundaryIndex, fromLang)
+            : mapSubtitleItemToCue(item, events, aligner);
+        if (!subtitle) {
+          if (protocol === "boundary") {
+            protocolInvalid = true;
+            break;
+          }
+          continue;
+        }
+
+        if (protocol === "boundary") {
+          nextBoundaryIndex = subtitle._ei + 1;
+        }
 
         const key = `${subtitle._si}:${subtitle._ei}`;
         // 流式过程中模型可能重复输出同一对象，按时间轴索引去重避免重复插入字幕轨。

--- a/src/libs/stream.test.js
+++ b/src/libs/stream.test.js
@@ -94,6 +94,59 @@ describe("createStreamingSubtitleParser", () => {
     ]);
   });
 
+  test("keeps boundary-v3 without anchors compatible with one shared boundary cursor", () => {
+    const parser = createStreamingSubtitleParser(events, { fromLang: "en" });
+
+    expect(
+      parser.write('[{"e":0,"t":"你好"},{"e":2,"t":"世界又来了"}]')
+    ).toEqual([
+      {
+        start: 0,
+        end: 1000,
+        text: "hello",
+        translation: "你好",
+        _si: 0,
+        _ei: 0,
+      },
+      {
+        start: 1000,
+        end: 3000,
+        text: "world again",
+        translation: "世界又来了",
+        _si: 1,
+        _ei: 2,
+      },
+    ]);
+  });
+
+  test("streams default boundary-v3 anchors with one shared boundary cursor", () => {
+    const parser = createStreamingSubtitleParser(events, { fromLang: "en" });
+
+    expect(
+      // `o` 仅供模型自检；流式结果的原文仍按 e 游标从输入事件重建。
+      parser.write(
+        '[{"e":0,"o":"wrong source","t":"你好"},{"e":2,"o":"also wrong","t":"世界又来了"}]'
+      )
+    ).toEqual([
+      {
+        start: 0,
+        end: 1000,
+        text: "hello",
+        translation: "你好",
+        _si: 0,
+        _ei: 0,
+      },
+      {
+        start: 1000,
+        end: 3000,
+        text: "world again",
+        translation: "世界又来了",
+        _si: 1,
+        _ei: 2,
+      },
+    ]);
+  });
+
   test("keeps incomplete subtitle object until it is closed", () => {
     const parser = createStreamingSubtitleParser(events);
 
@@ -167,6 +220,8 @@ describe("createStreamingSubtitleParser", () => {
             translation: "译文",
             _si: 4,
             _ei: 6,
+            _alignedSi: 1,
+            _alignedEi: 3,
           },
         ]
       );

--- a/src/libs/subtitleIndexAlign.js
+++ b/src/libs/subtitleIndexAlign.js
@@ -62,7 +62,11 @@ export const createSubtitleIndexAligner = (events = []) => {
 
     // 快路径：声称范围的词序列与 o 完全一致，无需纠正。
     const claimed = [];
-    for (let p = eventStartPos[cs]; p < table.length && table[p].ei <= ce; p++) {
+    for (
+      let p = eventStartPos[cs];
+      p < table.length && table[p].ei <= ce;
+      p++
+    ) {
       claimed.push(table[p].w);
     }
     if (claimed.length === L && claimed.every((w, i) => w === oTokens[i])) {
@@ -136,7 +140,7 @@ export const createSubtitleIndexAligner = (events = []) => {
       // 同组同距视为歧义，宁可不纠正。
       if (
         second &&
-        (top.offset > 0) === (second.offset > 0) &&
+        top.offset > 0 === second.offset > 0 &&
         top.dist === second.dist
       ) {
         return null;

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -417,7 +417,8 @@ export class Translator {
   #restoreViewportAnchor(anchor) {
     if (!anchor?.element?.isConnected) return;
 
-    const scrollingElement = document.scrollingElement || document.documentElement;
+    const scrollingElement =
+      document.scrollingElement || document.documentElement;
     if (!scrollingElement) return;
 
     const overflowY = window.getComputedStyle(scrollingElement).overflowY;
@@ -950,7 +951,7 @@ export class Translator {
 
     try {
       const textSheet = new CSSStyleSheet();
-      textSheet.replaceSync(textStyles)
+      textSheet.replaceSync(textStyles);
       this.#textSheet = textSheet;
     } catch (err) {
       kissLog("createTextStyles: CSSStyleSheet not available", err);
@@ -1331,7 +1332,9 @@ export class Translator {
   // 监控shadowroot
   #startObserveShadowRoot(shadowRoot) {
     try {
-      if (shadowRoot.host.matches(`#${APP_CONSTS.fabID}, #${APP_CONSTS.boxID}`)) {
+      if (
+        shadowRoot.host.matches(`#${APP_CONSTS.fabID}, #${APP_CONSTS.boxID}`)
+      ) {
         return;
       }
       this.#startObserveRoot(shadowRoot);

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -453,7 +453,9 @@ describe("Translator rule styles", () => {
     createTranslator({ transOpen: "false", isPlainText: "true" });
     await flushAsync();
 
-    expect(document.querySelector("pre > span")?.textContent).toBe("First line");
+    expect(document.querySelector("pre > span")?.textContent).toBe(
+      "First line"
+    );
   });
 
   test("splits plain text pre content into bounded block chunks", async () => {

--- a/src/libs/trustedTypes.test.js
+++ b/src/libs/trustedTypes.test.js
@@ -111,7 +111,7 @@ describe("trustedTypesHelper", () => {
   test("sanitizes HTML and does not retry when CSP blocks policy creation", () => {
     const createPolicy = jest.fn(() => {
       throw new Error(
-        'Creating a TrustedTypePolicy named \'kiss-translator-policy\' violates the following Content Security policy directive: "trusted-types gIqNx7 default". The action has been blocked.'
+        "Creating a TrustedTypePolicy named 'kiss-translator-policy' violates the following Content Security policy directive: \"trusted-types gIqNx7 default\". The action has been blocked."
       );
     });
     globalThis.trustedTypes = {
@@ -135,7 +135,7 @@ describe("trustedTypesHelper", () => {
   test("treats allow-duplicates CSP rejection as unavailable policy", () => {
     const createPolicy = jest.fn(() => {
       throw new Error(
-        'Creating a TrustedTypePolicy named \'kiss-translator-policy\' violates the following Content Security policy directive: "trusted-types fast-html dompurify 1DSScriptURL MeControlScriptURL @azure/ms-rest-js#xml.browser lit-html npsTrustedTypePolicy default \'allow-duplicates\'". The action has been blocked.'
+        "Creating a TrustedTypePolicy named 'kiss-translator-policy' violates the following Content Security policy directive: \"trusted-types fast-html dompurify 1DSScriptURL MeControlScriptURL @azure/ms-rest-js#xml.browser lit-html npsTrustedTypePolicy default 'allow-duplicates'\". The action has been blocked."
       );
     });
     globalThis.trustedTypes = {

--- a/src/scripts/build-task.mjs
+++ b/src/scripts/build-task.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env zx
 import { argv, quote, $ } from "zx";
+import { copySubtitleSamplesToWeb } from "./subtitle-samples.mjs";
 
 // 在 Windows 上使用 cmd.exe，避免 zx 默认使用 WSL bash 导致 node not found
 if (process.platform === "win32") {
   $.shell = "cmd.exe";
   $.prefix = "";
-  $.quote = quote
+  $.quote = quote;
 }
 
 // 用法: zx src/scripts/build-task.mjs --target=chrome
@@ -118,6 +119,9 @@ try {
         await fs.copy(inDest(f), path.join(userscriptDir, f));
       }
     }
+
+    // 字幕测试样本只随 GitHub Pages Web 产物发布，不进入任何插件压缩包。
+    await copySubtitleSamplesToWeb(targetDir);
   }
 
   console.log(

--- a/src/scripts/subtitle-samples.mjs
+++ b/src/scripts/subtitle-samples.mjs
@@ -1,0 +1,58 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * 读取并校验字幕样本索引，确保发布和 CLI 使用的是同一份可靠数据。
+ */
+export async function validateSubtitleSampleCatalog(
+  projectRoot = process.cwd()
+) {
+  const sampleRoot = path.resolve(projectRoot, "testdata/subtitle-samples");
+  const indexPath = path.join(sampleRoot, "index.json");
+  const catalog = JSON.parse(await fs.readFile(indexPath, "utf8"));
+
+  if (catalog?.version !== 1 || !Array.isArray(catalog.samples)) {
+    throw new Error("字幕样本索引格式无效");
+  }
+
+  for (const sample of catalog.samples) {
+    // 视频链接允许留空，但字段必须存在，保证 Web 与 CLI 读取同一套索引结构。
+    if (typeof sample.videoUrl !== "string") {
+      throw new Error(`字幕样本缺少视频链接字段: ${sample.id}`);
+    }
+
+    // 禁止索引路径逃逸到样本目录以外，避免构建时误复制其他项目文件。
+    const samplePath = path.resolve(sampleRoot, sample.path || "");
+    if (!samplePath.startsWith(`${sampleRoot}${path.sep}`)) {
+      throw new Error(`字幕样本路径越界: ${sample.path}`);
+    }
+
+    const data = await fs.readFile(samplePath);
+    const digest = crypto.createHash("sha256").update(data).digest("hex");
+    if (data.length !== sample.size || digest !== sample.sha256) {
+      throw new Error(`字幕样本校验失败: ${sample.id}`);
+    }
+
+    // 在构建阶段提前验证 JSON，避免把损坏的样本发布到 Web 页面。
+    const parsed = JSON.parse(data.toString("utf8"));
+    const events = Array.isArray(parsed) ? parsed : parsed?.events;
+    if (!Array.isArray(events)) {
+      throw new Error(`字幕样本不是有效的事件数组: ${sample.id}`);
+    }
+  }
+
+  return { catalog, sampleRoot };
+}
+
+/**
+ * 只把样本复制到 Web 构建，浏览器扩展和用户脚本发布包不会包含这些文件。
+ */
+export async function copySubtitleSamplesToWeb(
+  webBuildDir,
+  projectRoot = process.cwd()
+) {
+  const { sampleRoot } = await validateSubtitleSampleCatalog(projectRoot);
+  const destination = path.resolve(webBuildDir, "subtitle-samples");
+  await fs.cp(sampleRoot, destination, { recursive: true });
+}

--- a/src/scripts/test-subtitle-segmentation.js
+++ b/src/scripts/test-subtitle-segmentation.js
@@ -1,0 +1,168 @@
+// Babel CLI 不会像 React 构建器自动加载 .env，先补齐配置模块依赖的应用变量。
+import "dotenv/config";
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import {
+  prepareTimedTextEvents,
+  runBuiltinSegmentation,
+} from "../subtitle/youtubeSubtitleProcessing.js";
+import {
+  buildSegmentationMetrics,
+  getSegmentationMetricErrors,
+} from "../subtitle/subtitleSegmentationMetrics.js";
+import { buildBilingualVtt } from "../subtitle/vtt.js";
+
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+const SAMPLE_ROOT = path.join(PROJECT_ROOT, "testdata/subtitle-samples");
+const OUTPUT_ROOT = path.join(PROJECT_ROOT, "tmp/subtitle-segmentation");
+
+/** 解析 `--name=value` 和 `--name value` 两种命令行参数。 */
+function parseArguments(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const [rawName, inlineValue] = token.slice(2).split("=", 2);
+    result[rawName] =
+      inlineValue === undefined && argv[index + 1]?.startsWith("--") === false
+        ? argv[++index]
+        : (inlineValue ?? true);
+  }
+  return result;
+}
+
+/** 使用文件内容和索引元数据验证本地样本未被意外修改。 */
+function validateSampleFile(sample, data) {
+  const digest = crypto.createHash("sha256").update(data).digest("hex");
+  if (data.length !== sample.size || digest !== sample.sha256) {
+    throw new Error(`字幕样本校验失败: ${sample.id}`);
+  }
+}
+
+/** 将 JSON 以统一格式写入测试产物目录，便于代码审查和人工比较。 */
+const writeJson = (filePath, value) =>
+  fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+
+/** 对有序字幕边界生成稳定签名，用于发现规则升级造成的黄金边界变化。 */
+function getBoundarySignature(cues) {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify(
+        (cues || []).map(({ start, end, text }) => [start, end, text])
+      )
+    )
+    .digest("hex")
+    .slice(0, 16);
+}
+
+async function run() {
+  const args = parseArguments(process.argv.slice(2));
+  const catalog = JSON.parse(
+    await fs.readFile(path.join(SAMPLE_ROOT, "index.json"), "utf8")
+  );
+  const selectedSamples = catalog.samples.filter(
+    (sample) =>
+      !args.sample || args.sample === "all" || sample.id === args.sample
+  );
+  if (!selectedSamples.length) {
+    throw new Error(`没有找到字幕样本: ${args.sample}`);
+  }
+
+  const modes =
+    !args.mode || args.mode === "all" ? ["rule", "statistical"] : [args.mode];
+  if (modes.some((mode) => !["rule", "statistical"].includes(mode))) {
+    throw new Error(`不支持的断句模式: ${args.mode}`);
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputDir = path.join(OUTPUT_ROOT, timestamp);
+  await fs.mkdir(outputDir, { recursive: true });
+  const summary = [];
+  let hasStructuralErrors = false;
+
+  for (const sample of selectedSamples) {
+    const sourceBuffer = await fs.readFile(path.join(SAMPLE_ROOT, sample.path));
+    validateSampleFile(sample, sourceBuffer);
+    const sourceValue = JSON.parse(sourceBuffer.toString("utf8"));
+    const rawEvents = Array.isArray(sourceValue)
+      ? sourceValue
+      : sourceValue.events;
+    const fromLang = args.lang || sourceValue.lang || sample.language || "auto";
+    const sampleDir = path.join(outputDir, sample.id);
+    await fs.mkdir(sampleDir, { recursive: true });
+
+    const { events, flatEvents, filteredNonSpeechCount } =
+      prepareTimedTextEvents(rawEvents);
+    await writeJson(path.join(sampleDir, "raw.json"), sourceValue);
+    await writeJson(path.join(sampleDir, "flat-events.json"), flatEvents);
+
+    const sampleMetrics = {};
+    for (const mode of modes) {
+      const startedAt = performance.now();
+      const cues = runBuiltinSegmentation({
+        events,
+        flatEvents,
+        fromLang,
+        mode,
+        longSentenceThreshold: Number(args["long-sentence-threshold"]) || 100,
+      });
+      const metrics = buildSegmentationMetrics({
+        rawEvents,
+        canonicalEvents: events,
+        flatEvents,
+        cues,
+        fromLang,
+        processingMs: performance.now() - startedAt,
+        filteredNonSpeechCount,
+      });
+      const errors = getSegmentationMetricErrors(metrics);
+      const boundarySignature = getBoundarySignature(cues);
+      const expectedSignature = sample.goldenBoundaries?.[mode];
+      if (expectedSignature && expectedSignature !== boundarySignature) {
+        errors.push("golden-boundary-changed");
+      }
+      sampleMetrics[mode] = { ...metrics, boundarySignature, errors };
+      hasStructuralErrors ||= errors.length > 0;
+
+      await writeJson(path.join(sampleDir, `${mode}.json`), cues);
+      await fs.writeFile(
+        path.join(sampleDir, `${mode}.vtt`),
+        `${buildBilingualVtt(cues)}\n`,
+        "utf8"
+      );
+    }
+
+    await writeJson(path.join(sampleDir, "metrics.json"), sampleMetrics);
+    summary.push({
+      id: sample.id,
+      language: fromLang,
+      rawEventCount: rawEvents.length,
+      flatEventCount: flatEvents.length,
+      filteredNonSpeechCount,
+      modes: sampleMetrics,
+    });
+  }
+
+  await writeJson(path.join(outputDir, "summary.json"), summary);
+  console.table(
+    summary.flatMap((sample) =>
+      Object.entries(sample.modes).map(([mode, metrics]) => ({
+        sample: sample.id,
+        mode,
+        cues: metrics.cueCount,
+        filtered: metrics.filteredNonSpeechCount,
+        coverage: `${metrics.textCoveragePercent}%`,
+        errors: metrics.errors.join(",") || "-",
+      }))
+    )
+  );
+  console.log(`字幕断句测试结果: ${outputDir}`);
+  if (hasStructuralErrors) process.exitCode = 1;
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/subtitle/Menus.test.js
+++ b/src/subtitle/Menus.test.js
@@ -52,8 +52,9 @@ describe("subtitle Menus", () => {
         element.children.length === 0
     );
 
-    expect(view.container.textContent.startsWith("enable_subtitle_translate"))
-      .toBe(true);
+    expect(
+      view.container.textContent.startsWith("enable_subtitle_translate")
+    ).toBe(true);
 
     act(() => {
       label.parentElement.click();

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -20,9 +20,8 @@ import { eventsToSubtitles } from "./youtubeAiSegmentation.js";
 import {
   builtinSegment,
   formatSubtitles,
-  genFlatEvents,
   getFromLang,
-  normalizeTimedTextEvents,
+  prepareTimedTextEvents,
 } from "./youtubeSubtitleProcessing.js";
 import {
   CONTROLS_SELECTOR,
@@ -578,8 +577,8 @@ export class YouTubeCaptionProvider {
         return;
       }
 
-      const subtitleEvents = normalizeTimedTextEvents(events);
-      const flatEvents = genFlatEvents(subtitleEvents);
+      const { events: subtitleEvents, flatEvents } =
+        prepareTimedTextEvents(events);
       if (!flatEvents?.length) {
         logger.debug("Youtube Provider: flatEvents not got:", videoId);
         return;

--- a/src/subtitle/YouTubeCaptionProvider.test.js
+++ b/src/subtitle/YouTubeCaptionProvider.test.js
@@ -1,15 +1,9 @@
 import { act } from "react";
 import { apiSubtitle, apiSummarizeContext } from "../apis/index.js";
 import { YouTubeCaptionProvider } from "./YouTubeCaptionProvider.js";
-import {
-  getCaptionTracks,
-  getSubtitleEvents,
-} from "./youtubeCaptionTracks.js";
+import { getCaptionTracks, getSubtitleEvents } from "./youtubeCaptionTracks.js";
 import { eventsToSubtitles } from "./youtubeAiSegmentation.js";
-import {
-  genFlatEvents,
-  normalizeTimedTextEvents,
-} from "./youtubeSubtitleProcessing.js";
+import { prepareTimedTextEvents } from "./youtubeSubtitleProcessing.js";
 
 jest.mock("../config", () => ({
   MSG_XHR_DATA_YOUTUBE: "xhr-youtube",
@@ -56,9 +50,8 @@ jest.mock("./youtubeCaptionTracks.js", () => ({
 jest.mock("./youtubeSubtitleProcessing.js", () => ({
   builtinSegment: jest.fn(),
   formatSubtitles: jest.fn(),
-  genFlatEvents: jest.fn(),
   getFromLang: () => "en",
-  normalizeTimedTextEvents: jest.fn(),
+  prepareTimedTextEvents: jest.fn(),
 }));
 
 jest.mock("./youtubeAiSegmentation.js", () => ({
@@ -83,16 +76,18 @@ describe("YouTubeCaptionProvider manual translation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     window.history.replaceState({}, "", "/watch?v=video-1");
-    document.body.innerHTML = '<video></video><button class="captions" aria-pressed="true"></button>';
+    document.body.innerHTML =
+      '<video></video><button class="captions" aria-pressed="true"></button>';
     getCaptionTracks.mockResolvedValue({
       captionTracks: [{ baseUrl: "https://www.youtube.com/timedtext" }],
       fullDescription: "",
     });
     getSubtitleEvents.mockResolvedValue([{ text: "hello" }]);
-    normalizeTimedTextEvents.mockReturnValue([{ text: "hello" }]);
-    genFlatEvents.mockReturnValue([
-      { start: 0, end: 1000, text: "hello" },
-    ]);
+    // 新准备接口一次返回规范化事件和展平事件，避免测试继续依赖已删除的两段处理。
+    prepareTimedTextEvents.mockReturnValue({
+      events: [{ text: "hello" }],
+      flatEvents: [{ start: 0, end: 1000, text: "hello" }],
+    });
     eventsToSubtitles.mockResolvedValue([
       [{ start: 0, end: 1000, text: "hello", translation: "你好" }],
       100,
@@ -122,8 +117,7 @@ describe("YouTubeCaptionProvider manual translation", () => {
     await act(async () => flushPromises());
 
     expect(getSubtitleEvents).toHaveBeenCalledTimes(1);
-    expect(normalizeTimedTextEvents).toHaveBeenCalledTimes(1);
-    expect(genFlatEvents).toHaveBeenCalledTimes(1);
+    expect(prepareTimedTextEvents).toHaveBeenCalledTimes(1);
     expect(apiSubtitle).not.toHaveBeenCalled();
     expect(eventsToSubtitles).not.toHaveBeenCalled();
 

--- a/src/subtitle/sentenceBreaker.js
+++ b/src/subtitle/sentenceBreaker.js
@@ -1,3 +1,5 @@
+import { isNonSpeechSegment } from "./subtitleTextClassification.js";
+
 /**
  * 智能断句算法 - 从 YouTube 歌词/字幕 JSON 到结构化断句
  * 基于 Python 字幕生成器 (subtitle_generator.py) 的 JavaScript 等价实现。
@@ -204,7 +206,10 @@ function parseYoutubeData(data) {
     for (let i = 0; i < segs.length; i++) {
       const seg = segs[i];
       const text = seg.utf8 || "";
-      if (!text || text === "\n") continue;
+      if (!text || text === "\n" || isNonSpeechSegment(text)) {
+        // 保留 seg 在原数组中的位置，让前一个语音词仍可使用该标记的偏移作为结束时间。
+        continue;
+      }
 
       const offset = seg.tOffsetMs || 0;
       const wordStart = tStart + offset;

--- a/src/subtitle/subtitleBoundaryProtocol.js
+++ b/src/subtitle/subtitleBoundaryProtocol.js
@@ -1,0 +1,68 @@
+import { isNonSpeechSegment } from "./subtitleTextClassification.js";
+
+const NO_SPACE_LANGUAGES = ["zh", "ja", "ko", "th", "lo", "km", "my"];
+
+/** 判断源语言是否通常不以空格分隔词语，用于重建自然的原文。 */
+export const isNoSpaceSubtitleLanguage = (lang = "") =>
+  NO_SPACE_LANGUAGES.some((code) => String(lang).startsWith(code));
+
+/** 判断一条字幕是否完全由 `[Music]` 等非语音标记组成。 */
+export const isOnlyNonSpeechSubtitle = (text = "") => isNonSpeechSegment(text);
+
+/** 按语言书写习惯合并 boundary-v2/v3 边界范围内的原始事件文本。 */
+export function mergeSubtitleEventText(
+  events,
+  startIndex,
+  endIndex,
+  fromLang = "auto"
+) {
+  const texts = events
+    .slice(startIndex, endIndex + 1)
+    .map((event) => String(event?.text || "").trim())
+    .filter(Boolean);
+  return texts.join(isNoSpaceSubtitleLanguage(fromLang) ? "" : " ").trim();
+}
+
+/**
+ * 将 boundary-v2/v3 的单个对象映射为 cue。调用者持有 nextIndex 游标。
+ */
+export function mapBoundaryItemToCue(
+  item,
+  events,
+  nextIndex,
+  fromLang = "auto"
+) {
+  const endIndex = Number(item?.e ?? item?.end_id);
+  if (
+    !Number.isInteger(endIndex) ||
+    !Number.isInteger(nextIndex) ||
+    nextIndex < 0 ||
+    endIndex < nextIndex ||
+    endIndex >= events.length
+  ) {
+    return null;
+  }
+
+  const text = mergeSubtitleEventText(events, nextIndex, endIndex, fromLang);
+  if (!text) return null;
+  const translation = isOnlyNonSpeechSubtitle(text)
+    ? text
+    : String(item?.t ?? item?.translation ?? "");
+
+  return {
+    start: events[nextIndex].start,
+    end: events[endIndex].end,
+    text,
+    translation,
+    _si: nextIndex,
+    _ei: endIndex,
+  };
+}
+
+/**
+ * 只有显式开始索引才代表 index-v1；boundary-v3 的 `o` 只是模型自检锚点，不能触发旧模糊对齐器。
+ */
+export const isLegacyIndexSubtitleItem = (item) =>
+  item &&
+  (Object.prototype.hasOwnProperty.call(item, "s") ||
+    Object.prototype.hasOwnProperty.call(item, "start_id"));

--- a/src/subtitle/subtitleSegmentationMetrics.js
+++ b/src/subtitle/subtitleSegmentationMetrics.js
@@ -1,0 +1,179 @@
+import { isNonSpeechSegment } from "./subtitleTextClassification.js";
+
+const NO_SPACE_LANGUAGES = ["zh", "ja", "ko", "th", "lo", "km", "my"];
+
+// 指标统一保留两位小数，避免 CLI 和浏览器因浮点尾差产生不必要的差异。
+const round = (value) => Math.round((Number(value) || 0) * 100) / 100;
+
+const percentile = (values, ratio) => {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil(sorted.length * ratio) - 1;
+  return sorted[Math.max(0, index)];
+};
+
+const summarize = (values) => ({
+  average: round(
+    values.length
+      ? values.reduce((total, value) => total + value, 0) / values.length
+      : 0
+  ),
+  p95: percentile(values, 0.95),
+  max: values.length ? Math.max(...values) : 0,
+});
+
+/** 根据语言书写方式生成覆盖校验 token，中文等无空格语言按 Unicode 字符比较。 */
+const tokenize = (text, isNoSpace) => {
+  const normalized = String(text || "").toLowerCase();
+  if (isNoSpace) return Array.from(normalized.replace(/\s+/g, ""));
+  return normalized.match(/[\p{L}\p{N}]+|[^\s\p{L}\p{N}]/gu) || [];
+};
+
+const tokenCounts = (texts, isNoSpace) => {
+  const counts = new Map();
+  for (const token of tokenize((texts || []).join(" "), isNoSpace)) {
+    counts.set(token, (counts.get(token) || 0) + 1);
+  }
+  return counts;
+};
+
+/** 用多重集合比较原始文本与结果文本，分别统计遗漏和重复 token。 */
+const compareCoverage = (flatEvents, cues, isNoSpace) => {
+  const source = tokenCounts(
+    flatEvents.map((item) => item.text),
+    isNoSpace
+  );
+  const result = tokenCounts(
+    cues.map((item) => item.text),
+    isNoSpace
+  );
+  let sourceTokenCount = 0;
+  let missingTextCount = 0;
+  let duplicatedTextCount = 0;
+
+  for (const [token, count] of source) {
+    sourceTokenCount += count;
+    missingTextCount += Math.max(0, count - (result.get(token) || 0));
+  }
+  for (const [token, count] of result) {
+    duplicatedTextCount += Math.max(0, count - (source.get(token) || 0));
+  }
+
+  return {
+    textCoveragePercent: sourceTokenCount
+      ? round(((sourceTokenCount - missingTextCount) / sourceTokenCount) * 100)
+      : 100,
+    missingTextCount,
+    duplicatedTextCount,
+  };
+};
+
+/**
+ * 计算 CLI 和 Playground 共用的字幕断句结构及可读性指标。
+ */
+export function buildSegmentationMetrics({
+  rawEvents = [],
+  canonicalEvents = [],
+  flatEvents = [],
+  cues = [],
+  fromLang = "auto",
+  processingMs = 0,
+  filteredNonSpeechCount = 0,
+  ai = null,
+} = {}) {
+  const safeCues = Array.isArray(cues) ? cues : [];
+  const charLengths = safeCues.map((cue) => String(cue.text || "").length);
+  const wordLengths = safeCues.map(
+    (cue) =>
+      String(cue.text || "")
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean).length
+  );
+  const durations = safeCues.map((cue) =>
+    Math.max(0, Number(cue.end) - Number(cue.start))
+  );
+  const sourceStart = flatEvents[0]?.start || 0;
+  const sourceEnd = flatEvents[flatEvents.length - 1]?.end || sourceStart;
+  const isNoSpace = NO_SPACE_LANGUAGES.some((lang) =>
+    String(fromLang).startsWith(lang)
+  );
+
+  let emptyCueCount = 0;
+  let overlapCount = 0;
+  let nonMonotonicCount = 0;
+  let invalidCueCount = 0;
+  let coveredDurationMs = 0;
+
+  safeCues.forEach((cue, index) => {
+    if (!String(cue.text || "").trim()) emptyCueCount += 1;
+    const duration = Number(cue.end) - Number(cue.start);
+    if (
+      !Number.isFinite(Number(cue.start)) ||
+      !Number.isFinite(Number(cue.end)) ||
+      duration <= 0
+    ) {
+      invalidCueCount += 1;
+    }
+    if (Number.isFinite(duration) && duration > 0)
+      coveredDurationMs += duration;
+    if (index > 0) {
+      const previous = safeCues[index - 1];
+      if (Number(cue.start) < Number(previous.start)) nonMonotonicCount += 1;
+      if (Number(cue.start) < Number(previous.end)) overlapCount += 1;
+    }
+  });
+
+  const coverage = compareCoverage(flatEvents, safeCues, isNoSpace);
+  const warnings = {
+    tooLongTextCount: safeCues.filter((cue, index) =>
+      isNoSpace ? charLengths[index] > 30 : wordLengths[index] > 15
+    ).length,
+    tooLongDurationCount: durations.filter((duration) => duration > 10000)
+      .length,
+    fragmentCount: safeCues.filter(
+      (cue, index) =>
+        wordLengths[index] < 2 &&
+        durations[index] < 500 &&
+        !isNonSpeechSegment(cue.text)
+    ).length,
+    nonSpeechCueCount: safeCues.filter((cue) => isNonSpeechSegment(cue.text))
+      .length,
+  };
+
+  const metrics = {
+    processingMs: round(processingMs),
+    rawEventCount: rawEvents.length,
+    canonicalEventCount: canonicalEvents.length,
+    flatEventCount: flatEvents.length,
+    // 这是预处理阶段主动排除的片段数量，不属于可读性错误。
+    filteredNonSpeechCount: Math.max(0, Number(filteredNonSpeechCount) || 0),
+    cueCount: safeCues.length,
+    sourceDurationMs: Math.max(0, sourceEnd - sourceStart),
+    coveredDurationMs,
+    ...coverage,
+    emptyCueCount,
+    invalidCueCount,
+    overlapCount,
+    nonMonotonicCount,
+    chars: summarize(charLengths),
+    words: summarize(wordLengths),
+    durationMs: summarize(durations),
+    warnings,
+  };
+
+  if (ai) metrics.ai = ai;
+  return metrics;
+}
+
+export function getSegmentationMetricErrors(metrics = {}) {
+  const errors = [];
+  if (metrics.invalidCueCount) errors.push("invalid-cue");
+  if (metrics.emptyCueCount) errors.push("empty-cue");
+  if (metrics.overlapCount) errors.push("overlap");
+  if (metrics.nonMonotonicCount) errors.push("non-monotonic");
+  if (metrics.missingTextCount) errors.push("missing-text");
+  if (metrics.duplicatedTextCount) errors.push("duplicated-text");
+  if (metrics.warnings?.nonSpeechCueCount) errors.push("non-speech-leaked");
+  return errors;
+}

--- a/src/subtitle/subtitleSegmentationMetrics.test.js
+++ b/src/subtitle/subtitleSegmentationMetrics.test.js
@@ -1,0 +1,52 @@
+import {
+  buildSegmentationMetrics,
+  getSegmentationMetricErrors,
+} from "./subtitleSegmentationMetrics";
+
+describe("subtitleSegmentationMetrics", () => {
+  test("treats spacing changes in Chinese as complete text coverage", () => {
+    const metrics = buildSegmentationMetrics({
+      flatEvents: [
+        { text: "你", start: 0, end: 500 },
+        { text: "好", start: 500, end: 1000 },
+      ],
+      cues: [{ text: "你好", start: 0, end: 1000 }],
+      fromLang: "zh-CN",
+    });
+
+    expect(metrics.textCoveragePercent).toBe(100);
+    expect(metrics.missingTextCount).toBe(0);
+    expect(metrics.duplicatedTextCount).toBe(0);
+  });
+
+  test("reports structural timeline and text coverage errors", () => {
+    const metrics = buildSegmentationMetrics({
+      flatEvents: [
+        { text: "hello", start: 0, end: 500 },
+        { text: "world", start: 500, end: 1000 },
+      ],
+      // 同时构造重叠、重复和遗漏，确保 CLI 与 Playground 使用同一错误分类。
+      cues: [
+        { text: "hello", start: 0, end: 700 },
+        { text: "hello", start: 600, end: 1000 },
+      ],
+      fromLang: "en",
+    });
+
+    expect(getSegmentationMetricErrors(metrics)).toEqual(
+      expect.arrayContaining(["overlap", "missing-text", "duplicated-text"])
+    );
+  });
+
+  test("reports filtered non-speech count and detects leaked non-speech cues", () => {
+    const metrics = buildSegmentationMetrics({
+      flatEvents: [],
+      cues: [{ text: "[Music]", start: 0, end: 1000 }],
+      filteredNonSpeechCount: 2,
+    });
+
+    expect(metrics.filteredNonSpeechCount).toBe(2);
+    expect(metrics.warnings.nonSpeechCueCount).toBe(1);
+    expect(getSegmentationMetricErrors(metrics)).toContain("non-speech-leaked");
+  });
+});

--- a/src/subtitle/subtitleTextClassification.js
+++ b/src/subtitle/subtitleTextClassification.js
@@ -1,0 +1,13 @@
+// 纯方括号字幕通常是音乐、笑声等声音说明；可选的 `>>` 是 YouTube 的说话人切换前缀。
+const NON_SPEECH_SEGMENT_RE = /^(?:>>\s*)?(?:\[[^\]\r\n]+\]\s*)+$/u;
+
+/**
+ * 判断单个字幕片段是否完全由非语音说明组成。
+ * 只匹配整个片段，避免误删 `Use [React] in this project` 一类正常对白。
+ *
+ * @param {string} [text=""] 待判断的字幕片段。
+ * @returns {boolean} 是否为纯非语音片段。
+ */
+export function isNonSpeechSegment(text = "") {
+  return NON_SPEECH_SEGMENT_RE.test(String(text).trim());
+}

--- a/src/subtitle/youtubeAiSegmentation.js
+++ b/src/subtitle/youtubeAiSegmentation.js
@@ -9,43 +9,109 @@ import { splitEventsIntoChunks } from "./youtubeSubtitleProcessing.js";
  */
 
 /**
- * 提取相邻字幕分块的简短上下文，辅助 AI 断句保持语义连续。
- *
- * @param {Array<Array<object>>} chunks 已切分的字幕事件分块。
- * @param {number} chunkIndex 当前分块索引。
- * @param {"prev"|"next"} side 提取前一块或后一块上下文。
- * @param {number} [maxEvents=3] 最多取用的相邻事件数量。
- * @param {number} [maxChars=240] 输出上下文最大字符数。
- * @returns {string} 清洗后的上下文文本。
+ * 只接受从事件 0 开始连续覆盖的字幕前缀，非法、跳号或重叠后的对象全部丢弃。
+ * VTT 旧协议没有事件索引，无法进行游标校验，只保留原有兼容行为。
  */
-export function getChunkContext(
-  chunks,
-  chunkIndex,
-  side,
-  maxEvents = 3,
-  maxChars = 240
-) {
-  const NON_SPEECH_RE = /^\[.+\]$/i;
-  const adj = side === "prev" ? chunks[chunkIndex - 1] : chunks[chunkIndex + 1];
-  if (!adj?.length) return "";
-  const picked =
-    side === "prev" ? adj.slice(-maxEvents) : adj.slice(0, maxEvents);
-  return picked
-    .map((e) => String(e?.text ?? "").trim())
-    .filter((t) => t && !NON_SPEECH_RE.test(t))
-    .join(" ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, maxChars);
+function takeContinuousCuePrefix(cues, eventCount) {
+  const safeCues = Array.isArray(cues) ? cues : [];
+  const hasIndexedCue = safeCues.some(
+    (cue) => Number.isInteger(cue?._ei) || Number.isInteger(cue?._alignedEi)
+  );
+  if (!hasIndexedCue) {
+    return {
+      cues: safeCues,
+      coveredEnd: safeCues.length ? eventCount - 1 : -1,
+      verifiable: false,
+    };
+  }
+
+  const prefix = [];
+  let nextIndex = 0;
+  for (const cue of safeCues) {
+    const startIndex = cue._alignedSi ?? cue._si;
+    const endIndex = cue._alignedEi ?? cue._ei;
+    if (
+      !Number.isInteger(startIndex) ||
+      !Number.isInteger(endIndex) ||
+      startIndex !== nextIndex ||
+      endIndex < startIndex ||
+      endIndex >= eventCount
+    ) {
+      break;
+    }
+    prefix.push(cue);
+    nextIndex = endIndex + 1;
+  }
+
+  return { cues: prefix, coveredEnd: nextIndex - 1, verifiable: true };
+}
+
+/** 把尾部请求的局部事件索引恢复为当前 chunk 的全局索引。 */
+function offsetCueIndices(cues, offset) {
+  return (cues || []).map((cue) => ({
+    ...cue,
+    _si: Number.isInteger(cue._si) ? cue._si + offset : cue._si,
+    _ei: Number.isInteger(cue._ei) ? cue._ei + offset : cue._ei,
+    _alignedSi: Number.isInteger(cue._alignedSi)
+      ? cue._alignedSi + offset
+      : cue._alignedSi,
+    _alignedEi: Number.isInteger(cue._alignedEi)
+      ? cue._alignedEi + offset
+      : cue._alignedEi,
+  }));
+}
+
+/** 根据设置标记 AI 译文为待重翻译，保持现有字幕管理器的处理语义。 */
+function markDraftTranslations(cues, clearSegmentTranslation) {
+  return clearSegmentTranslation
+    ? (cues || []).map((cue) => ({ ...cue, _isDraftTranslation: true }))
+    : cues || [];
+}
+
+/**
+ * 最终校验字幕时间轴和原文顺序；兼容 VTT 时也能发现漏词或重复词。
+ * 校验失败直接对当前 chunk 全量降级，避免把损坏结果交给播放器。
+ */
+function finalizeAiCues(cues, segmentEvents, fromLang, formatSubtitles) {
+  const sorted = [...(cues || [])].sort((a, b) => a.start - b.start);
+  const hasInvalidTimeline = sorted.some((cue, index) => {
+    const start = Number(cue.start);
+    const end = Number(cue.end);
+    const previous = sorted[index - 1];
+    return (
+      !String(cue.text || "").trim() ||
+      !Number.isFinite(start) ||
+      !Number.isFinite(end) ||
+      end <= start ||
+      (previous && start < Number(previous.end))
+    );
+  });
+  // 仅比较字母和数字序列，允许模型在 VTT 旧协议中修正空格或标点。
+  const normalizeText = (items) =>
+    (items || [])
+      .map((item) => String(item?.text || ""))
+      .join("")
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}]/gu, "");
+  const hasInvalidCoverage =
+    normalizeText(sorted) !== normalizeText(segmentEvents);
+
+  if (hasInvalidTimeline || hasInvalidCoverage) {
+    logger.info("Youtube Provider: AI result validation failed, falling back");
+    return formatSubtitles(segmentEvents, fromLang).sort(
+      (a, b) => a.start - b.start
+    );
+  }
+  return sorted;
 }
 
 /**
  * 通过大模型 AI 接口对字幕切片事件流进行“智能断句”与“辅助翻译”。
  *
  * 设计要点：
- * 1. 预先剥离 `[Music]`、`[Laughter]` 等非语音事件，节省 Token 并避免直译混淆。
+ * 1. 只接收预处理后的语音事件，非语音标记不会进入模型和完整覆盖校验。
  * 2. 对 AI 响应尾部遗漏进行一次 Tail Retry，降低流式截断导致的尾句丢失。
- * 3. 当断句 API 与正式翻译 API 不一致时，清空断句模型返回的 translation，交给后续翻译流程处理。
+ * 3. 启用强制重翻译时，把断句模型译文标记为草稿，交给后续翻译流程替换。
  *
  * @param {object} param0 参数对象。
  * @param {string} param0.videoId 当前视频 ID。
@@ -56,12 +122,10 @@ export function getChunkContext(
  * @param {Function} param0.apiSubtitle 调用字幕断句 API 的函数。
  * @param {object} param0.docInfo 页面与 AI 上下文信息。
  * @param {Function} param0.formatSubtitles AI 失败时的内置格式化降级函数。
- * @param {boolean} param0.clearSegmentTranslation 是否清空断句 API 返回的翻译字段。
- * @param {string} [param0.prevContext=""] 前一分块的简短上下文。
- * @param {string} [param0.nextContext=""] 后一分块的简短上下文。
+ * @param {boolean} param0.clearSegmentTranslation 是否把断句 API 译文标记为待重翻译。
  * @param {Function} [param0.onSubtitleChunk] AI 流式返回完整句子时的增量回调。
  * @param {AbortSignal} [param0.signal] 当前字幕处理生命周期的取消信号。
- * @returns {Promise<Array<object>>} AI 断句后的字幕条目；失败时返回可保留的非语音条目。
+ * @returns {Promise<Array<object>>} AI 断句后的字幕条目；失败时返回内置规则断句结果。
  */
 export async function aiSegment({
   videoId,
@@ -73,44 +137,24 @@ export async function aiSegment({
   docInfo,
   formatSubtitles,
   clearSegmentTranslation,
-  prevContext = "",
-  nextContext = "",
   onSubtitleChunk,
   signal,
   setting,
 }) {
-  const NON_SPEECH_RE = /^\[.+\]$/i;
-  const speechEvents = [];
-  const nonSpeechEvents = [];
-
-  for (const item of chunkEvents) {
-    if (!item.text) continue;
-    if (NON_SPEECH_RE.test(item.text.trim())) {
-      nonSpeechEvents.push(item);
-    } else {
-      speechEvents.push(item);
-    }
-  }
-
-  const toStandaloneSub = (e) => ({
-    start: e.start,
-    end: e.end,
-    text: e.text,
-    translation: e.text,
-  });
-
-  if (!speechEvents.length) return nonSpeechEvents.map(toStandaloneSub);
+  // 调用方已经统一过滤非语音片段，这里只剔除无文本项，避免重复分类和事后回填。
+  const segmentEvents = (chunkEvents || []).filter((item) => item?.text);
+  if (!segmentEvents.length) return [];
 
   try {
-    const chunkSign = `${speechEvents[0].start} --> ${
-      speechEvents[speechEvents.length - 1].end
+    const chunkSign = `${segmentEvents[0].start} --> ${
+      segmentEvents[segmentEvents.length - 1].end
     }`;
     logger.debug("Youtube Provider: aiSegment events", {
       videoId,
       chunkSign,
       fromLang,
       toLang,
-      speechEvents,
+      segmentEvents,
     });
 
     const resolvedSegApiSetting = resolveApiPromptSettings(
@@ -124,11 +168,9 @@ export async function aiSegment({
       chunkSign,
       fromLang,
       toLang,
-      events: speechEvents,
+      events: segmentEvents,
       apiSetting: resolvedSegApiSetting,
       docInfo,
-      prevContext,
-      nextContext,
       signal,
       onSubtitleChunk: ({ subtitles }) => {
         if (!subtitles?.length || !onSubtitleChunk) return;
@@ -141,76 +183,71 @@ export async function aiSegment({
       },
     });
     logger.debug("Youtube Provider: aiSegment subtitles", subtitles);
-    if (Array.isArray(subtitles) && subtitles.length) {
-      let result = subtitles;
-      if (clearSegmentTranslation) {
-        result = subtitles.map((sub) => ({
-          ...sub,
-          _isDraftTranslation: true,
-        }));
+    if (Array.isArray(subtitles)) {
+      const initial = takeContinuousCuePrefix(
+        markDraftTranslations(subtitles, clearSegmentTranslation),
+        segmentEvents.length
+      );
+      if (
+        !initial.verifiable ||
+        initial.coveredEnd === segmentEvents.length - 1
+      ) {
+        return finalizeAiCues(
+          initial.cues,
+          segmentEvents,
+          fromLang,
+          formatSubtitles
+        );
       }
 
-      const maxEi = Math.max(...result.map((s) => s._ei ?? -1));
-
-      if (maxEi >= 0 && maxEi < speechEvents.length - 1) {
-        const tailEvents = speechEvents.slice(maxEi + 1);
-        if (tailEvents.length <= speechEvents.length * 0.5) {
-          try {
-            const tailSign = `${tailEvents[0].start} --> ${
-              tailEvents[tailEvents.length - 1].end
-            }`;
-            const lastResultText = result[result.length - 1]?.text || "";
-
-            const tailSubs = await apiSubtitle({
-              videoId,
-              chunkSign: tailSign,
-              fromLang,
-              toLang,
-              events: tailEvents,
-              apiSetting: resolvedSegApiSetting,
-              docInfo,
-              prevContext: [prevContext, lastResultText]
-                .filter(Boolean)
-                .join(" "),
-              nextContext,
-              signal,
-            });
-
-            if (tailSubs?.length) {
-              let processedTailSubs = tailSubs;
-              if (clearSegmentTranslation) {
-                processedTailSubs = processedTailSubs.map((sub) => ({
-                  ...sub,
-                  _isDraftTranslation: true,
-                }));
-              }
-              result = [...result, ...processedTailSubs];
-            } else {
-              result = [...result, ...formatSubtitles(tailEvents, fromLang)];
-            }
-          } catch {
-            result = [...result, ...formatSubtitles(tailEvents, fromLang)];
-          }
-        }
+      // 未覆盖尾部最多重试一次；二次响应仍不完整时，只对剩余事件使用规则断句。
+      const tailOffset = initial.coveredEnd + 1;
+      const tailEvents = segmentEvents.slice(tailOffset);
+      let tailPrefix = { cues: [], coveredEnd: -1, verifiable: true };
+      try {
+        const tailSign = `${tailEvents[0].start} --> ${
+          tailEvents[tailEvents.length - 1].end
+        }`;
+        const tailSubs = await apiSubtitle({
+          videoId,
+          chunkSign: tailSign,
+          fromLang,
+          toLang,
+          events: tailEvents,
+          apiSetting: resolvedSegApiSetting,
+          docInfo,
+          signal,
+        });
+        tailPrefix = takeContinuousCuePrefix(
+          markDraftTranslations(tailSubs, clearSegmentTranslation),
+          tailEvents.length
+        );
+      } catch (tailError) {
+        logger.info("Youtube Provider: ai tail retry", tailError);
       }
 
-      const gapCues = nonSpeechEvents
-        .filter(
-          (ns) =>
-            !result.some((sub) => ns.start < sub.end && ns.end > sub.start)
-        )
-        .map(toStandaloneSub);
-
-      return [...result, ...gapCues].sort((a, b) => a.start - b.start);
+      const acceptedTail = offsetCueIndices(tailPrefix.cues, tailOffset);
+      const fallbackOffset = tailPrefix.verifiable
+        ? tailOffset + tailPrefix.coveredEnd + 1
+        : segmentEvents.length;
+      const fallbackEvents = segmentEvents.slice(fallbackOffset);
+      const fallbackCues = fallbackEvents.length
+        ? formatSubtitles(fallbackEvents, fromLang)
+        : [];
+      return finalizeAiCues(
+        [...initial.cues, ...acceptedTail, ...fallbackCues],
+        segmentEvents,
+        fromLang,
+        formatSubtitles
+      );
     }
   } catch (err) {
     logger.info("Youtube Provider: ai segmentation", err);
   }
 
-  return [
-    ...formatSubtitles(speechEvents, fromLang),
-    ...nonSpeechEvents.map(toStandaloneSub),
-  ].sort((a, b) => a.start - b.start);
+  return formatSubtitles(segmentEvents, fromLang).sort(
+    (a, b) => a.start - b.start
+  );
 }
 
 /**
@@ -287,8 +324,6 @@ export async function eventsToSubtitles({
       docInfo,
       formatSubtitles,
       clearSegmentTranslation: shouldClearSegmentTranslation,
-      prevContext: "",
-      nextContext: getChunkContext(eventChunks, 0, "next"),
       signal,
       setting,
       onSubtitleChunk: ({ subtitles }) => {
@@ -366,7 +401,7 @@ export async function eventsToSubtitles({
  * @param {Function} params.apiSubtitle 调用 AI 断句接口的函数。
  * @param {object} params.docInfo 页面/视频上下文信息。
  * @param {Function} params.formatSubtitles AI 断句失败时的内置降级断句函数。
- * @param {boolean} params.clearSegmentTranslation 是否清空 AI 断句返回的翻译，交给后续翻译服务重翻。
+ * @param {boolean} params.clearSegmentTranslation 是否把 AI 译文标记为草稿，交给后续翻译服务重翻。
  * @param {Function} params.onAppendSubtitles chunk 完成或流式返回时合并字幕的回调。
  * @param {Function} params.getCurrentVideoId 读取当前页面视频 ID 的函数。
  * @param {AbortSignal} [params.signal] 当前字幕处理生命周期的取消信号。
@@ -475,8 +510,6 @@ export function createAiChunkScheduler({
         docInfo,
         formatSubtitles,
         clearSegmentTranslation,
-        prevContext: getChunkContext(chunks, index, "prev"),
-        nextContext: getChunkContext(chunks, index, "next"),
         signal,
         setting,
         onSubtitleChunk: ({ subtitles }) => {
@@ -604,7 +637,7 @@ export function createAiChunkScheduler({
  * @param {Function} param0.apiSubtitle 调用字幕断句 API 的函数。
  * @param {object} param0.docInfo 页面与 AI 上下文信息。
  * @param {Function} param0.formatSubtitles AI 失败时的内置格式化降级函数。
- * @param {boolean} param0.clearSegmentTranslation 是否清空断句 API 返回的翻译字段。
+ * @param {boolean} param0.clearSegmentTranslation 是否把断句 API 译文标记为待重翻译。
  * @param {Function} param0.onAppendSubtitles 分块完成时同步到 provider 的回调。
  * @param {Function} param0.getCurrentVideoId 读取当前页面视频 ID 的函数。
  * @param {AbortSignal} [param0.signal] 当前字幕处理生命周期的取消信号。
@@ -659,8 +692,6 @@ export async function processRemainingChunksAsync({
         docInfo,
         formatSubtitles,
         clearSegmentTranslation,
-        prevContext: getChunkContext(chunks, i, "prev"),
-        nextContext: getChunkContext(chunks, i, "next"),
         signal,
         setting,
         onSubtitleChunk: ({ subtitles }) => {

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -1,7 +1,9 @@
 import {
+  aiSegment,
   createAiChunkScheduler,
   eventsToSubtitles,
 } from "./youtubeAiSegmentation";
+import { prepareTimedTextEvents } from "./youtubeSubtitleProcessing";
 
 jest.mock("../libs/log.js", () => ({
   LogLevel: {
@@ -42,6 +44,101 @@ const subtitle = {
   _si: 0,
   _ei: 1,
 };
+
+describe("aiSegment recovery", () => {
+  test("sends only speech events after timedtext preparation", async () => {
+    const prepared = prepareTimedTextEvents([
+      {
+        tStartMs: 0,
+        dDurationMs: 1500,
+        segs: [
+          { utf8: "Hello" },
+          { utf8: " [Music]", tOffsetMs: 500 },
+          { utf8: " world.", tOffsetMs: 900 },
+        ],
+      },
+    ]);
+    const apiSubtitle = jest.fn(({ events }) =>
+      Promise.resolve([
+        {
+          start: events[0].start,
+          end: events[events.length - 1].end,
+          text: events.map((event) => event.text).join(" "),
+          translation: "你好，世界。",
+          _si: 0,
+          _ei: events.length - 1,
+        },
+      ])
+    );
+
+    const result = await aiSegment({
+      videoId: "video-non-speech",
+      fromLang: "en",
+      toLang: "zh-CN",
+      chunkEvents: prepared.flatEvents,
+      segApiSetting: { apiSlug: "openai" },
+      apiSubtitle,
+      docInfo: {},
+      formatSubtitles: jest.fn(() => []),
+      clearSegmentTranslation: false,
+      setting: {},
+    });
+
+    expect(
+      apiSubtitle.mock.calls[0][0].events.map((event) => event.text)
+    ).toEqual(["Hello", "world."]);
+    expect(result[0].text).toBe("Hello world.");
+  });
+
+  test("retries an uncovered tail once and falls back only for the remaining events", async () => {
+    const events = Array.from({ length: 4 }, (_, index) => ({
+      start: index * 1000,
+      end: (index + 1) * 1000,
+      text: `word-${index}`,
+    }));
+    const apiSubtitle = jest
+      .fn()
+      // 首次响应只覆盖 0，遗漏尾部超过整个 chunk 的一半。
+      .mockResolvedValueOnce([
+        { ...events[0], translation: "译文-0", _si: 0, _ei: 0 },
+      ])
+      // 尾部重试只再覆盖局部事件 0，剩余局部事件必须精确降级。
+      .mockResolvedValueOnce([
+        { ...events[1], translation: "译文-1", _si: 0, _ei: 0 },
+      ]);
+    const formatSubtitles = jest.fn((tailEvents) => [
+      {
+        start: tailEvents[0].start,
+        end: tailEvents[tailEvents.length - 1].end,
+        text: tailEvents.map((event) => event.text).join(" "),
+        translation: "",
+      },
+    ]);
+
+    const result = await aiSegment({
+      videoId: "video-recovery",
+      fromLang: "en",
+      toLang: "zh-CN",
+      chunkEvents: events,
+      segApiSetting: { apiSlug: "openai" },
+      apiSubtitle,
+      docInfo: {},
+      formatSubtitles,
+      clearSegmentTranslation: false,
+      setting: {},
+    });
+
+    expect(apiSubtitle).toHaveBeenCalledTimes(2);
+    expect(apiSubtitle.mock.calls[1][0].events).toEqual(events.slice(1));
+    expect(formatSubtitles).toHaveBeenCalledWith(events.slice(2), "en");
+    expect(result.map(({ start, end }) => [start, end])).toEqual([
+      [0, 1000],
+      [1000, 2000],
+      [2000, 4000],
+    ]);
+    expect(result[1]).toMatchObject({ _si: 1, _ei: 1 });
+  });
+});
 
 describe("eventsToSubtitles", () => {
   test("appends streamed first-chunk subtitles before full chunk resolves", async () => {

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -5,6 +5,7 @@ import {
 } from "../config";
 import { logger } from "../libs/log.js";
 import { intelligentSentenceBreak } from "./sentenceBreaker.js";
+import { isNonSpeechSegment } from "./subtitleTextClassification.js";
 
 /**
  * YouTube 字幕文本处理层。
@@ -50,123 +51,99 @@ export function cleanTimedText(utf8 = "") {
 }
 
 /**
- * 规范化 YouTube json3 events。
- * 保留断行控制事件和时间断点，同时清洗可见文本并去除重复字幕。
+ * 一次完成 YouTube json3 events 的文本清洗、相邻重复事件去除和时间轴展平。
+ * 原始输入不会被修改；统计断句读取 events，规则和 AI 断句读取已过滤非语音片段的 flatEvents。
  *
- * @param {Array<object>} [events=[]] YouTube 原始 json3 events。
- * @returns {Array<object>} 规范化后的 events。
+ * @param {Array<object>} [rawEvents=[]] YouTube 原始 json3 events。
+ * @returns {{events:Array<object>, flatEvents:Array<object>, filteredNonSpeechCount:number}}
  */
-export function normalizeTimedTextEvents(events = []) {
-  const normalizedEvents = [];
+export function prepareTimedTextEvents(rawEvents = []) {
+  const events = [];
+  const flatEvents = [];
+  let filteredNonSpeechCount = 0;
+  let buffer = null;
   let lastVisibleEventKey = "";
 
-  events.forEach((event) => {
-    const { segs = [], tStartMs = 0, dDurationMs = 0 } = event || {};
-
-    // YouTube 会用 aAppend + "\n" 标记原始字幕断行；统计断句模式会读取这个信号。
-    // 因此这类控制事件必须原样保留，不能被“空文本清理”误删。
-    if (event?.aAppend === 1 && segs.length === 1 && segs[0]?.utf8 === "\n") {
-      normalizedEvents.push(event);
-      lastVisibleEventKey = "";
-      return;
+  const flushBuffer = (endAt) => {
+    if (!buffer) return;
+    if (!buffer.end || (Number.isFinite(endAt) && buffer.end > endAt)) {
+      buffer.end = endAt;
     }
+    if (Number.isFinite(buffer.end) && buffer.end > buffer.start) {
+      flatEvents.push(buffer);
+    }
+    buffer = null;
+  };
 
-    const normalizedSegs = segs.map((seg) => ({
+  for (const rawEvent of Array.isArray(rawEvents) ? rawEvents : []) {
+    const event = rawEvent || {};
+    const rawSegs = Array.isArray(event.segs) ? event.segs : [];
+    const tStartMs = Number(event.tStartMs) || 0;
+    const dDurationMs = Number(event.dDurationMs) || 0;
+    const isLineBreak =
+      event.aAppend === 1 && rawSegs.length === 1 && rawSegs[0]?.utf8 === "\n";
+
+    const normalizedSegs = rawSegs.map((seg) => ({
       ...seg,
-      utf8: cleanTimedText(seg?.utf8),
+      // 统计断句仍需识别 YouTube 的物理换行控制信号。
+      utf8: isLineBreak ? "\n" : cleanTimedText(seg?.utf8),
     }));
-    const visibleSegs = normalizedSegs.filter((seg) => seg.utf8);
-
-    // 清洗后没有可见文本的 seg 仍可能携带 tOffsetMs 断点。
-    // 这些断点会被 genFlatEvents 用来截断前一个可见片段，直接丢弃会让字幕粘连。
-    // 因此这里只清理文本内容，不改变原始 seg 的时间结构。
-    if (!visibleSegs.length) {
-      normalizedEvents.push({
-        ...event,
-        segs: normalizedSegs,
-      });
-      lastVisibleEventKey = "";
-      return;
-    }
-
-    const visibleText = visibleSegs
-      .map((seg) => seg.utf8)
+    const visibleText = normalizedSegs
+      .map((seg) => cleanTimedText(seg.utf8))
+      .filter(Boolean)
       .join(" ")
       .replace(/\s+/g, " ")
       .trim();
-    const eventKey = `${tStartMs}|${dDurationMs}|${visibleText}`;
+    const eventKey = visibleText
+      ? `${tStartMs}|${dDurationMs}|${visibleText}`
+      : "";
 
-    // 部分 json3 timedtext 会把同一字幕用两套 pPenId 样式连续输出两遍。
-    // 去重键只使用时间和可见文本，避免格式层差异污染字幕内容。
-    if (eventKey === lastVisibleEventKey) return;
+    // 只删除相邻且时间、时长、可见文本完全相同的重复事件。
+    if (eventKey && eventKey === lastVisibleEventKey) continue;
 
-    normalizedEvents.push({
-      ...event,
-      segs: normalizedSegs,
-    });
+    const canonicalEvent = { ...event, segs: normalizedSegs };
+    events.push(canonicalEvent);
     lastVisibleEventKey = eventKey;
-  });
 
-  return normalizedEvents;
-}
-
-/**
- * 将 YouTube events 格式的原始字幕流展平为按单词或词组标记起止时间的数组。
- *
- * @param {Array<object>} [events=[]] 规范化后的 YouTube json3 events。
- * @returns {Array<object>} 展平后的字幕事件流。
- */
-export function genFlatEvents(events = []) {
-  const segments = [];
-  let buffer = null;
-
-  events.forEach(({ segs = [], tStartMs = 0, dDurationMs = 0 }) => {
-    segs.forEach(({ utf8 = "", tOffsetMs = 0 }, j) => {
+    for (let index = 0; index < normalizedSegs.length; index += 1) {
+      const { utf8 = "", tOffsetMs = 0 } = normalizedSegs[index];
       const text = cleanTimedText(utf8);
-      const start = tStartMs + tOffsetMs;
+      const start = tStartMs + (Number(tOffsetMs) || 0);
+
       if (!text) {
-        if (buffer) {
-          if (!buffer.end || buffer.end > start) {
-            buffer.end = start;
-          }
-          if (buffer.end > buffer.start) {
-            segments.push(buffer);
-          }
-          buffer = null;
-        }
-        return;
+        // json3 换行控制偶尔比前一事件的末尾词更早；这种倒退断点不能截掉未来词。
+        if (!buffer || start > buffer.start) flushBuffer(start);
+        continue;
       }
 
-      if (buffer) {
-        if (!buffer.end || buffer.end > start) {
-          buffer.end = start;
-        }
-        if (buffer.end > buffer.start) {
-          segments.push(buffer);
-        }
-        buffer = null;
+      if (isNonSpeechSegment(text)) {
+        // 在声音说明开始处结束前一个语音片段，保留真实静音间隔供后续断句判断。
+        flushBuffer(start);
+        filteredNonSpeechCount += 1;
+        continue;
       }
 
-      buffer = {
-        text,
-        start,
-      };
-
-      if (j === segs.length - 1) {
+      flushBuffer(start);
+      buffer = { text, start };
+      if (index === normalizedSegs.length - 1) {
         buffer.end = tStartMs + dDurationMs;
       }
-    });
-  });
-
-  if (buffer) {
-    if (buffer.end > buffer.start) {
-      segments.push(buffer);
     }
   }
 
-  return segments.filter(
-    (s) => s && typeof s.start === "number" && s.end > s.start
-  );
+  flushBuffer(buffer?.end);
+
+  return {
+    events,
+    flatEvents: flatEvents.filter(
+      (item) =>
+        item &&
+        Number.isFinite(item.start) &&
+        Number.isFinite(item.end) &&
+        item.end > item.start
+    ),
+    filteredNonSpeechCount,
+  };
 }
 
 /**
@@ -352,9 +329,19 @@ export function formatSubtitles(
 
     let currentLine = null;
     const MAX_LENGTH = 30;
+    const PAUSE_THRESHOLD_MS = 1000;
 
     for (const segment of flatEvents) {
       if (segment.text) {
+        // 无标点字幕遇到明显静音时先结束上一句，避免跨越长停顿合并。
+        if (
+          currentLine &&
+          segment.start - currentLine.end > PAUSE_THRESHOLD_MS
+        ) {
+          subtitles.push(currentLine);
+          currentLine = null;
+        }
+
         if (!currentLine) {
           currentLine = {
             text: segment.text,
@@ -366,7 +353,11 @@ export function formatSubtitles(
           currentLine.end = segment.end;
         }
 
-        if (currentLine.text.length >= MAX_LENGTH) {
+        // 中文和日文句末可能带引号或括号，仍应在当前时间事件处立即落句。
+        const isEndOfSentence = /[。！？.!?…][”’"'」』】）》）\]]*$/.test(
+          segment.text
+        );
+        if (isEndOfSentence || currentLine.text.length >= MAX_LENGTH) {
           subtitles.push(currentLine);
           currentLine = null;
         }
@@ -448,20 +439,46 @@ export function algorithmicSegment(events) {
  * @returns {Array<object>} 格式化后的字幕条目。
  */
 export function builtinSegment(events, flatEvents, fromLang, setting = {}) {
-  const { useAlgorithmBreaker } = setting;
+  return runBuiltinSegmentation({
+    events,
+    flatEvents,
+    fromLang,
+    mode: setting.useAlgorithmBreaker,
+    longSentenceThreshold: setting.longSentenceThreshold,
+  });
+}
 
-  if (useAlgorithmBreaker === "statistical") {
+/**
+ * 统一运行规则或统计算法，并始终返回标准 SubtitleCue 结构。
+ */
+export function runBuiltinSegmentation({
+  events = [],
+  flatEvents = [],
+  fromLang = "auto",
+  mode = "rule",
+  longSentenceThreshold = 120,
+} = {}) {
+  const toCues = (items) =>
+    (items || []).map((item) => ({
+      start: item.start,
+      end: item.end,
+      text: item.text,
+      translation: item.translation || "",
+    }));
+
+  if (mode === "statistical") {
     logger.info("Youtube Provider: Sentence break mode: STATISTICAL");
     const result = algorithmicSegment(events);
-    if (result?.length) return result;
-    logger.info("Youtube Provider: Statistical segmentation returned empty");
-    return [];
+    if (result?.length) return toCues(result);
+    logger.info(
+      "Youtube Provider: Statistical segmentation returned empty, falling back to rule"
+    );
   }
 
   logger.info("Youtube Provider: Sentence break mode: RULE");
-  return formatSubtitles(flatEvents, fromLang, {
-    longSentenceThreshold: setting.longSentenceThreshold,
-  });
+  return toCues(
+    formatSubtitles(flatEvents, fromLang, { longSentenceThreshold })
+  );
 }
 
 /**
@@ -479,42 +496,43 @@ export function splitEventsIntoChunks(flatEvents, chunkLength = 1000) {
   const eventChunks = [];
   let currentChunk = [];
   let currentChunkTextLength = 0;
-  const MAX_CHUNK_LENGTH = chunkLength + 500;
+  const maxChunkLength = Math.max(1, Number(chunkLength) || 1000);
+  const preferredBoundaryLength = Math.floor(maxChunkLength * 0.8);
   const PAUSE_THRESHOLD_MS = 1000;
+
+  const flushChunk = () => {
+    if (!currentChunk.length) return;
+    eventChunks.push(currentChunk);
+    currentChunk = [];
+    currentChunkTextLength = 0;
+  };
 
   for (let i = 0; i < flatEvents.length; i++) {
     const event = flatEvents[i];
-    currentChunk.push(event);
-    currentChunkTextLength += event.text.length;
+    const eventLength = String(event?.text || "").length;
 
-    const isLastEvent = i === flatEvents.length - 1;
-    if (isLastEvent) {
-      continue;
+    if (
+      currentChunk.length &&
+      currentChunkTextLength + eventLength > maxChunkLength
+    ) {
+      flushChunk();
     }
 
-    let shouldSplit = false;
+    currentChunk.push(event);
+    currentChunkTextLength += eventLength;
 
-    if (currentChunkTextLength >= MAX_CHUNK_LENGTH) {
-      shouldSplit = true;
-    } else if (currentChunkTextLength >= chunkLength) {
+    const isLastEvent = i === flatEvents.length - 1;
+    if (!isLastEvent && currentChunkTextLength >= preferredBoundaryLength) {
       const isEndOfSentence = /[.?!…\])]$/.test(event.text);
       const nextEvent = flatEvents[i + 1];
       const pauseDuration = nextEvent.start - event.end;
       if (isEndOfSentence || pauseDuration > PAUSE_THRESHOLD_MS) {
-        shouldSplit = true;
+        flushChunk();
       }
     }
-
-    if (shouldSplit) {
-      eventChunks.push(currentChunk);
-      currentChunk = [];
-      currentChunkTextLength = 0;
-    }
   }
 
-  if (currentChunk.length > 0) {
-    eventChunks.push(currentChunk);
-  }
+  flushChunk();
 
   return eventChunks;
 }

--- a/src/subtitle/youtubeSubtitleProcessing.test.js
+++ b/src/subtitle/youtubeSubtitleProcessing.test.js
@@ -1,10 +1,13 @@
+import fs from "fs";
+import path from "path";
 import {
   cleanTimedText,
   formatSubtitles,
-  genFlatEvents,
-  normalizeTimedTextEvents,
+  prepareTimedTextEvents,
+  runBuiltinSegmentation,
   splitEventsIntoChunks,
 } from "./youtubeSubtitleProcessing.js";
+import { isNonSpeechSegment } from "./subtitleTextClassification.js";
 
 jest.mock("../config", () => ({
   OPT_LANGS_SPEC_DEFAULT: new Map(),
@@ -22,6 +25,18 @@ jest.mock("../libs/log.js", () => ({
 }));
 
 describe("youtubeSubtitleProcessing", () => {
+  test.each([
+    ["[Music]", true],
+    ["[music]", true],
+    ["[Laughter]", true],
+    ["[Music] [Applause]", true],
+    [">> [music]", true],
+    ["Use [React] in this project", false],
+    ["normal dialogue", false],
+  ])("classifies non-speech segment %s", (text, expected) => {
+    expect(isNonSpeechSegment(text)).toBe(expected);
+  });
+
   test("cleans timedtext html, U+200B and duplicate whitespace", () => {
     expect(cleanTimedText(" <b>Hello</b>\u200B   world ")).toBe("Hello world");
   });
@@ -34,7 +49,7 @@ describe("youtubeSubtitleProcessing", () => {
       segs: [{ utf8: "\n" }],
     };
 
-    expect(normalizeTimedTextEvents([lineBreak])).toEqual([lineBreak]);
+    expect(prepareTimedTextEvents([lineBreak]).events).toEqual([lineBreak]);
   });
 
   test("deduplicates repeated visible timedtext events", () => {
@@ -44,7 +59,9 @@ describe("youtubeSubtitleProcessing", () => {
       segs: [{ utf8: "hello" }],
     };
 
-    expect(normalizeTimedTextEvents([event, { ...event }])).toHaveLength(1);
+    expect(prepareTimedTextEvents([event, { ...event }]).events).toHaveLength(
+      1
+    );
   });
 
   test("generates flat events with start and end timestamps", () => {
@@ -59,10 +76,127 @@ describe("youtubeSubtitleProcessing", () => {
       },
     ];
 
-    expect(genFlatEvents(events)).toEqual([
+    expect(prepareTimedTextEvents(events).flatEvents).toEqual([
       { text: "hello", start: 1000, end: 1500 },
       { text: "world", start: 1500, end: 2000 },
     ]);
+  });
+
+  test("filters a non-speech segment inside a mixed event and keeps its time gap", () => {
+    const prepared = prepareTimedTextEvents([
+      {
+        tStartMs: 1000,
+        dDurationMs: 1000,
+        segs: [
+          { utf8: "hello" },
+          { utf8: " [Music]", tOffsetMs: 300 },
+          { utf8: " world", tOffsetMs: 500 },
+        ],
+      },
+    ]);
+
+    expect(prepared.events[0].segs).toHaveLength(3);
+    expect(prepared.flatEvents).toEqual([
+      { text: "hello", start: 1000, end: 1300 },
+      { text: "world", start: 1500, end: 2000 },
+    ]);
+    expect(prepared.filteredNonSpeechCount).toBe(1);
+  });
+
+  test("filters non-speech without dropping following speech when a newline timestamp moves backwards", () => {
+    const rawEvents = [
+      {
+        tStartMs: 1000,
+        dDurationMs: 1000,
+        segs: [{ utf8: "[Music]", tOffsetMs: 500 }],
+      },
+      {
+        tStartMs: 1490,
+        dDurationMs: 100,
+        aAppend: 1,
+        segs: [{ utf8: "\n" }],
+      },
+      {
+        tStartMs: 1600,
+        dDurationMs: 400,
+        segs: [{ utf8: "hello" }],
+      },
+    ];
+
+    expect(prepareTimedTextEvents(rawEvents).flatEvents).toEqual([
+      { text: "hello", start: 1600, end: 2000 },
+    ]);
+  });
+
+  test.each(["rule", "statistical"])(
+    "%s segmentation excludes non-speech cues",
+    (mode) => {
+      const prepared = prepareTimedTextEvents([
+        {
+          tStartMs: 0,
+          dDurationMs: 500,
+          segs: [{ utf8: "Hello" }],
+        },
+        {
+          tStartMs: 500,
+          dDurationMs: 400,
+          segs: [{ utf8: "[Music]" }],
+        },
+        {
+          tStartMs: 900,
+          dDurationMs: 600,
+          segs: [{ utf8: "world." }],
+        },
+      ]);
+      const cues = runBuiltinSegmentation({
+        ...prepared,
+        fromLang: "en",
+        mode,
+      });
+
+      expect(cues).not.toHaveLength(0);
+      expect(cues.every((cue) => !isNonSpeechSegment(cue.text))).toBe(true);
+      expect(cues.map((cue) => cue.text).join(" ")).toContain("Hello world.");
+    }
+  );
+
+  test("restores complete rule-segmented sentences around music markers in the real sample", () => {
+    const source = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "testdata/subtitle-samples/english-asr-zero-pause.json"
+        ),
+        "utf8"
+      )
+    );
+    const prepared = prepareTimedTextEvents(source.events || source);
+    const cues = runBuiltinSegmentation({
+      ...prepared,
+      fromLang: "en",
+      mode: "rule",
+      // 本断言只验证音乐标记不再制造边界，避免被独立的超长句二次切分规则干扰。
+      longSentenceThreshold: 1000,
+    });
+
+    expect(prepared.filteredNonSpeechCount).toBe(13);
+    expect(cues).toEqual(
+      expect.arrayContaining([
+        {
+          start: 24840,
+          end: 33800,
+          text: "You have characters, locations, shots, dialogue, and somehow all of those pieces need to stay organized while you're building the story.",
+          translation: "",
+        },
+        {
+          start: 33800,
+          end: 36360,
+          text: "This is where Storyboard Studio comes in.",
+          translation: "",
+        },
+      ])
+    );
+    expect(cues.every((cue) => !/\[music\]/i.test(cue.text))).toBe(true);
   });
 
   test("splits chunks on sentence boundary after target length", () => {
@@ -72,11 +206,68 @@ describe("youtubeSubtitleProcessing", () => {
         { text: "world.", start: 100, end: 200 },
         { text: "again", start: 200, end: 300 },
       ],
-      10
+      12
     );
 
     expect(chunks).toHaveLength(2);
     expect(chunks[0].map((item) => item.text)).toEqual(["hello", "world."]);
+  });
+
+  test("treats chunkLength as a hard limit except for one oversized event", () => {
+    const chunks = splitEventsIntoChunks(
+      [
+        { text: "1234", start: 0, end: 100 },
+        { text: "5678", start: 100, end: 200 },
+        { text: "oversized", start: 200, end: 300 },
+      ],
+      5
+    );
+
+    expect(chunks.map((chunk) => chunk.map((event) => event.text))).toEqual([
+      ["1234"],
+      ["5678"],
+      ["oversized"],
+    ]);
+  });
+
+  test("splits the zero-pause ASR sample into five chunks at the new default", () => {
+    const source = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "testdata/subtitle-samples/english-asr-zero-pause.json"
+        ),
+        "utf8"
+      )
+    );
+    const prepared = prepareTimedTextEvents(source.events || source);
+
+    const chunks = splitEventsIntoChunks(prepared.flatEvents, 1000);
+
+    expect(chunks).toHaveLength(5);
+    // 除单个超限事件外，分块器必须继续遵守 1000 字符硬上限。
+    expect(
+      chunks.every(
+        (chunk) =>
+          chunk.reduce(
+            (length, event) => length + String(event.text || "").length,
+            0
+          ) <= 1000
+      )
+    ).toBe(true);
+  });
+
+  test("falls back to rule segmentation when statistical output is empty", () => {
+    const flatEvents = [{ text: "hello.", start: 0, end: 1000 }];
+
+    expect(
+      runBuiltinSegmentation({
+        events: [],
+        flatEvents,
+        fromLang: "en",
+        mode: "statistical",
+      })
+    ).toEqual([{ text: "hello.", start: 0, end: 1000, translation: "" }]);
   });
 
   test("reprocesses overlong space-separated subtitles with pause rules", () => {
@@ -92,5 +283,53 @@ describe("youtubeSubtitleProcessing", () => {
 
     expect(subtitles.length).toBeGreaterThan(1);
     expect(subtitles[0].text).toContain("First,");
+  });
+
+  test.each([
+    [
+      "zh-CN",
+      "chinese-asr.json",
+      ["今天我们测试中文字幕断句。", "这里不应该插入多余空格。"],
+    ],
+    [
+      "ja",
+      "japanese-asr.json",
+      ["今日は字幕の区切りを確認します。", "自然な表示になるでしょうか。"],
+    ],
+  ])(
+    "splits %s rule subtitles at native sentence punctuation",
+    (lang, file, texts) => {
+      const source = JSON.parse(
+        fs.readFileSync(
+          path.join(process.cwd(), "testdata/subtitle-samples", file),
+          "utf8"
+        )
+      );
+      const prepared = prepareTimedTextEvents(source.events || source);
+
+      expect(
+        runBuiltinSegmentation({
+          ...prepared,
+          fromLang: lang,
+          mode: "rule",
+        }).map((cue) => cue.text)
+      ).toEqual(texts);
+    }
+  );
+
+  test("splits no-space-language subtitles at a long pause without punctuation", () => {
+    // 对无标点的自动字幕，超过一秒的静音仍应形成明确边界。
+    expect(
+      formatSubtitles(
+        [
+          { text: "第一段字幕", start: 0, end: 1000 },
+          { text: "第二段字幕", start: 2200, end: 3200 },
+        ],
+        "zh-CN"
+      )
+    ).toEqual([
+      { text: "第一段字幕", start: 0, end: 1000 },
+      { text: "第二段字幕", start: 2200, end: 3200 },
+    ]);
   });
 });

--- a/src/views/Options/Playground.js
+++ b/src/views/Options/Playground.js
@@ -1,11 +1,16 @@
 import { useMemo, useState } from "react";
+import Box from "@mui/material/Box";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
 import TranForm from "../Selection/TranForm";
+import SubtitleSegmentationPlayground from "./SubtitleSegmentationPlayground";
 import {
   DEFAULT_SETTING,
   DEFAULT_TRANBOX_SETTING,
   resolveApiPromptList,
 } from "../../config";
 import { useSetting } from "../../hooks/Setting";
+import { useI18n } from "../../hooks/I18n";
 
 /**
  * 翻译测试沙盒游乐场组件 (Playground)
@@ -14,6 +19,9 @@ import { useSetting } from "../../hooks/Setting";
 export default function Playgound() {
   // 当前输入的测试文本状态
   const [text, setText] = useState("");
+  // Playground 内的页签状态只影响页面展示，不写入用户设置。
+  const [activeTab, setActiveTab] = useState("translation");
+  const i18n = useI18n();
   // 从全局钩子中读取设置
   const { setting } = useSetting();
   // 解构获取当前翻译服务配置列表与语言检测器
@@ -35,22 +43,49 @@ export default function Playgound() {
     aiDictPromptSlug,
   } = tranboxSetting || DEFAULT_TRANBOX_SETTING;
   return (
-    <TranForm
-      text={text}
-      setText={setText}
-      apiSlugs={apiSlugs}
-      fromLang={fromLang}
-      toLang={toLang}
-      toLang2={toLang2}
-      transApis={resolvedTransApis}
-      simpleStyle={false}
-      langDetector={langDetector}
-      enDict={enDict}
-      enSug={enSug}
-      aiDictApiSlug={aiDictApiSlug}
-      aiDictPromptSlug={aiDictPromptSlug}
-      prompts={prompts}
-      isPlaygound={true} // 标识为 Playground 环境以进行特定的渲染样式和交互处理
-    />
+    <Box>
+      <Tabs
+        value={activeTab}
+        onChange={(_, value) => setActiveTab(value)}
+        sx={{ mb: 2 }}
+      >
+        <Tab
+          value="translation"
+          label={i18n("playground_text_translation", "文本翻译")}
+        />
+        <Tab
+          value="segmentation"
+          label={i18n("subtitle_segmentation", "字幕断句")}
+        />
+      </Tabs>
+
+      {activeTab === "translation" && (
+        <TranForm
+          text={text}
+          setText={setText}
+          apiSlugs={apiSlugs}
+          fromLang={fromLang}
+          toLang={toLang}
+          toLang2={toLang2}
+          transApis={resolvedTransApis}
+          simpleStyle={false}
+          langDetector={langDetector}
+          enDict={enDict}
+          enSug={enSug}
+          aiDictApiSlug={aiDictApiSlug}
+          aiDictPromptSlug={aiDictPromptSlug}
+          prompts={prompts}
+          isPlaygound={true} // 标识为 Playground 环境以进行特定的渲染样式和交互处理
+        />
+      )}
+
+      {activeTab === "segmentation" && (
+        <SubtitleSegmentationPlayground
+          subtitleSetting={subtitleSetting}
+          transApis={resolvedTransApis}
+          prompts={prompts}
+        />
+      )}
+    </Box>
   );
 }

--- a/src/views/Options/Playground.test.js
+++ b/src/views/Options/Playground.test.js
@@ -1,0 +1,51 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import Playground from "./Playground";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock("../../hooks/Setting", () => ({
+  useSetting: () => ({
+    setting: {
+      transApis: [],
+      prompts: [],
+      subtitleSetting: {},
+      tranboxSetting: {},
+    },
+  }),
+}));
+
+// 子组件使用轻量替身，当前测试只关注 Playground 的页签归属和切换行为。
+jest.mock("../Selection/TranForm", () => {
+  const React = require("react");
+  return () => React.createElement("div", { "data-testid": "translation-tab" });
+});
+
+jest.mock("./SubtitleSegmentationPlayground", () => {
+  const React = require("react");
+  return () =>
+    React.createElement("div", { "data-testid": "segmentation-tab" });
+});
+
+test("moves the existing translator into the text tab and exposes segmentation testing", async () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  expect(
+    container.querySelector('[data-testid="translation-tab"]')
+  ).not.toBeNull();
+  const segmentationTab = [...container.querySelectorAll('[role="tab"]')].find(
+    (tab) => tab.textContent === "字幕断句"
+  );
+  await act(async () => {
+    segmentationTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+
+  expect(container.querySelector('[data-testid="translation-tab"]')).toBeNull();
+  expect(
+    container.querySelector('[data-testid="segmentation-tab"]')
+  ).not.toBeNull();
+  act(() => root.unmount());
+});

--- a/src/views/Options/Setting.js
+++ b/src/views/Options/Setting.js
@@ -190,8 +190,11 @@ export default function Settings() {
     skipLangs = [],
   } = setting;
   // 解构 FAB 悬浮球的显隐状态及点击后的默认交互行为
-  const { isHide = false, fabClickAction = 0, hideExceptionList = "" } =
-    fab || {};
+  const {
+    isHide = false,
+    fabClickAction = 0,
+    hideExceptionList = "",
+  } = fab || {};
 
   return (
     <Box>

--- a/src/views/Options/SubtitleSegmentationPlayground.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.js
@@ -1,0 +1,1016 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Grid from "@mui/material/Grid";
+import LinearProgress from "@mui/material/LinearProgress";
+import MenuItem from "@mui/material/MenuItem";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Typography from "@mui/material/Typography";
+import DownloadIcon from "@mui/icons-material/Download";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import StopIcon from "@mui/icons-material/Stop";
+import UploadFileIcon from "@mui/icons-material/UploadFile";
+import {
+  DEFAULT_SUBTITLE_PROMPT_SLUG,
+  findPromptBySlug,
+  isPresetPromptSlug,
+  OPT_LANGS_FROM_REVERSED as OPT_LANGS_FROM,
+  PROMPT_MODE_GLOBAL,
+} from "../../config";
+import { detectSubtitleProtocol, handleSubtitle } from "../../apis/trans";
+import { useConfirm } from "../../hooks/Confirm";
+import { useI18n } from "../../hooks/I18n";
+import { downloadBlobFile } from "../../libs/utils";
+import { aiSegment } from "../../subtitle/youtubeAiSegmentation";
+import {
+  formatSubtitles,
+  prepareTimedTextEvents,
+  runBuiltinSegmentation,
+  splitEventsIntoChunks,
+} from "../../subtitle/youtubeSubtitleProcessing";
+import {
+  buildSegmentationMetrics,
+  getSegmentationMetricErrors,
+} from "../../subtitle/subtitleSegmentationMetrics";
+import { DEFAULT_PARAMS } from "../../subtitle/sentenceBreaker";
+import { buildBilingualVtt } from "../../subtitle/vtt";
+
+const SAMPLE_BASE_URL = `${process.env.REACT_APP_SITEURL}/subtitle-samples`;
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_UPLOAD_EVENTS = 100000;
+// 原始数据和结果框默认显示五行，并允许用户从右下角按需拉高查看区域。
+const RESIZABLE_TEXT_FIELD_SX = {
+  "& textarea": {
+    resize: "vertical !important",
+    overflow: "auto !important",
+  },
+};
+
+/** 用命名占位符组装包含运行时数据的多语言文案。 */
+function formatI18n(i18n, key, fallback, values = {}) {
+  return Object.entries(values).reduce(
+    (text, [name, value]) =>
+      text.split(`{${name}}`).join(value === undefined ? "" : String(value)),
+    i18n(key, fallback)
+  );
+}
+
+/** 从裸数组或 `{events, lang}` 包装对象中提取测试事件。 */
+function parseSubtitleSource(value, i18n = (_, fallback) => fallback) {
+  const events = Array.isArray(value) ? value : value?.events;
+  if (!Array.isArray(events) || !events.length) {
+    throw new Error(
+      i18n(
+        "subtitle_playground_invalid_events",
+        "字幕文件没有有效的 events 数组"
+      )
+    );
+  }
+  if (events.length > MAX_UPLOAD_EVENTS) {
+    throw new Error(
+      formatI18n(
+        i18n,
+        "subtitle_playground_event_limit",
+        "字幕事件数量不能超过 {max}",
+        { max: MAX_UPLOAD_EVENTS }
+      )
+    );
+  }
+  if (!events.some((event) => Array.isArray(event?.segs))) {
+    throw new Error(
+      i18n(
+        "subtitle_playground_missing_segments",
+        "字幕文件缺少 YouTube json3 的 segs 数据"
+      )
+    );
+  }
+  return { events, lang: Array.isArray(value) ? "" : value.lang || "" };
+}
+
+/** 在浏览器中验证远程样本内容，避免缓存或发布错误导致测试数据损坏。 */
+async function verifyRemoteSample(
+  buffer,
+  sample,
+  i18n = (_, fallback) => fallback
+) {
+  if (buffer.byteLength !== sample.size) {
+    throw new Error(
+      i18n(
+        "subtitle_playground_remote_size_invalid",
+        "远程字幕样本大小校验失败"
+      )
+    );
+  }
+  if (!globalThis.crypto?.subtle?.digest) return;
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", buffer);
+  const hex = [...new Uint8Array(digest)]
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+  if (hex !== sample.sha256) {
+    throw new Error(
+      i18n(
+        "subtitle_playground_remote_hash_invalid",
+        "远程字幕样本哈希校验失败"
+      )
+    );
+  }
+}
+
+/** 把测试结果裁剪为播放器和下载文件使用的公开字幕结构。 */
+const toPublicCues = (cues) =>
+  (cues || []).map(({ start, end, text, translation = "" }) => ({
+    start,
+    end,
+    text,
+    translation,
+  }));
+
+/** 判断带内部索引的 AI 结果是否从 0 连续覆盖到请求事件末尾。 */
+function hasCompleteIndexedCoverage(cues, eventCount) {
+  if (!Array.isArray(cues) || !cues.length) return false;
+  const hasIndices = cues.some(
+    (cue) => Number.isInteger(cue?._ei) || Number.isInteger(cue?._alignedEi)
+  );
+  // VTT 旧协议没有索引，仍交由时间轴结构指标检查。
+  if (!hasIndices) return true;
+
+  let nextIndex = 0;
+  for (const cue of cues) {
+    const startIndex = cue._alignedSi ?? cue._si;
+    const endIndex = cue._alignedEi ?? cue._ei;
+    if (startIndex !== nextIndex || endIndex < startIndex) return false;
+    nextIndex = endIndex + 1;
+  }
+  return nextIndex === eventCount;
+}
+
+/** 字幕断句工作台，所有配置只读取当前字幕设置，不单独持久化。 */
+export default function SubtitleSegmentationPlayground({
+  subtitleSetting = {},
+  transApis = [],
+  prompts = [],
+}) {
+  const confirm = useConfirm();
+  const i18n = useI18n();
+  const [catalog, setCatalog] = useState([]);
+  const [sampleId, setSampleId] = useState("");
+  const [sampleName, setSampleName] = useState("uploaded");
+  const [fromLang, setFromLang] = useState("en");
+  const [sourceValue, setSourceValue] = useState(null);
+  const [sourceText, setSourceText] = useState("");
+  const [result, setResult] = useState(null);
+  const [metrics, setMetrics] = useState(null);
+  const [resultFormat, setResultFormat] = useState("json");
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(null);
+  const [error, setError] = useState("");
+  const [showLanguageRequired, setShowLanguageRequired] = useState(false);
+  const abortRef = useRef(null);
+  const languageSelectRef = useRef(null);
+  // 索引只应拉取一次，通过 ref 读取当前语言，避免翻译函数变化导致重复请求。
+  const i18nRef = useRef(i18n);
+  i18nRef.current = i18n;
+
+  const segApi = useMemo(
+    () =>
+      subtitleSetting?.segSlug && subtitleSetting.segSlug !== "-"
+        ? transApis.find((api) => api.apiSlug === subtitleSetting.segSlug)
+        : null,
+    [subtitleSetting?.segSlug, transApis]
+  );
+  const mode = segApi
+    ? "ai"
+    : subtitleSetting?.useAlgorithmBreaker === "statistical"
+      ? "statistical"
+      : "rule";
+  const effectivePromptSlug =
+    subtitleSetting?.segPromptMode === PROMPT_MODE_GLOBAL
+      ? subtitleSetting?.segPromptSlug || DEFAULT_SUBTITLE_PROMPT_SLUG
+      : segApi?.subtitlePromptSlug || DEFAULT_SUBTITLE_PROMPT_SLUG;
+  const effectivePrompt = findPromptBySlug(prompts, effectivePromptSlug);
+  const promptSource =
+    subtitleSetting?.segPromptMode === PROMPT_MODE_GLOBAL
+      ? i18n("subtitle_playground_prompt_global", "全局字幕设置")
+      : isPresetPromptSlug(effectivePromptSlug)
+        ? i18n("subtitle_playground_prompt_preset", "接口预设")
+        : i18n("subtitle_playground_prompt_custom", "接口自定义");
+  const aiProtocol = detectSubtitleProtocol(segApi?.subtitlePrompt || "");
+  const prepared = useMemo(() => {
+    if (!sourceValue) return null;
+    try {
+      return prepareTimedTextEvents(parseSubtitleSource(sourceValue).events);
+    } catch {
+      return null;
+    }
+  }, [sourceValue]);
+  const estimatedChunkCount = segApi
+    ? splitEventsIntoChunks(
+        prepared?.flatEvents || [],
+        subtitleSetting?.chunkLength || 1000
+      ).length
+    : 0;
+  // AI 可以结合完整文本自动识别语言；内置规则和统计模式必须使用明确语言。
+  const requiresExplicitLanguage =
+    Boolean(sourceValue) && !segApi && fromLang === "auto";
+
+  // 页面加载时只拉取轻量索引，实际样本等用户选择后再下载。
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${SAMPLE_BASE_URL}/index.json?v=${process.env.REACT_APP_VERSION}`, {
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then((value) => setCatalog(value.samples || []))
+      .catch((fetchError) => {
+        if (fetchError.name !== "AbortError") {
+          setError(
+            i18nRef.current(
+              "subtitle_playground_remote_index_failed",
+              "远程字幕样本索引加载失败，可以继续上传本地 JSON"
+            )
+          );
+        }
+      });
+    return () => controller.abort();
+  }, []);
+
+  // 切换 Playground 页签或离开页面时取消仍在进行的样本下载和 AI 请求。
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const selectRemoteSample = async (id) => {
+    abortRef.current?.abort();
+    setSampleId(id);
+    setResult(null);
+    setMetrics(null);
+    setShowLanguageRequired(false);
+    if (!id) return;
+    const sample = catalog.find((item) => item.id === id);
+    if (!sample) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setProgress(null);
+    setError("");
+    try {
+      const response = await fetch(
+        `${SAMPLE_BASE_URL}/${sample.path}?hash=${sample.sha256.slice(0, 16)}`,
+        { signal: controller.signal }
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const buffer = await response.arrayBuffer();
+      await verifyRemoteSample(buffer, sample, i18n);
+      const text = new TextDecoder().decode(buffer);
+      const value = JSON.parse(text);
+      parseSubtitleSource(value, i18n);
+      setSourceValue(value);
+      setSourceText(JSON.stringify(value, null, 2));
+      setSampleName(sample.id);
+      setFromLang(sample.language || "auto");
+    } catch (loadError) {
+      if (loadError.name !== "AbortError") {
+        setError(
+          formatI18n(
+            i18n,
+            "subtitle_playground_sample_load_failed",
+            "字幕样本加载失败：{message}",
+            { message: loadError.message }
+          )
+        );
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
+    }
+  };
+
+  const uploadSample = async (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+    setError("");
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setError(
+        i18n("subtitle_playground_file_too_large", "字幕文件不能超过 10MB")
+      );
+      return;
+    }
+    try {
+      const text = await file.text();
+      const value = JSON.parse(text);
+      parseSubtitleSource(value, i18n);
+      setSourceValue(value);
+      setSourceText(JSON.stringify(value, null, 2));
+      setSampleId("");
+      setSampleName(file.name.replace(/\.json$/i, "") || "uploaded");
+      // 本地文件来源不可验证，先重置为 AutoDetect；内置模式会要求用户再明确选择。
+      setFromLang("auto");
+      setResult(null);
+      setMetrics(null);
+      setShowLanguageRequired(false);
+    } catch (uploadError) {
+      setError(
+        formatI18n(
+          i18n,
+          "subtitle_playground_file_parse_failed",
+          "字幕文件解析失败：{message}",
+          { message: uploadError.message }
+        )
+      );
+    }
+  };
+
+  const runTest = async () => {
+    if (!sourceValue || !prepared || loading) return;
+    if (requiresExplicitLanguage) {
+      // 点击运行后再提示具体语言，并把焦点移到需要处理的字段。
+      setShowLanguageRequired(true);
+      languageSelectRef.current?.focus();
+      return;
+    }
+    if (segApi) {
+      const confirmed = await confirm({
+        title: i18n("subtitle_playground_ai_confirm_title", "发送 AI 断句请求"),
+        message: formatI18n(
+          i18n,
+          "subtitle_playground_ai_confirm_message",
+          "将使用 {api} / {model} 发送约 {count} 个字幕请求。样本文本会发送到当前 AI 服务。",
+          {
+            api: segApi.apiName || segApi.apiSlug,
+            model:
+              segApi.model ||
+              i18n("subtitle_playground_default_model", "默认模型"),
+            count: estimatedChunkCount,
+          }
+        ),
+        confirmText: i18n("subtitle_playground_continue", "继续"),
+        cancelText: i18n("cancel", "取消"),
+      });
+      if (!confirmed) return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setResult(null);
+    setMetrics(null);
+    setError("");
+    const startedAt = performance.now();
+
+    try {
+      const rawEvents = parseSubtitleSource(sourceValue, i18n).events;
+      let cues = [];
+      let aiMetrics = null;
+
+      if (segApi) {
+        const chunks = splitEventsIntoChunks(
+          prepared.flatEvents,
+          subtitleSetting?.chunkLength || 1000
+        );
+        setProgress({ completed: 0, total: chunks.length });
+        let requestCount = 0;
+        let invalidResponseCount = 0;
+        let streamedChunkCues = [];
+        // 请求函数必须定义在 chunk 循环外，避免每轮创建闭包并触发 CI 的 no-loop-func 校验。
+        const runAiSubtitleRequest = async (params) => {
+          requestCount += 1;
+          const response = await handleSubtitle({
+            events: params.events,
+            from: params.fromLang,
+            to: params.toLang,
+            apiSetting: params.apiSetting,
+            docInfo: params.docInfo,
+            onSubtitleChunk: params.onSubtitleChunk,
+            signal: params.signal,
+          });
+          if (!hasCompleteIndexedCoverage(response, params.events.length)) {
+            invalidResponseCount += 1;
+          }
+          return response;
+        };
+        // 流式响应只包含本次新闭合的字幕，需要与已完成 chunk 合并后再刷新右侧预览。
+        const publishStreamedCues = ({ subtitles }) => {
+          streamedChunkCues.push(...(subtitles || []));
+          setResult(
+            toPublicCues([...cues, ...streamedChunkCues]).sort(
+              (a, b) => a.start - b.start
+            )
+          );
+        };
+
+        for (const [chunkIndex, chunkEvents] of chunks.entries()) {
+          streamedChunkCues = [];
+          // 测试页顺序跑完所有 chunk，不采用播放器的按需预加载调度。
+          const chunkCues = await aiSegment({
+            videoId: `subtitle-playground-${sampleName}-${chunkIndex}`,
+            fromLang,
+            toLang: subtitleSetting?.toLang,
+            chunkEvents,
+            segApiSetting: segApi,
+            apiSubtitle: runAiSubtitleRequest,
+            docInfo: {
+              title: i18n("subtitle_segmentation", "字幕断句"),
+              description: "",
+              summary: "",
+            },
+            formatSubtitles: (events, lang) =>
+              formatSubtitles(events, lang, {
+                longSentenceThreshold:
+                  subtitleSetting?.longSentenceThreshold ?? 120,
+              }),
+            clearSegmentTranslation: false,
+            signal: controller.signal,
+            setting: { ...subtitleSetting, prompts },
+            onSubtitleChunk: publishStreamedCues,
+          });
+          cues.push(...chunkCues);
+          // 完整 chunk 返回后以校验后的最终结果覆盖临时流式预览。
+          setResult(toPublicCues(cues).sort((a, b) => a.start - b.start));
+          setProgress({ completed: chunkIndex + 1, total: chunks.length });
+        }
+
+        const fallbackCueCount = cues.filter(
+          (cue) => !Number.isInteger(cue._ei)
+        ).length;
+        aiMetrics = {
+          protocol: aiProtocol,
+          chunkCount: chunks.length,
+          requestCount,
+          retryCount: Math.max(0, requestCount - chunks.length),
+          fallbackCueCount,
+          invalidResponseCount,
+        };
+      } else {
+        cues = runBuiltinSegmentation({
+          events: prepared.events,
+          flatEvents: prepared.flatEvents,
+          fromLang,
+          mode,
+          longSentenceThreshold: subtitleSetting?.longSentenceThreshold ?? 120,
+        });
+      }
+
+      const publicCues = toPublicCues(cues).sort((a, b) => a.start - b.start);
+      const nextMetrics = buildSegmentationMetrics({
+        rawEvents,
+        canonicalEvents: prepared.events,
+        flatEvents: prepared.flatEvents,
+        cues: publicCues,
+        fromLang,
+        processingMs: performance.now() - startedAt,
+        filteredNonSpeechCount: prepared.filteredNonSpeechCount,
+        ai: aiMetrics,
+      });
+      setResult(publicCues);
+      setMetrics({
+        ...nextMetrics,
+        errors: getSegmentationMetricErrors(nextMetrics),
+      });
+    } catch (runError) {
+      if (runError.name !== "AbortError") {
+        setError(
+          formatI18n(
+            i18n,
+            "subtitle_playground_test_failed",
+            "字幕断句失败：{message}",
+            { message: runError.message }
+          )
+        );
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+        setProgress(null);
+      }
+    }
+  };
+
+  const resultText = result
+    ? resultFormat === "vtt"
+      ? buildBilingualVtt(result)
+      : JSON.stringify(result, null, 2)
+    : "";
+
+  const downloadResult = () => {
+    if (!resultText) return;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    downloadBlobFile(
+      resultText,
+      `${sampleName}-${mode}-${timestamp}.${resultFormat}`
+    );
+  };
+
+  const configItems = segApi
+    ? [
+        [i18n("subtitle_playground_mode", "模式"), "AI"],
+        [
+          i18n("subtitle_playground_api", "API"),
+          segApi.apiName || segApi.apiSlug,
+        ],
+        [
+          i18n("subtitle_playground_type_model", "类型 / 模型"),
+          `${segApi.apiType || "-"} / ${segApi.model || "-"}`,
+        ],
+        [
+          i18n("subtitle_playground_prompt", "提示词"),
+          formatI18n(
+            i18n,
+            "subtitle_playground_prompt_value",
+            "{prompt}（{source}）",
+            {
+              prompt:
+                effectivePrompt?.name ||
+                effectivePromptSlug ||
+                i18n("subtitle_playground_api_default", "接口默认"),
+              source: promptSource,
+            }
+          ),
+        ],
+        [
+          i18n("subtitle_playground_chunk_length", "Chunk 长度"),
+          subtitleSetting?.chunkLength || 1000,
+        ],
+        [
+          i18n("subtitle_playground_estimated_chunks", "预计 Chunk"),
+          estimatedChunkCount,
+        ],
+        [
+          i18n("subtitle_playground_target_language", "目标语言"),
+          subtitleSetting?.toLang || "-",
+        ],
+        [
+          i18n("subtitle_playground_streaming", "流式"),
+          segApi.useStream
+            ? i18n("subtitle_playground_enabled", "启用")
+            : i18n("subtitle_playground_disabled", "关闭"),
+        ],
+        [
+          i18n("subtitle_playground_protocol", "协议"),
+          formatI18n(
+            i18n,
+            "subtitle_playground_protocol_value",
+            "{protocol}（{compatibility}）",
+            {
+              protocol: aiProtocol,
+              compatibility: i18n(
+                "subtitle_playground_legacy_compatible",
+                "兼容旧协议"
+              ),
+            }
+          ),
+        ],
+      ]
+    : mode === "statistical"
+      ? [
+          [
+            i18n("subtitle_playground_mode", "模式"),
+            i18n("subtitle_playground_statistical_mode", "统计断句"),
+          ],
+          [
+            i18n("subtitle_playground_max_duration", "最大时长"),
+            `${DEFAULT_PARAMS.maxDurationMs}ms`,
+          ],
+          [
+            i18n("subtitle_playground_max_words", "最大词数"),
+            DEFAULT_PARAMS.maxWords,
+          ],
+          [
+            i18n("subtitle_playground_min_boundary_score", "最小边界评分"),
+            DEFAULT_PARAMS.minBoundaryScore,
+          ],
+          [
+            i18n("subtitle_playground_min_sentence_words", "最小句子词数"),
+            DEFAULT_PARAMS.minSentenceWords,
+          ],
+          [i18n("subtitle_playground_source_language", "源语言"), fromLang],
+        ]
+      : [
+          [
+            i18n("subtitle_playground_mode", "模式"),
+            i18n("subtitle_playground_rule_mode", "规则断句"),
+          ],
+          [
+            i18n("subtitle_playground_long_sentence_threshold", "长句阈值"),
+            subtitleSetting?.longSentenceThreshold ?? 120,
+          ],
+          [i18n("subtitle_playground_source_language", "源语言"), fromLang],
+        ];
+
+  return (
+    <Stack spacing={2}>
+      {error && <Alert severity="warning">{error}</Alert>}
+      {segApi && Number(subtitleSetting?.chunkLength) > 1000 && (
+        <Alert severity="warning">
+          {i18n(
+            "subtitle_playground_chunk_risk",
+            "当前 AI Chunk 长度高于推荐默认值 1000，长输入可能增加漏句或边界退化风险。"
+          )}
+        </Alert>
+      )}
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="subtitle2" gutterBottom>
+          {i18n("subtitle_playground_config_title", "当前生效的断句配置")}
+        </Typography>
+        <Grid container spacing={1}>
+          {configItems.map(([label, value]) => (
+            <Grid item xs={6} md={3} key={label}>
+              <Typography variant="caption" color="text.secondary">
+                {label}
+              </Typography>
+              <Typography variant="body2">{String(value)}</Typography>
+            </Grid>
+          ))}
+        </Grid>
+      </Paper>
+
+      {/* 中等宽度下两个下拉框同排，按钮区跨满下一行，避免三列最小宽度撑出横向滚动条。 */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "minmax(0, 1fr)",
+            md: "repeat(2, minmax(0, 1fr))",
+          },
+          gap: 2,
+          alignItems: "start",
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <TextField
+            select
+            fullWidth
+            size="small"
+            label={i18n("subtitle_playground_builtin_sample", "内置字幕样本")}
+            value={sampleId}
+            disabled={loading}
+            onChange={(event) => selectRemoteSample(event.target.value)}
+          >
+            <MenuItem value="">
+              {i18n("subtitle_playground_select_sample", "请选择远程样本")}
+            </MenuItem>
+            {catalog.map((sample) => (
+              <MenuItem key={sample.id} value={sample.id}>
+                {sample.name}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <TextField
+            inputRef={languageSelectRef}
+            select
+            fullWidth
+            size="small"
+            label={i18n(
+              "subtitle_playground_source_language_label",
+              "字幕源语言"
+            )}
+            value={fromLang}
+            disabled={loading}
+            error={showLanguageRequired && requiresExplicitLanguage}
+            helperText={
+              showLanguageRequired && requiresExplicitLanguage
+                ? i18n(
+                    "subtitle_playground_language_required",
+                    "规则和统计断句不支持 AutoDetect，请选择具体的字幕源语言。"
+                  )
+                : ""
+            }
+            onChange={(event) => {
+              setFromLang(event.target.value);
+              setShowLanguageRequired(false);
+              // 源语言变化会改变断句语义，直接清空旧结果比显示“已过期”更明确。
+              setResult(null);
+              setMetrics(null);
+            }}
+          >
+            {OPT_LANGS_FROM.map(([code, name]) => (
+              <MenuItem key={code} value={code}>
+                {name}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+        <Box
+          sx={{ minWidth: 0, gridColumn: "1 / -1" }}
+          data-testid="segmentation-actions"
+        >
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            <Button
+              component="label"
+              variant="outlined"
+              startIcon={<UploadFileIcon />}
+              disabled={loading}
+            >
+              {i18n("subtitle_playground_upload_json", "上传 JSON")}
+              <input
+                hidden
+                type="file"
+                accept=".json,application/json"
+                onChange={uploadSample}
+              />
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={
+                loading ? <CircularProgress size={16} /> : <PlayArrowIcon />
+              }
+              disabled={!sourceValue || loading}
+              onClick={runTest}
+            >
+              {i18n("subtitle_playground_run", "运行测试")}
+            </Button>
+            <Button
+              variant="outlined"
+              color="warning"
+              startIcon={<StopIcon />}
+              disabled={!loading}
+              onClick={() => abortRef.current?.abort()}
+            >
+              {i18n("cancel", "取消")}
+            </Button>
+          </Stack>
+          {loading && progress && (
+            <Box
+              sx={{ mt: 1, width: "100%" }}
+              data-testid="segmentation-progress"
+            >
+              <LinearProgress
+                variant="determinate"
+                value={(progress.completed * 100) / Math.max(1, progress.total)}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {formatI18n(
+                  i18n,
+                  "subtitle_playground_progress",
+                  "正在处理 Chunk {completed}/{total}",
+                  progress
+                )}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "minmax(0, 1fr)",
+            md: "repeat(2, minmax(0, 1fr))",
+          },
+          gap: 2,
+          alignItems: "start",
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            {i18n("subtitle_playground_source_json", "原始字幕 JSON")}
+          </Typography>
+          <TextField
+            fullWidth
+            multiline
+            rows={5}
+            value={sourceText}
+            InputProps={{ readOnly: true }}
+            inputProps={{
+              "aria-label": i18n(
+                "subtitle_playground_source_json",
+                "原始字幕 JSON"
+              ),
+            }}
+            sx={RESIZABLE_TEXT_FIELD_SX}
+          />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            {i18n("subtitle_playground_result", "断句结果")}
+          </Typography>
+          <Box sx={{ position: "relative" }}>
+            <TextField
+              fullWidth
+              multiline
+              rows={5}
+              value={resultText}
+              InputProps={{ readOnly: true }}
+              inputProps={{
+                "aria-label": i18n("subtitle_playground_result", "断句结果"),
+              }}
+              sx={RESIZABLE_TEXT_FIELD_SX}
+            />
+            <Stack
+              direction="row"
+              spacing={0.5}
+              alignItems="center"
+              sx={{
+                position: "absolute",
+                zIndex: 1,
+                top: 8,
+                right: 8,
+                p: 0.25,
+                borderRadius: 1,
+                bgcolor: "background.paper",
+                boxShadow: 1,
+              }}
+            >
+              <ToggleButtonGroup
+                exclusive
+                size="small"
+                value={resultFormat}
+                onChange={(_, value) => value && setResultFormat(value)}
+              >
+                <ToggleButton value="json">JSON</ToggleButton>
+                <ToggleButton value="vtt">VTT</ToggleButton>
+              </ToggleButtonGroup>
+              <Button
+                size="small"
+                startIcon={<DownloadIcon />}
+                disabled={!result}
+                onClick={downloadResult}
+              >
+                {i18n("subtitle_playground_download", "下载")}
+              </Button>
+            </Stack>
+          </Box>
+        </Box>
+      </Box>
+
+      {metrics && !loading && (
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="subtitle1" gutterBottom>
+            {i18n("subtitle_playground_stats_title", "断句统计信息")}
+          </Typography>
+          <Grid container spacing={1.5}>
+            {[
+              [
+                i18n("subtitle_playground_metric_processing", "处理耗时"),
+                `${metrics.processingMs}ms`,
+              ],
+              [
+                i18n("subtitle_playground_metric_raw_events", "原始事件"),
+                metrics.rawEventCount,
+              ],
+              [
+                i18n(
+                  "subtitle_playground_metric_canonical_events",
+                  "规范化事件"
+                ),
+                metrics.canonicalEventCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_flat_events", "Flat Events"),
+                metrics.flatEventCount,
+              ],
+              [
+                i18n(
+                  "subtitle_playground_metric_filtered_non_speech",
+                  "已过滤非语音片段"
+                ),
+                metrics.filteredNonSpeechCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_cues", "字幕条目"),
+                metrics.cueCount,
+              ],
+              [
+                i18n(
+                  "subtitle_playground_metric_source_duration",
+                  "源时间跨度"
+                ),
+                `${metrics.sourceDurationMs}ms`,
+              ],
+              [
+                i18n("subtitle_playground_metric_covered_duration", "覆盖时长"),
+                `${metrics.coveredDurationMs}ms`,
+              ],
+              [
+                i18n("subtitle_playground_metric_text_coverage", "文本覆盖率"),
+                `${metrics.textCoveragePercent}%`,
+              ],
+              [
+                i18n("subtitle_playground_metric_empty_cues", "空字幕"),
+                metrics.emptyCueCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_invalid_cues", "无效字幕"),
+                metrics.invalidCueCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_overlaps", "时间重叠"),
+                metrics.overlapCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_non_monotonic", "时间倒退"),
+                metrics.nonMonotonicCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_missing_text", "文本遗漏"),
+                metrics.missingTextCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_duplicated_text", "文本重复"),
+                metrics.duplicatedTextCount,
+              ],
+              [
+                i18n("subtitle_playground_metric_avg_chars", "平均字符"),
+                metrics.chars.average,
+              ],
+              [
+                i18n("subtitle_playground_metric_p95_chars", "P95 字符"),
+                metrics.chars.p95,
+              ],
+              [
+                i18n("subtitle_playground_metric_max_chars", "最大字符"),
+                metrics.chars.max,
+              ],
+              [
+                i18n("subtitle_playground_metric_avg_words", "平均词数"),
+                metrics.words.average,
+              ],
+              [
+                i18n("subtitle_playground_metric_p95_words", "P95 词数"),
+                metrics.words.p95,
+              ],
+              [
+                i18n("subtitle_playground_metric_max_words", "最大词数"),
+                metrics.words.max,
+              ],
+              [
+                i18n("subtitle_playground_metric_avg_duration", "平均时长"),
+                `${metrics.durationMs.average}ms`,
+              ],
+              [
+                i18n("subtitle_playground_metric_p95_duration", "P95 时长"),
+                `${metrics.durationMs.p95}ms`,
+              ],
+              [
+                i18n("subtitle_playground_metric_max_duration", "最大时长"),
+                `${metrics.durationMs.max}ms`,
+              ],
+            ].map(([label, value]) => (
+              <Grid item xs={6} sm={4} md={2} key={label}>
+                <Typography variant="caption" color="text.secondary">
+                  {label}
+                </Typography>
+                <Typography variant="body1">{String(value)}</Typography>
+              </Grid>
+            ))}
+          </Grid>
+          {metrics.errors.length > 0 && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {formatI18n(
+                i18n,
+                "subtitle_playground_structure_error",
+                "结构错误：{errors}",
+                { errors: metrics.errors.join(", ") }
+              )}
+            </Alert>
+          )}
+          {Object.values(metrics.warnings).some(Boolean) && (
+            <Alert severity="warning" sx={{ mt: 2 }}>
+              {formatI18n(
+                i18n,
+                "subtitle_playground_readability_warning",
+                "可读性警告：超长文本 {longText}，超过 10 秒 {longDuration}，短碎片 {fragments}，泄漏的非语音字幕 {nonSpeech}",
+                {
+                  longText: metrics.warnings.tooLongTextCount,
+                  longDuration: metrics.warnings.tooLongDurationCount,
+                  fragments: metrics.warnings.fragmentCount,
+                  nonSpeech: metrics.warnings.nonSpeechCueCount,
+                }
+              )}
+            </Alert>
+          )}
+          {metrics.ai && (
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              {formatI18n(
+                i18n,
+                "subtitle_playground_ai_stats",
+                "AI：协议 {protocol}，Chunk {chunks}，请求 {requests}，重试 {retries}，降级字幕 {fallbacks}，无效响应 {invalid}",
+                {
+                  protocol: metrics.ai.protocol,
+                  chunks: metrics.ai.chunkCount,
+                  requests: metrics.ai.requestCount,
+                  retries: metrics.ai.retryCount,
+                  fallbacks: metrics.ai.fallbackCueCount,
+                  invalid: metrics.ai.invalidResponseCount,
+                }
+              )}
+            </Typography>
+          )}
+        </Paper>
+      )}
+    </Stack>
+  );
+}

--- a/src/views/Options/SubtitleSegmentationPlayground.test.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.test.js
@@ -1,0 +1,310 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import fs from "fs";
+import path from "path";
+import SubtitleSegmentationPlayground from "./SubtitleSegmentationPlayground";
+import { handleSubtitle } from "../../apis/trans";
+import { I18N, UI_LANGS } from "../../config/i18n";
+import { downloadBlobFile } from "../../libs/utils";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+const mockConfirm = jest.fn(() => Promise.resolve(true));
+
+jest.mock("../../apis/trans", () => ({
+  detectSubtitleProtocol: () => "boundary-v3",
+  handleSubtitle: jest.fn(),
+}));
+
+jest.mock("../../hooks/Confirm", () => ({
+  useConfirm: () => mockConfirm,
+}));
+
+jest.mock("../../hooks/I18n", () => ({
+  // 组件测试固定使用中文备用文案，避免依赖完整的设置上下文。
+  useI18n:
+    () =>
+    (_, fallback = "") =>
+      fallback,
+}));
+
+jest.mock("../../libs/utils", () => {
+  const actual = jest.requireActual("../../libs/utils");
+  return { ...actual, downloadBlobFile: jest.fn() };
+});
+
+/** 等待 React effect 和异步事件处理器完成一次状态提交。 */
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** 通过 MUI 下拉菜单选择本地字幕的明确源语言。 */
+async function selectSourceLanguage(container, language) {
+  const languageSelect = container.querySelectorAll('[role="combobox"]')[1];
+  await act(async () => {
+    languageSelect.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, button: 0 })
+    );
+    await Promise.resolve();
+  });
+  const option = document.body.querySelector(`[data-value="${language}"]`);
+  await act(async () => {
+    option.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+function renderPlayground({ subtitleSetting, transApis = [] } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SubtitleSegmentationPlayground
+        subtitleSetting={
+          subtitleSetting || {
+            segSlug: "-",
+            useAlgorithmBreaker: "rule",
+            longSentenceThreshold: 120,
+            toLang: "zh-CN",
+          }
+        }
+        transApis={transApis}
+        prompts={[]}
+      />
+    );
+  });
+  return { container, root };
+}
+
+describe("SubtitleSegmentationPlayground", () => {
+  const source = JSON.stringify({
+    lang: "en",
+    events: [
+      {
+        tStartMs: 0,
+        dDurationMs: 1000,
+        segs: [{ utf8: "Hello world." }],
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    handleSubtitle.mockReset();
+    mockConfirm.mockClear();
+    mockConfirm.mockResolvedValue(true);
+    downloadBlobFile.mockReset();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 1, samples: [] }),
+    });
+  });
+
+  test("covers every page copy key in all supported UI languages", () => {
+    // 从实际组件提取翻译键，防止后续新增文案时只补中文而遗漏其他语言。
+    const sourceFiles = [
+      "SubtitleSegmentationPlayground.js",
+      "Playground.js",
+    ].map((fileName) =>
+      fs.readFileSync(path.join(__dirname, fileName), "utf8")
+    );
+    const keyPattern =
+      /["'](subtitle_playground_[a-z0-9_]+|playground_text_translation|subtitle_segmentation)["']/g;
+    const keys = new Set(["cancel"]);
+    for (const sourceFile of sourceFiles) {
+      for (const match of sourceFile.matchAll(keyPattern)) keys.add(match[1]);
+    }
+
+    for (const key of keys) {
+      for (const [language] of UI_LANGS) {
+        expect(I18N[key]?.[language]).toEqual(expect.any(String));
+        expect(I18N[key][language]).not.toBe("");
+      }
+    }
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test("uploads a sample, runs rule segmentation, switches VTT and downloads it", async () => {
+    const { container, root } = renderPlayground();
+    await flushEffects();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/subtitle-samples/index.json"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    const input = container.querySelector('input[type="file"]');
+    const file = new File([source], "sample.json", {
+      type: "application/json",
+    });
+    Object.defineProperty(file, "text", { value: async () => source });
+    Object.defineProperty(input, "files", { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    let runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("运行测试")
+    );
+    expect(runButton.disabled).toBe(false);
+    expect(container.textContent).not.toContain("不支持 AutoDetect");
+    await act(async () => {
+      runButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("不支持 AutoDetect");
+    await selectSourceLanguage(container, "en");
+    runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("运行测试")
+    );
+    expect(runButton.disabled).toBe(false);
+    expect(container.textContent).not.toContain("不支持 AutoDetect");
+    await act(async () => {
+      runButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("断句统计信息");
+    expect(container.textContent).toContain("已过滤非语音片段");
+    expect(container.textContent).toContain("100%");
+
+    const vttButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "VTT"
+    );
+    const sourceArea = container.querySelector(
+      'textarea[aria-label="原始字幕 JSON"]'
+    );
+    const resultArea = container.querySelector(
+      'textarea[aria-label="断句结果"]'
+    );
+    expect(sourceArea.getAttribute("rows")).toBe("5");
+    expect(resultArea.getAttribute("rows")).toBe("5");
+    expect(container.textContent.indexOf("当前生效的断句配置")).toBeLessThan(
+      container.textContent.indexOf("内置字幕样本")
+    );
+    // 切换和下载控件应与结果文本框处于同一浮动容器内。
+    expect(
+      resultArea
+        .closest(".MuiFormControl-root")
+        .parentElement.contains(vttButton)
+    ).toBe(true);
+    await act(async () => {
+      vttButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      [...container.querySelectorAll("textarea")].some((area) =>
+        area.value.includes("WEBVTT")
+      )
+    ).toBe(true);
+
+    const downloadButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "下载"
+    );
+    act(() => {
+      downloadButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(downloadBlobFile).toHaveBeenCalledWith(
+      expect.stringContaining("WEBVTT"),
+      expect.stringMatching(/^sample-rule-.*\.vtt$/)
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("uses useConfirm and previews completed AI cues while streaming", async () => {
+    let resolveResponse;
+    const streamedCue = {
+      start: 0,
+      end: 1000,
+      text: "Hello world.",
+      translation: "你好，世界。",
+      _si: 0,
+      _ei: 0,
+    };
+    handleSubtitle.mockImplementation(({ onSubtitleChunk }) => {
+      onSubtitleChunk({ subtitles: [streamedCue], isFinal: false });
+      return new Promise((resolve) => {
+        resolveResponse = resolve;
+      });
+    });
+    const { container, root } = renderPlayground({
+      subtitleSetting: {
+        segSlug: "test-ai",
+        chunkLength: 2000,
+        longSentenceThreshold: 120,
+        toLang: "zh-CN",
+      },
+      transApis: [
+        {
+          apiSlug: "test-ai",
+          apiName: "测试 AI",
+          apiType: "openai",
+          model: "test-model",
+          useStream: true,
+        },
+      ],
+    });
+    await flushEffects();
+    expect(container.textContent).toContain("boundary-v3");
+    expect(container.textContent).toContain(
+      "当前 AI Chunk 长度高于推荐默认值 1000"
+    );
+
+    const input = container.querySelector('input[type="file"]');
+    const file = new File([source], "stream.json", {
+      type: "application/json",
+    });
+    Object.defineProperty(file, "text", { value: async () => source });
+    Object.defineProperty(input, "files", { value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const runButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("运行测试")
+    );
+    // AI 模式允许本地字幕保留 AutoDetect，不应阻止发起测试。
+    expect(runButton.disabled).toBe(false);
+    await act(async () => {
+      runButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "发送 AI 断句请求",
+        confirmText: "继续",
+      })
+    );
+    expect(
+      container.querySelector('textarea[aria-label="断句结果"]').value
+    ).toContain("Hello world.");
+    expect(container.textContent).not.toContain("断句统计信息");
+    expect(
+      container
+        .querySelector('[data-testid="segmentation-actions"]')
+        .contains(
+          container.querySelector('[data-testid="segmentation-progress"]')
+        )
+    ).toBe(true);
+
+    await act(async () => {
+      resolveResponse([streamedCue]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("断句统计信息");
+    expect(container.textContent).not.toContain("当前结果已过期");
+
+    act(() => root.unmount());
+  });
+});

--- a/src/views/Popup/PopupCont.js
+++ b/src/views/Popup/PopupCont.js
@@ -317,8 +317,7 @@ export default function PopupCont({
     scanAll,
     isPlainText: isPlainTextValue = false,
   } = rule || {};
-  const isPlainText =
-    isPlainTextValue === true || isPlainTextValue === "true";
+  const isPlainText = isPlainTextValue === true || isPlainTextValue === "true";
 
   return (
     <Stack sx={{ p: 2 }} spacing={2}>

--- a/testdata/subtitle-samples/chinese-asr.json
+++ b/testdata/subtitle-samples/chinese-asr.json
@@ -1,0 +1,36 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 4200,
+    "segs": [
+      {
+        "utf8": "今天"
+      },
+      {
+        "utf8": "我们",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": "测试",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": "中文字幕",
+        "tOffsetMs": 1900
+      },
+      {
+        "utf8": "断句。",
+        "tOffsetMs": 3000
+      }
+    ]
+  },
+  {
+    "tStartMs": 4400,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "这里不应该插入多余空格。"
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/english-asr-zero-pause.json
+++ b/testdata/subtitle-samples/english-asr-zero-pause.json
@@ -1,0 +1,5865 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 344640,
+    "id": 1,
+    "wpWinPosId": 1,
+    "wsWinStyleId": 1
+  },
+  {
+    "tStartMs": 0,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Hey"
+      },
+      {
+        "utf8": " everyone,",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " I'm",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " Kira.",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " I've",
+        "tOffsetMs": 2000
+      },
+      {
+        "utf8": " been",
+        "tOffsetMs": 2160
+      }
+    ]
+  },
+  {
+    "tStartMs": 2310,
+    "dDurationMs": 1490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 2320,
+    "dDurationMs": 3600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "exploring"
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 299
+      },
+      {
+        "utf8": " Google",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " quite",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 3790,
+    "dDurationMs": 2130,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 3800,
+    "dDurationMs": 4160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "bit"
+      },
+      {
+        "utf8": " recently",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " today",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " want",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1840
+      },
+      {
+        "utf8": " show",
+        "tOffsetMs": 1920
+      }
+    ]
+  },
+  {
+    "tStartMs": 5910,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 5920,
+    "dDurationMs": 4400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you"
+      },
+      {
+        "utf8": " one",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " its",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " newest",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " features",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " called",
+        "tOffsetMs": 1680
+      }
+    ]
+  },
+  {
+    "tStartMs": 7950,
+    "dDurationMs": 2370,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 7960,
+    "dDurationMs": 4400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Storyboard"
+      },
+      {
+        "utf8": " Studio.",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " At",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " first,",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1865
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 2280
+      }
+    ]
+  },
+  {
+    "tStartMs": 10310,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 10320,
+    "dDurationMs": 4600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "thought"
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " was",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " just",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " another",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " update,",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " but",
+        "tOffsetMs": 1880
+      }
+    ]
+  },
+  {
+    "tStartMs": 12350,
+    "dDurationMs": 2570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 12360,
+    "dDurationMs": 4800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "after"
+      },
+      {
+        "utf8": " testing",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " myself,",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 2040
+      },
+      {
+        "utf8": " started",
+        "tOffsetMs": 2160
+      }
+    ]
+  },
+  {
+    "tStartMs": 14910,
+    "dDurationMs": 2250,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 14920,
+    "dDurationMs": 5000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "seeing"
+      },
+      {
+        "utf8": " some",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " real",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " potential.",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " One",
+        "tOffsetMs": 1840
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 2040
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 2120
+      }
+    ]
+  },
+  {
+    "tStartMs": 17150,
+    "dDurationMs": 2770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 17160,
+    "dDurationMs": 5440,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "trickiest"
+      },
+      {
+        "utf8": " parts",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " AI",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " filmmaking",
+        "tOffsetMs": 1360
+      }
+    ]
+  },
+  {
+    "tStartMs": 19910,
+    "dDurationMs": 2690,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 19920,
+    "dDurationMs": 5080,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "is"
+      },
+      {
+        "utf8": " moving",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " from",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " an",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " idea",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1840
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 2000
+      },
+      {
+        "utf8": " sequence",
+        "tOffsetMs": 2080
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 2560
+      }
+    ]
+  },
+  {
+    "tStartMs": 22590,
+    "dDurationMs": 2410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 22600,
+    "dDurationMs": 5560,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "scenes"
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " actually",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " feel",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " connected.",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " You",
+        "tOffsetMs": 2240
+      }
+    ]
+  },
+  {
+    "tStartMs": 24990,
+    "dDurationMs": 3170,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 25000,
+    "dDurationMs": 5120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "have"
+      },
+      {
+        "utf8": " characters,",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " locations,",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " shots,",
+        "tOffsetMs": 2240
+      }
+    ]
+  },
+  {
+    "tStartMs": 28150,
+    "dDurationMs": 1970,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 28160,
+    "dDurationMs": 3560,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "dialogue,"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " somehow",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1315
+      }
+    ]
+  },
+  {
+    "tStartMs": 30110,
+    "dDurationMs": 1610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 30120,
+    "dDurationMs": 2920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "all"
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " those",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " pieces",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " need",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " stay",
+        "tOffsetMs": 1320
+      }
+    ]
+  },
+  {
+    "tStartMs": 31710,
+    "dDurationMs": 1330,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 31720,
+    "dDurationMs": 3240,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "organized"
+      },
+      {
+        "utf8": " while",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " you're",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " building",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1240
+      }
+    ]
+  },
+  {
+    "tStartMs": 33030,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 33040,
+    "dDurationMs": 4200,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "story."
+      },
+      {
+        "utf8": " This",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1020
+      },
+      {
+        "utf8": " where",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " Storyboard",
+        "tOffsetMs": 1280
+      }
+    ]
+  },
+  {
+    "tStartMs": 34950,
+    "dDurationMs": 2290,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 34960,
+    "dDurationMs": 3320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Studio"
+      },
+      {
+        "utf8": " comes",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " in.",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " Let",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " me",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " show",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 1880
+      },
+      {
+        "utf8": " how",
+        "tOffsetMs": 2000
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 2160
+      }
+    ]
+  },
+  {
+    "tStartMs": 37230,
+    "dDurationMs": 1050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 37240,
+    "dDurationMs": 3480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "works."
+      }
+    ]
+  },
+  {
+    "tStartMs": 38270,
+    "dDurationMs": 2450,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 38280,
+    "dDurationMs": 4320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "To"
+      },
+      {
+        "utf8": " get",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " started,",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " create",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " new",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " project.",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 40710,
+    "dDurationMs": 1890,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 40720,
+    "dDurationMs": 4200,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Once"
+      },
+      {
+        "utf8": " you're",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " inside",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " workspace,",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " open",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 42590,
+    "dDurationMs": 2330,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 42600,
+    "dDurationMs": 4080,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " tool",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " section",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " from",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " left",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " sidebar.",
+        "tOffsetMs": 1400
+      }
+    ]
+  },
+  {
+    "tStartMs": 44910,
+    "dDurationMs": 1770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 44920,
+    "dDurationMs": 4480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "There"
+      },
+      {
+        "utf8": " are",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " quite",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " few",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " tools",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " here",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " now,",
+        "tOffsetMs": 1280
+      }
+    ]
+  },
+  {
+    "tStartMs": 46670,
+    "dDurationMs": 2730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 46680,
+    "dDurationMs": 5400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "including"
+      },
+      {
+        "utf8": " things",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " like",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " sketch",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " tool,",
+        "tOffsetMs": 1320
+      }
+    ]
+  },
+  {
+    "tStartMs": 49390,
+    "dDurationMs": 2690,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 49400,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "mockup,"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " magic",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " mask.",
+        "tOffsetMs": 1160
+      }
+    ]
+  },
+  {
+    "tStartMs": 52070,
+    "dDurationMs": 1610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 52080,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "You"
+      },
+      {
+        "utf8": " can",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " even",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " create",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " own",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " custom",
+        "tOffsetMs": 1160
+      }
+    ]
+  },
+  {
+    "tStartMs": 53670,
+    "dDurationMs": 2210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 53680,
+    "dDurationMs": 4240,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "tools."
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " plan",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " explore",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " those",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 1920
+      },
+      {
+        "utf8": " more",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 55870,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 55880,
+    "dDurationMs": 4000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "detail"
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " future",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " video.",
+        "tOffsetMs": 920
+      }
+    ]
+  },
+  {
+    "tStartMs": 57910,
+    "dDurationMs": 1970,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 57920,
+    "dDurationMs": 4720,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "For"
+      },
+      {
+        "utf8": " now,",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " scroll",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " down",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " until",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " find",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 59870,
+    "dDurationMs": 2770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 59880,
+    "dDurationMs": 4600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Storyboard"
+      },
+      {
+        "utf8": " Studio",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " open",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " it.",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 62630,
+    "dDurationMs": 1850,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 62640,
+    "dDurationMs": 3680,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Before"
+      },
+      {
+        "utf8": " building",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " anything,",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " first",
+        "tOffsetMs": 1559
+      }
+    ]
+  },
+  {
+    "tStartMs": 64470,
+    "dDurationMs": 1850,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 64480,
+    "dDurationMs": 4440,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "thing"
+      },
+      {
+        "utf8": " we",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " need",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " decide",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " visual",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 66310,
+    "dDurationMs": 2610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 66320,
+    "dDurationMs": 4480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "style"
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " world",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " we're",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " creating.",
+        "tOffsetMs": 1120
+      }
+    ]
+  },
+  {
+    "tStartMs": 68910,
+    "dDurationMs": 1890,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 68920,
+    "dDurationMs": 3360,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "You"
+      },
+      {
+        "utf8": " can",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " create",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " own",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " custom",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " style",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " if",
+        "tOffsetMs": 1720
+      }
+    ]
+  },
+  {
+    "tStartMs": 70790,
+    "dDurationMs": 1490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 70800,
+    "dDurationMs": 3880,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you"
+      },
+      {
+        "utf8": " want.",
+        "tOffsetMs": 120
+      }
+    ]
+  },
+  {
+    "tStartMs": 72270,
+    "dDurationMs": 2410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 72280,
+    "dDurationMs": 4800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "For"
+      },
+      {
+        "utf8": " this",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " tutorial,",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " I'm",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " going",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " with",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1720
+      },
+      {
+        "utf8": " 3D",
+        "tOffsetMs": 1840
+      }
+    ]
+  },
+  {
+    "tStartMs": 74670,
+    "dDurationMs": 2410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 74680,
+    "dDurationMs": 4960,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "animation"
+      },
+      {
+        "utf8": " preset.",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " Once",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " you've",
+        "tOffsetMs": 1800
+      },
+      {
+        "utf8": " selected",
+        "tOffsetMs": 1920
+      }
+    ]
+  },
+  {
+    "tStartMs": 77070,
+    "dDurationMs": 2570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 77080,
+    "dDurationMs": 4040,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "it,"
+      },
+      {
+        "utf8": " click",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " Get",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " Started.",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " That",
+        "tOffsetMs": 1800
+      },
+      {
+        "utf8": " takes",
+        "tOffsetMs": 2040
+      },
+      {
+        "utf8": " us",
+        "tOffsetMs": 2280
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 2440
+      }
+    ]
+  },
+  {
+    "tStartMs": 79630,
+    "dDurationMs": 1490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 79640,
+    "dDurationMs": 2880,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " script",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " tab.",
+        "tOffsetMs": 440
+      }
+    ]
+  },
+  {
+    "tStartMs": 81110,
+    "dDurationMs": 1410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 81120,
+    "dDurationMs": 3440,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "This"
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " actually",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " where",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " things",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " started",
+        "tOffsetMs": 1080
+      }
+    ]
+  },
+  {
+    "tStartMs": 82510,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 82520,
+    "dDurationMs": 3880,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "getting"
+      },
+      {
+        "utf8": " interesting",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " me.",
+        "tOffsetMs": 920
+      }
+    ]
+  },
+  {
+    "tStartMs": 84550,
+    "dDurationMs": 1850,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 84560,
+    "dDurationMs": 4000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "I"
+      },
+      {
+        "utf8": " pasted",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " story",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 1480
+      }
+    ]
+  },
+  {
+    "tStartMs": 86390,
+    "dDurationMs": 2170,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 86400,
+    "dDurationMs": 5160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "automatically"
+      },
+      {
+        "utf8": " broke",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " down",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " into",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " scenes,",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 88550,
+    "dDurationMs": 3010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 88560,
+    "dDurationMs": 5040,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "actions,"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " dialogue.",
+        "tOffsetMs": 760
+      }
+    ]
+  },
+  {
+    "tStartMs": 91550,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 91560,
+    "dDurationMs": 3600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "I"
+      },
+      {
+        "utf8": " expected",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " rough",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " outline.",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " What",
+        "tOffsetMs": 1880
+      }
+    ]
+  },
+  {
+    "tStartMs": 93590,
+    "dDurationMs": 1570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 93600,
+    "dDurationMs": 3480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "surprised"
+      },
+      {
+        "utf8": " me",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " was",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " how",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " usable",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 95150,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 95160,
+    "dDurationMs": 3840,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "breakdown"
+      },
+      {
+        "utf8": " already",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " was.",
+        "tOffsetMs": 800
+      }
+    ]
+  },
+  {
+    "tStartMs": 97070,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 97080,
+    "dDurationMs": 3840,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "It"
+      },
+      {
+        "utf8": " wasn't",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " perfect",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " you'd",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " still",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " want",
+        "tOffsetMs": 1720
+      }
+    ]
+  },
+  {
+    "tStartMs": 98990,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 99000,
+    "dDurationMs": 4680,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "to"
+      },
+      {
+        "utf8": " review",
+        "tOffsetMs": 80
+      },
+      {
+        "utf8": " everything",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " yourself,",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " but",
+        "tOffsetMs": 1640
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 1800
+      }
+    ]
+  },
+  {
+    "tStartMs": 100910,
+    "dDurationMs": 2770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 100920,
+    "dDurationMs": 4760,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "handled"
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " lot",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " initial",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " setup",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " work.",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 103670,
+    "dDurationMs": 2010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 103680,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "The"
+      },
+      {
+        "utf8": " experience",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " felt",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " less",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " like",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " organizing",
+        "tOffsetMs": 1400
+      }
+    ]
+  },
+  {
+    "tStartMs": 105670,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 105680,
+    "dDurationMs": 3840,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "text"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " more",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " like",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " having",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " small",
+        "tOffsetMs": 1520
+      }
+    ]
+  },
+  {
+    "tStartMs": 107590,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 107600,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "pre-production"
+      },
+      {
+        "utf8": " assistant",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " helping",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " behind",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 109510,
+    "dDurationMs": 2010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 109520,
+    "dDurationMs": 5160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " scenes.",
+        "tOffsetMs": 80
+      }
+    ]
+  },
+  {
+    "tStartMs": 111510,
+    "dDurationMs": 3170,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 111520,
+    "dDurationMs": 5120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Next,"
+      },
+      {
+        "utf8": " let's",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " move",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " over",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " assets",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " tab.",
+        "tOffsetMs": 2040
+      }
+    ]
+  },
+  {
+    "tStartMs": 114670,
+    "dDurationMs": 1970,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 114680,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Normally,"
+      },
+      {
+        "utf8": " this",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " where",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " lot",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " manual",
+        "tOffsetMs": 1520
+      }
+    ]
+  },
+  {
+    "tStartMs": 116630,
+    "dDurationMs": 2330,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 116640,
+    "dDurationMs": 4120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "work"
+      },
+      {
+        "utf8": " begins.",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " Creating",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " characters,",
+        "tOffsetMs": 1480
+      }
+    ]
+  },
+  {
+    "tStartMs": 118950,
+    "dDurationMs": 1810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 118960,
+    "dDurationMs": 3000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "building"
+      },
+      {
+        "utf8": " locations,",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " gathering",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1561
+      }
+    ]
+  },
+  {
+    "tStartMs": 120750,
+    "dDurationMs": 1210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 120760,
+    "dDurationMs": 2920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "props."
+      }
+    ]
+  },
+  {
+    "tStartMs": 121950,
+    "dDurationMs": 1730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 121960,
+    "dDurationMs": 3120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "But"
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " can",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " automate",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " large",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " part",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 123670,
+    "dDurationMs": 1410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 123680,
+    "dDurationMs": 3680,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "that"
+      },
+      {
+        "utf8": " process.",
+        "tOffsetMs": 200
+      }
+    ]
+  },
+  {
+    "tStartMs": 125070,
+    "dDurationMs": 2290,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 125080,
+    "dDurationMs": 5360,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Just"
+      },
+      {
+        "utf8": " click",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " autofill",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " characters,",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " autofill",
+        "tOffsetMs": 1880
+      }
+    ]
+  },
+  {
+    "tStartMs": 127350,
+    "dDurationMs": 3090,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 127360,
+    "dDurationMs": 5000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "locations,"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " autofill",
+        "tOffsetMs": 1039
+      },
+      {
+        "utf8": " props.",
+        "tOffsetMs": 1480
+      }
+    ]
+  },
+  {
+    "tStartMs": 130430,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 130440,
+    "dDurationMs": 4400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Flow"
+      },
+      {
+        "utf8": " reads",
+        "tOffsetMs": 319
+      },
+      {
+        "utf8": " through",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " script",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " starts",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 132350,
+    "dDurationMs": 2490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 132360,
+    "dDurationMs": 4000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "generating"
+      },
+      {
+        "utf8": " assets",
+        "tOffsetMs": 599
+      },
+      {
+        "utf8": " based",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " on",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " story.",
+        "tOffsetMs": 1680
+      }
+    ]
+  },
+  {
+    "tStartMs": 134830,
+    "dDurationMs": 1530,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 134840,
+    "dDurationMs": 3440,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "What"
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " like",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " here",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " you're",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " not",
+        "tOffsetMs": 1280
+      }
+    ]
+  },
+  {
+    "tStartMs": 136350,
+    "dDurationMs": 1930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 136360,
+    "dDurationMs": 4200,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "locked"
+      },
+      {
+        "utf8": " into",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " anything.",
+        "tOffsetMs": 480
+      }
+    ]
+  },
+  {
+    "tStartMs": 138270,
+    "dDurationMs": 2290,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 138280,
+    "dDurationMs": 4520,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "If"
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " character,",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " location,",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " or",
+        "tOffsetMs": 1679
+      },
+      {
+        "utf8": " prop",
+        "tOffsetMs": 1840
+      }
+    ]
+  },
+  {
+    "tStartMs": 140550,
+    "dDurationMs": 2250,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 140560,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "doesn't"
+      },
+      {
+        "utf8": " match",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " what",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " had",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " mind,",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 2160
+      }
+    ]
+  },
+  {
+    "tStartMs": 142790,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 142800,
+    "dDurationMs": 5240,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "can"
+      },
+      {
+        "utf8": " regenerate",
+        "tOffsetMs": 159
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " or",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " make",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " adjustments",
+        "tOffsetMs": 1400
+      }
+    ]
+  },
+  {
+    "tStartMs": 144830,
+    "dDurationMs": 3210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 144840,
+    "dDurationMs": 3200,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "until"
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " feels",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " right.",
+        "tOffsetMs": 680
+      }
+    ]
+  },
+  {
+    "tStartMs": 148270,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 148280,
+    "dDurationMs": 4120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Once"
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " assets",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " are",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " ready,",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " head",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " over",
+        "tOffsetMs": 1720
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1920
+      }
+    ]
+  },
+  {
+    "tStartMs": 150310,
+    "dDurationMs": 2090,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 150320,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " storyboard",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " tab.",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " This",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 1800
+      },
+      {
+        "utf8": " where",
+        "tOffsetMs": 1920
+      }
+    ]
+  },
+  {
+    "tStartMs": 152390,
+    "dDurationMs": 2210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 152400,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "everything"
+      },
+      {
+        "utf8": " starts",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " coming",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " together.",
+        "tOffsetMs": 1000
+      }
+    ]
+  },
+  {
+    "tStartMs": 154590,
+    "dDurationMs": 1730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 154600,
+    "dDurationMs": 3256,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "You'll"
+      },
+      {
+        "utf8": " see",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " scenes",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " already",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " arranged",
+        "tOffsetMs": 1200
+      }
+    ]
+  },
+  {
+    "tStartMs": 156310,
+    "dDurationMs": 1546,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 156320,
+    "dDurationMs": 1720,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "as"
+      },
+      {
+        "utf8": " storyboard",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " frames.",
+        "tOffsetMs": 680
+      }
+    ]
+  },
+  {
+    "tStartMs": 157846,
+    "dDurationMs": 194,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 157856,
+    "dDurationMs": 2064,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": ">> [music]",
+        "isSpeakerChange": 1
+      }
+    ]
+  },
+  {
+    "tStartMs": 158030,
+    "dDurationMs": 1890,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 158040,
+    "dDurationMs": 4080,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": ">> At",
+        "isSpeakerChange": 1
+      },
+      {
+        "utf8": " first,",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " they're",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " empty.",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " But",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " when",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 1760
+      }
+    ]
+  },
+  {
+    "tStartMs": 159910,
+    "dDurationMs": 2210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 159920,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "click"
+      },
+      {
+        "utf8": " autofill",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " scene,",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " uses",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 2080
+      }
+    ]
+  },
+  {
+    "tStartMs": 162110,
+    "dDurationMs": 1730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 162120,
+    "dDurationMs": 3760,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "assets"
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " script",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 976
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " generate",
+        "tOffsetMs": 1280
+      }
+    ]
+  },
+  {
+    "tStartMs": 163830,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 163840,
+    "dDurationMs": 4480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "shots"
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " each",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " scene.",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " And",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " these",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " aren't",
+        "tOffsetMs": 1880
+      }
+    ]
+  },
+  {
+    "tStartMs": 165870,
+    "dDurationMs": 2450,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 165880,
+    "dDurationMs": 4160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "just"
+      },
+      {
+        "utf8": " random",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " images.",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " They're",
+        "tOffsetMs": 1760
+      },
+      {
+        "utf8": " connected",
+        "tOffsetMs": 1880
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 2320
+      }
+    ]
+  },
+  {
+    "tStartMs": 168310,
+    "dDurationMs": 1730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 168320,
+    "dDurationMs": 4120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " story",
+        "tOffsetMs": 80
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " built",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " around",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " world",
+        "tOffsetMs": 1400
+      }
+    ]
+  },
+  {
+    "tStartMs": 170030,
+    "dDurationMs": 2410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 170040,
+    "dDurationMs": 4080,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you've"
+      },
+      {
+        "utf8": " already",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " established.",
+        "tOffsetMs": 480
+      }
+    ]
+  },
+  {
+    "tStartMs": 172430,
+    "dDurationMs": 1690,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 172440,
+    "dDurationMs": 3440,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "This"
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " point",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " where",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " started",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " seeing",
+        "tOffsetMs": 1360
+      }
+    ]
+  },
+  {
+    "tStartMs": 174110,
+    "dDurationMs": 1770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 174120,
+    "dDurationMs": 3160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 111
+      },
+      {
+        "utf8": " real",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " potential",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " tool.",
+        "tOffsetMs": 1160
+      }
+    ]
+  },
+  {
+    "tStartMs": 175870,
+    "dDurationMs": 1410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 175880,
+    "dDurationMs": 3280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Because"
+      },
+      {
+        "utf8": " you're",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " no",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " longer",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " trying",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1280
+      }
+    ]
+  },
+  {
+    "tStartMs": 177270,
+    "dDurationMs": 1890,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 177280,
+    "dDurationMs": 3600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "imagine"
+      },
+      {
+        "utf8": " what",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 679
+      },
+      {
+        "utf8": " film",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " might",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " look",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " like,",
+        "tOffsetMs": 1520
+      }
+    ]
+  },
+  {
+    "tStartMs": 179150,
+    "dDurationMs": 1730,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 179160,
+    "dDurationMs": 4320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you're"
+      },
+      {
+        "utf8": " starting",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 312
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " see",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " it,",
+        "tOffsetMs": 799
+      },
+      {
+        "utf8": " scene",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 180870,
+    "dDurationMs": 2610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 180880,
+    "dDurationMs": 4400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "by"
+      },
+      {
+        "utf8": " scene,",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " shot",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " by",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " shot.",
+        "tOffsetMs": 1320
+      }
+    ]
+  },
+  {
+    "tStartMs": 183470,
+    "dDurationMs": 1810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 183480,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "One"
+      },
+      {
+        "utf8": " thing",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " worth",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " mentioning",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " before",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " moving",
+        "tOffsetMs": 1440
+      }
+    ]
+  },
+  {
+    "tStartMs": 185270,
+    "dDurationMs": 2490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 185280,
+    "dDurationMs": 4679,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "on"
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 239
+      },
+      {
+        "utf8": " saving",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " project.",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " Closing",
+        "tOffsetMs": 1920
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 2360
+      }
+    ]
+  },
+  {
+    "tStartMs": 187750,
+    "dDurationMs": 2209,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 187760,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "tab"
+      },
+      {
+        "utf8": " before",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " saving",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " causes",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " loss",
+        "tOffsetMs": 1720
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 2040
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 2120
+      }
+    ]
+  },
+  {
+    "tStartMs": 189949,
+    "dDurationMs": 1731,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 189959,
+    "dDurationMs": 4321,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "script"
+      },
+      {
+        "utf8": " breakdown",
+        "tOffsetMs": 401
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 881
+      },
+      {
+        "utf8": " structure,",
+        "tOffsetMs": 1000
+      }
+    ]
+  },
+  {
+    "tStartMs": 191670,
+    "dDurationMs": 2610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 191680,
+    "dDurationMs": 4760,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "requiring"
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " rebuild",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " from",
+        "tOffsetMs": 1320
+      },
+      {
+        "utf8": " scratch.",
+        "tOffsetMs": 1480
+      }
+    ]
+  },
+  {
+    "tStartMs": 194270,
+    "dDurationMs": 2170,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 194280,
+    "dDurationMs": 4560,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Once"
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 239
+      },
+      {
+        "utf8": " project",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " saved,",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " next",
+        "tOffsetMs": 1600
+      },
+      {
+        "utf8": " step",
+        "tOffsetMs": 1880
+      }
+    ]
+  },
+  {
+    "tStartMs": 196430,
+    "dDurationMs": 2410,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 196440,
+    "dDurationMs": 4960,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "is"
+      },
+      {
+        "utf8": " giving",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " characters",
+        "tOffsetMs": 519
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " voice.",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " Open",
+        "tOffsetMs": 2079
+      }
+    ]
+  },
+  {
+    "tStartMs": 198830,
+    "dDurationMs": 2570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 198840,
+    "dDurationMs": 5679,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "the"
+      },
+      {
+        "utf8": " characters",
+        "tOffsetMs": 80
+      },
+      {
+        "utf8": " panel.",
+        "tOffsetMs": 640
+      }
+    ]
+  },
+  {
+    "tStartMs": 201390,
+    "dDurationMs": 3129,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 201400,
+    "dDurationMs": 3119,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Select"
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " character.",
+        "tOffsetMs": 440
+      }
+    ]
+  },
+  {
+    "tStartMs": 206190,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 206200,
+    "dDurationMs": 4160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Choose"
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " voice,",
+        "tOffsetMs": 319
+      },
+      {
+        "utf8": " then",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " preview",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " few",
+        "tOffsetMs": 1759
+      }
+    ]
+  },
+  {
+    "tStartMs": 208190,
+    "dDurationMs": 2170,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 208200,
+    "dDurationMs": 4280,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "different"
+      },
+      {
+        "utf8": " options.",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " I",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " wouldn't",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " rush",
+        "tOffsetMs": 1759
+      },
+      {
+        "utf8": " this",
+        "tOffsetMs": 1960
+      }
+    ]
+  },
+  {
+    "tStartMs": 210350,
+    "dDurationMs": 2130,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 210360,
+    "dDurationMs": 4200,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "part."
+      },
+      {
+        "utf8": " A",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " voice",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " can",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " completely",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " change",
+        "tOffsetMs": 1599
+      },
+      {
+        "utf8": " how",
+        "tOffsetMs": 1960
+      }
+    ]
+  },
+  {
+    "tStartMs": 212470,
+    "dDurationMs": 2090,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 212480,
+    "dDurationMs": 4039,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "a"
+      },
+      {
+        "utf8": " character",
+        "tOffsetMs": 39
+      },
+      {
+        "utf8": " feels",
+        "tOffsetMs": 479
+      },
+      {
+        "utf8": " on",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " screen.",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " Once",
+        "tOffsetMs": 1759
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 214550,
+    "dDurationMs": 1969,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 214560,
+    "dDurationMs": 5959,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "find"
+      },
+      {
+        "utf8": " something",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " fits,",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " repeat",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1840
+      }
+    ]
+  },
+  {
+    "tStartMs": 216509,
+    "dDurationMs": 4010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 216519,
+    "dDurationMs": 4000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "process"
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 481
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 641
+      },
+      {
+        "utf8": " rest",
+        "tOffsetMs": 761
+      },
+      {
+        "utf8": " of",
+        "tOffsetMs": 1041
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 1121
+      },
+      {
+        "utf8": " cast.",
+        "tOffsetMs": 1241
+      }
+    ]
+  },
+  {
+    "tStartMs": 241510,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 241520,
+    "dDurationMs": 3960,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": ">> Now",
+        "isSpeakerChange": 1
+      },
+      {
+        "utf8": " we",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " get",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " final",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " step,",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1487
+      }
+    ]
+  },
+  {
+    "tStartMs": 243390,
+    "dDurationMs": 2090,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 243400,
+    "dDurationMs": 4559,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "turning"
+      },
+      {
+        "utf8": " storyboard",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " frames",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " into",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " actual",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 245470,
+    "dDurationMs": 2489,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 245480,
+    "dDurationMs": 5920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "video."
+      },
+      {
+        "utf8": " Open",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " all",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " media",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1840
+      },
+      {
+        "utf8": " select",
+        "tOffsetMs": 2040
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 2400
+      }
+    ]
+  },
+  {
+    "tStartMs": 247949,
+    "dDurationMs": 3451,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 247959,
+    "dDurationMs": 3441,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "frame"
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 321
+      },
+      {
+        "utf8": " want",
+        "tOffsetMs": 441
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 641
+      },
+      {
+        "utf8": " animate.",
+        "tOffsetMs": 761
+      }
+    ]
+  },
+  {
+    "tStartMs": 256550,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 256560,
+    "dDurationMs": 4600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Click"
+      },
+      {
+        "utf8": " add",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 519
+      },
+      {
+        "utf8": " prompt.",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " From",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " here,",
+        "tOffsetMs": 1720
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 2080
+      },
+      {
+        "utf8": " can",
+        "tOffsetMs": 2200
+      }
+    ]
+  },
+  {
+    "tStartMs": 258949,
+    "dDurationMs": 2211,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 258959,
+    "dDurationMs": 3721,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "animate"
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 441
+      },
+      {
+        "utf8": " scene",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " using",
+        "tOffsetMs": 921
+      },
+      {
+        "utf8": " agent",
+        "tOffsetMs": 1321
+      },
+      {
+        "utf8": " mode",
+        "tOffsetMs": 1681
+      },
+      {
+        "utf8": " or",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 261150,
+    "dDurationMs": 1530,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 261160,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "standard"
+      },
+      {
+        "utf8": " mode.",
+        "tOffsetMs": 480
+      }
+    ]
+  },
+  {
+    "tStartMs": 262670,
+    "dDurationMs": 2290,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 262680,
+    "dDurationMs": 6080,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "I"
+      },
+      {
+        "utf8": " prefer",
+        "tOffsetMs": 80
+      },
+      {
+        "utf8": " agent",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " mode.",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " It",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " saves",
+        "tOffsetMs": 1680
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 2000
+      },
+      {
+        "utf8": " from",
+        "tOffsetMs": 2120
+      }
+    ]
+  },
+  {
+    "tStartMs": 264950,
+    "dDurationMs": 3810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 264960,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "having"
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " write",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " perfect",
+        "tOffsetMs": 760
+      },
+      {
+        "utf8": " prompt.",
+        "tOffsetMs": 1200
+      }
+    ]
+  },
+  {
+    "tStartMs": 270070,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 270080,
+    "dDurationMs": 3720,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Just"
+      },
+      {
+        "utf8": " copy",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " scene",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " from",
+        "tOffsetMs": 920
+      },
+      {
+        "utf8": " your",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " script,",
+        "tOffsetMs": 1240
+      }
+    ]
+  },
+  {
+    "tStartMs": 271990,
+    "dDurationMs": 1810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 272000,
+    "dDurationMs": 3600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "paste"
+      },
+      {
+        "utf8": " it",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " in,",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " agent",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " will",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 273790,
+    "dDurationMs": 1810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 273800,
+    "dDurationMs": 4160,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "automatically"
+      },
+      {
+        "utf8": " generate",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1119
+      },
+      {
+        "utf8": " prompt",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 275590,
+    "dDurationMs": 2370,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 275600,
+    "dDurationMs": 4120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you."
+      }
+    ]
+  },
+  {
+    "tStartMs": 277950,
+    "dDurationMs": 1770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 277960,
+    "dDurationMs": 4320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "There's"
+      },
+      {
+        "utf8": " also",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " small",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " detail",
+        "tOffsetMs": 1000
+      },
+      {
+        "utf8": " here",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 1600
+      }
+    ]
+  },
+  {
+    "tStartMs": 279710,
+    "dDurationMs": 2570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 279720,
+    "dDurationMs": 4120,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "makes"
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " difference.",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " Use",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1400
+      },
+      {
+        "utf8": " @",
+        "tOffsetMs": 1640
+      },
+      {
+        "utf8": " symbol",
+        "tOffsetMs": 1880
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 2400
+      }
+    ]
+  },
+  {
+    "tStartMs": 282270,
+    "dDurationMs": 1570,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 282280,
+    "dDurationMs": 3600,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "select"
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 360
+      },
+      {
+        "utf8": " character",
+        "tOffsetMs": 440
+      },
+      {
+        "utf8": " involved",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 1360
+      }
+    ]
+  },
+  {
+    "tStartMs": 283830,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 283840,
+    "dDurationMs": 5960,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "scene."
+      },
+      {
+        "utf8": " This",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " helps",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " understand",
+        "tOffsetMs": 1520
+      }
+    ]
+  },
+  {
+    "tStartMs": 285870,
+    "dDurationMs": 3930,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 285880,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "exactly"
+      },
+      {
+        "utf8": " who",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " should",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " appear",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " shot.",
+        "tOffsetMs": 1360
+      }
+    ]
+  },
+  {
+    "tStartMs": 292670,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 292680,
+    "dDurationMs": 4400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Once"
+      },
+      {
+        "utf8": " everything",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " ready,",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " click",
+        "tOffsetMs": 1320
+      }
+    ]
+  },
+  {
+    "tStartMs": 294310,
+    "dDurationMs": 2770,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 294320,
+    "dDurationMs": 2760,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "generate."
+      }
+    ]
+  },
+  {
+    "tStartMs": 298430,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 298440,
+    "dDurationMs": 3560,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "A"
+      },
+      {
+        "utf8": " few",
+        "tOffsetMs": 80
+      },
+      {
+        "utf8": " moments",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " later,",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " storyboard",
+        "tOffsetMs": 1160
+      }
+    ]
+  },
+  {
+    "tStartMs": 300190,
+    "dDurationMs": 1810,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 300200,
+    "dDurationMs": 4000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "frame"
+      },
+      {
+        "utf8": " becomes",
+        "tOffsetMs": 280
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " moving",
+        "tOffsetMs": 719
+      },
+      {
+        "utf8": " scene",
+        "tOffsetMs": 1120
+      },
+      {
+        "utf8": " with",
+        "tOffsetMs": 1520
+      }
+    ]
+  },
+  {
+    "tStartMs": 301990,
+    "dDurationMs": 2210,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 302000,
+    "dDurationMs": 3320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "AI-generated"
+      },
+      {
+        "utf8": " visuals",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 1480
+      },
+      {
+        "utf8": " synchronized",
+        "tOffsetMs": 1640
+      }
+    ]
+  },
+  {
+    "tStartMs": 304190,
+    "dDurationMs": 1130,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 304200,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "dialogue."
+      }
+    ]
+  },
+  {
+    "tStartMs": 305310,
+    "dDurationMs": 2690,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 305320,
+    "dDurationMs": 4680,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": ">> Look",
+        "isSpeakerChange": 1
+      },
+      {
+        "utf8": " at",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " that",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " fine",
+        "tOffsetMs": 480
+      },
+      {
+        "utf8": " prize.",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " Too",
+        "tOffsetMs": 1920
+      },
+      {
+        "utf8": " much",
+        "tOffsetMs": 2120
+      },
+      {
+        "utf8": " work",
+        "tOffsetMs": 2400
+      }
+    ]
+  },
+  {
+    "tStartMs": 307990,
+    "dDurationMs": 2010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 308000,
+    "dDurationMs": 4360,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "to"
+      },
+      {
+        "utf8": " outrun",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " an",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " old",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " man.",
+        "tOffsetMs": 919
+      }
+    ]
+  },
+  {
+    "tStartMs": 309990,
+    "dDurationMs": 2370,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 310000,
+    "dDurationMs": 5000,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Let's"
+      },
+      {
+        "utf8": " outthink",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " him",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " instead.",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " I'm",
+        "tOffsetMs": 2080
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 2240
+      }
+    ]
+  },
+  {
+    "tStartMs": 312350,
+    "dDurationMs": 2650,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 312360,
+    "dDurationMs": 2640,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "position."
+      }
+    ]
+  },
+  {
+    "tStartMs": 315350,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 315360,
+    "dDurationMs": 3400,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": ">> And",
+        "isSpeakerChange": 1
+      },
+      {
+        "utf8": " that's",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " quick",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " look",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " at",
+        "tOffsetMs": 960
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " new",
+        "tOffsetMs": 1160
+      }
+    ]
+  },
+  {
+    "tStartMs": 316750,
+    "dDurationMs": 2010,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 316760,
+    "dDurationMs": 3320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "storyboard"
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 263
+      },
+      {
+        "utf8": " studio",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " inside",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " Google",
+        "tOffsetMs": 1720
+      }
+    ]
+  },
+  {
+    "tStartMs": 318750,
+    "dDurationMs": 1330,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 318760,
+    "dDurationMs": 3360,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Flow."
+      }
+    ]
+  },
+  {
+    "tStartMs": 320070,
+    "dDurationMs": 2050,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 320080,
+    "dDurationMs": 3920,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "This"
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " actually",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " my",
+        "tOffsetMs": 680
+      },
+      {
+        "utf8": " first",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " tutorial",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " video",
+        "tOffsetMs": 1680
+      }
+    ]
+  },
+  {
+    "tStartMs": 322110,
+    "dDurationMs": 1890,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 322120,
+    "dDurationMs": 4840,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "on"
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " channel,",
+        "tOffsetMs": 240
+      },
+      {
+        "utf8": " so",
+        "tOffsetMs": 720
+      },
+      {
+        "utf8": " I'd",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " love",
+        "tOffsetMs": 1240
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 1440
+      },
+      {
+        "utf8": " hear",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " what",
+        "tOffsetMs": 1760
+      }
+    ]
+  },
+  {
+    "tStartMs": 323990,
+    "dDurationMs": 2970,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 324000,
+    "dDurationMs": 4560,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you"
+      },
+      {
+        "utf8": " think.",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " Did",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " this",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " workflow",
+        "tOffsetMs": 1360
+      },
+      {
+        "utf8": " make",
+        "tOffsetMs": 1760
+      },
+      {
+        "utf8": " sense?",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 326950,
+    "dDurationMs": 1610,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 326960,
+    "dDurationMs": 3720,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "Are"
+      },
+      {
+        "utf8": " there",
+        "tOffsetMs": 120
+      },
+      {
+        "utf8": " other",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " Google",
+        "tOffsetMs": 560
+      },
+      {
+        "utf8": " Flow",
+        "tOffsetMs": 880
+      },
+      {
+        "utf8": " features",
+        "tOffsetMs": 1120
+      }
+    ]
+  },
+  {
+    "tStartMs": 328550,
+    "dDurationMs": 2130,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 328560,
+    "dDurationMs": 3800,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "you'd"
+      },
+      {
+        "utf8": " like",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " me",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 520
+      },
+      {
+        "utf8": " explore",
+        "tOffsetMs": 640
+      },
+      {
+        "utf8": " next?",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " Let",
+        "tOffsetMs": 1840
+      },
+      {
+        "utf8": " me",
+        "tOffsetMs": 2040
+      }
+    ]
+  },
+  {
+    "tStartMs": 330670,
+    "dDurationMs": 1690,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 330680,
+    "dDurationMs": 4239,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "know"
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 160
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 239
+      },
+      {
+        "utf8": " comments.",
+        "tOffsetMs": 320
+      },
+      {
+        "utf8": " And",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " if",
+        "tOffsetMs": 1160
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 1280
+      },
+      {
+        "utf8": " found",
+        "tOffsetMs": 1400
+      }
+    ]
+  },
+  {
+    "tStartMs": 332350,
+    "dDurationMs": 2569,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 332360,
+    "dDurationMs": 4320,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "this"
+      },
+      {
+        "utf8": " useful,",
+        "tOffsetMs": 200
+      },
+      {
+        "utf8": " consider",
+        "tOffsetMs": 1040
+      },
+      {
+        "utf8": " liking",
+        "tOffsetMs": 1520
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 1880
+      },
+      {
+        "utf8": " video",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 334909,
+    "dDurationMs": 1771,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 334919,
+    "dDurationMs": 4241,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "and"
+      },
+      {
+        "utf8": " subscribing",
+        "tOffsetMs": 201
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 881
+      },
+      {
+        "utf8": " more",
+        "tOffsetMs": 1041
+      },
+      {
+        "utf8": " AI",
+        "tOffsetMs": 1441
+      },
+      {
+        "utf8": " [music]",
+        "tOffsetMs": 1754
+      }
+    ]
+  },
+  {
+    "tStartMs": 336670,
+    "dDurationMs": 2490,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 336680,
+    "dDurationMs": 4578,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "filmmaking"
+      },
+      {
+        "utf8": " experiments,",
+        "tOffsetMs": 600
+      },
+      {
+        "utf8": " tutorials,",
+        "tOffsetMs": 1560
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 2360
+      }
+    ]
+  },
+  {
+    "tStartMs": 339150,
+    "dDurationMs": 2108,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 339160,
+    "dDurationMs": 5480,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "discoveries."
+      },
+      {
+        "utf8": " Thanks",
+        "tOffsetMs": 840
+      },
+      {
+        "utf8": " for",
+        "tOffsetMs": 1080
+      },
+      {
+        "utf8": " watching,",
+        "tOffsetMs": 1200
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 2000
+      }
+    ]
+  },
+  {
+    "tStartMs": 341248,
+    "dDurationMs": 3392,
+    "wWinId": 1,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 341258,
+    "dDurationMs": 3382,
+    "wWinId": 1,
+    "segs": [
+      {
+        "utf8": "[music]"
+      },
+      {
+        "utf8": " I'll",
+        "tOffsetMs": 22
+      },
+      {
+        "utf8": " see",
+        "tOffsetMs": 142
+      },
+      {
+        "utf8": " you",
+        "tOffsetMs": 342
+      },
+      {
+        "utf8": " in",
+        "tOffsetMs": 462
+      },
+      {
+        "utf8": " the",
+        "tOffsetMs": 542
+      },
+      {
+        "utf8": " next",
+        "tOffsetMs": 622
+      },
+      {
+        "utf8": " one.",
+        "tOffsetMs": 942
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/english-long-no-punctuation.json
+++ b/testdata/subtitle-samples/english-long-no-punctuation.json
@@ -1,0 +1,63 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 9000,
+    "segs": [
+      {
+        "utf8": "well"
+      },
+      {
+        "utf8": " this",
+        "tOffsetMs": 400
+      },
+      {
+        "utf8": " is",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " a",
+        "tOffsetMs": 1100
+      },
+      {
+        "utf8": " deliberately",
+        "tOffsetMs": 1500
+      },
+      {
+        "utf8": " long",
+        "tOffsetMs": 2200
+      },
+      {
+        "utf8": " stream",
+        "tOffsetMs": 2700
+      },
+      {
+        "utf8": " without",
+        "tOffsetMs": 3300
+      },
+      {
+        "utf8": " punctuation",
+        "tOffsetMs": 4000
+      },
+      {
+        "utf8": " and",
+        "tOffsetMs": 4900
+      },
+      {
+        "utf8": " with",
+        "tOffsetMs": 5500
+      },
+      {
+        "utf8": " repeated",
+        "tOffsetMs": 6100
+      },
+      {
+        "utf8": " repeated",
+        "tOffsetMs": 6900
+      },
+      {
+        "utf8": " words",
+        "tOffsetMs": 7600
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/english-manual.json
+++ b/testdata/subtitle-samples/english-manual.json
@@ -1,0 +1,29 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 2200,
+    "segs": [
+      {
+        "utf8": "Welcome to the subtitle test."
+      }
+    ]
+  },
+  {
+    "tStartMs": 2400,
+    "dDurationMs": 2600,
+    "segs": [
+      {
+        "utf8": "This track already contains punctuation."
+      }
+    ]
+  },
+  {
+    "tStartMs": 5200,
+    "dDurationMs": 2300,
+    "segs": [
+      {
+        "utf8": "Can both algorithms preserve it?"
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/index.json
+++ b/testdata/subtitle-samples/index.json
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "samples": [
+    {
+      "id": "english-asr-zero-pause",
+      "name": "英文自动字幕：弱停顿",
+      "language": "en",
+      "path": "english-asr-zero-pause.json",
+      "videoUrl": "https://www.youtube.com/watch?v=qCPlEOY2zgI",
+      "size": 89277,
+      "sha256": "eea691ee23be8b433eae101e038085793bc5c6bbaae23d8a568483777c5b0833",
+      "goldenBoundaries": {
+        "rule": "cb331e4a774d5f62",
+        "statistical": "ab45d8625b8f0349"
+      },
+      "tags": [
+        "asr",
+        "word-level",
+        "zero-pause",
+        "real-world"
+      ]
+    },
+    {
+      "id": "english-manual",
+      "name": "英文人工字幕：完整标点",
+      "language": "en",
+      "path": "english-manual.json",
+      "videoUrl": "",
+      "size": 434,
+      "sha256": "946d907e44c665ffb9f9d2829048098a38413673b328d5cb3a04a58cb43b9903",
+      "goldenBoundaries": {
+        "rule": "a47333ac0bdd4f8f",
+        "statistical": "b1c2d032eb844e22"
+      },
+      "tags": [
+        "manual",
+        "punctuation"
+      ]
+    },
+    {
+      "id": "english-long-no-punctuation",
+      "name": "英文自动字幕：无标点长语流",
+      "language": "en",
+      "path": "english-long-no-punctuation.json",
+      "videoUrl": "",
+      "size": 1020,
+      "sha256": "65549ad1879e72294128b12bdf38b80354e18e99a00c0f3562cba1d2b5c8dae9",
+      "goldenBoundaries": {
+        "rule": "80b10bfa8003f401",
+        "statistical": "55a5e65db22fb0e8"
+      },
+      "tags": [
+        "asr",
+        "no-punctuation",
+        "repetition"
+      ]
+    },
+    {
+      "id": "chinese-asr",
+      "name": "中文自动字幕：无空格语言",
+      "language": "zh-CN",
+      "path": "chinese-asr.json",
+      "videoUrl": "",
+      "size": 548,
+      "sha256": "46c65235e75d3ce5672cea42be11e1cb0062439633392e0b4fd2af2dc519b809",
+      "goldenBoundaries": {
+        "rule": "e05fbcc97e0eae2d",
+        "statistical": "fed325b859f98a8c"
+      },
+      "tags": [
+        "asr",
+        "cjk",
+        "no-space"
+      ]
+    },
+    {
+      "id": "japanese-asr",
+      "name": "日文自动字幕：无空格语言",
+      "language": "ja",
+      "path": "japanese-asr.json",
+      "videoUrl": "",
+      "size": 500,
+      "sha256": "1aed3a2b88319948236edd90ca0e2a8d48f5b963b78cc294d4871825e3a88510",
+      "goldenBoundaries": {
+        "rule": "2ba3a608cab2ca24",
+        "statistical": "4273b177527bb8ae"
+      },
+      "tags": [
+        "asr",
+        "cjk",
+        "no-space"
+      ]
+    },
+    {
+      "id": "technical-content",
+      "name": "技术内容：数字与符号",
+      "language": "en",
+      "path": "technical-content.json",
+      "videoUrl": "",
+      "size": 559,
+      "sha256": "60448ba8c1bc07da476726102620c74e384cd5b5bdffdad39b15b9b9c45366bf",
+      "goldenBoundaries": {
+        "rule": "aae164b6a59fcfff",
+        "statistical": "aae164b6a59fcfff"
+      },
+      "tags": [
+        "technical",
+        "numbers",
+        "symbols"
+      ]
+    },
+    {
+      "id": "noisy-events",
+      "name": "异常事件：标签、重复和非语音",
+      "language": "en",
+      "path": "noisy-events.json",
+      "videoUrl": "",
+      "size": 777,
+      "sha256": "cc0d696396a5f273f52660a855e526ed4e1d384f962e9fb7d8572606ade91d92",
+      "goldenBoundaries": {
+        "rule": "a5da3c9788edca6e",
+        "statistical": "082980b36903aecd"
+      },
+      "tags": [
+        "dirty",
+        "duplicate",
+        "line-break",
+        "non-speech"
+      ]
+    },
+    {
+      "id": "long-video",
+      "name": "长视频：二十一分钟时间轴",
+      "language": "en",
+      "path": "long-video.json",
+      "videoUrl": "",
+      "size": 3038,
+      "sha256": "4f4cbb8ab41d759ea57d566b4cf0748ff08c8ae50cae6ad64c747915d470561c",
+      "goldenBoundaries": {
+        "rule": "8b6c5e02101b91bc",
+        "statistical": "8b6c5e02101b91bc"
+      },
+      "tags": [
+        "long-duration",
+        "sparse"
+      ]
+    }
+  ]
+}

--- a/testdata/subtitle-samples/japanese-asr.json
+++ b/testdata/subtitle-samples/japanese-asr.json
@@ -1,0 +1,32 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 4500,
+    "segs": [
+      {
+        "utf8": "今日は"
+      },
+      {
+        "utf8": "字幕の",
+        "tOffsetMs": 700
+      },
+      {
+        "utf8": "区切りを",
+        "tOffsetMs": 1500
+      },
+      {
+        "utf8": "確認します。",
+        "tOffsetMs": 2600
+      }
+    ]
+  },
+  {
+    "tStartMs": 4800,
+    "dDurationMs": 2800,
+    "segs": [
+      {
+        "utf8": "自然な表示になるでしょうか。"
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/long-video.json
+++ b/testdata/subtitle-samples/long-video.json
@@ -1,0 +1,200 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Long video sample starts here."
+      }
+    ]
+  },
+  {
+    "tStartMs": 60000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute one checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 120000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute two checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 180000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute three checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 240000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute four checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 300000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute five checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 360000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute six checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 420000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute seven checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 480000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute eight checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 540000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute nine checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 600000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute ten checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 660000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute eleven checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 720000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute twelve checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 780000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute thirteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 840000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute fourteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 900000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute fifteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 960000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute sixteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 1020000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute seventeen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 1080000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute eighteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 1140000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute nineteen checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 1200000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Minute twenty checkpoint."
+      }
+    ]
+  },
+  {
+    "tStartMs": 1260000,
+    "dDurationMs": 3000,
+    "segs": [
+      {
+        "utf8": "Long video sample ends here."
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/noisy-events.json
+++ b/testdata/subtitle-samples/noisy-events.json
@@ -1,0 +1,57 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 1800,
+    "segs": [
+      {
+        "utf8": "<b>Hello</b>​   world"
+      }
+    ]
+  },
+  {
+    "tStartMs": 0,
+    "dDurationMs": 1800,
+    "pPenId": 2,
+    "segs": [
+      {
+        "utf8": "<i>Hello</i>​ world"
+      }
+    ]
+  },
+  {
+    "tStartMs": 1800,
+    "dDurationMs": 0,
+    "aAppend": 1,
+    "segs": [
+      {
+        "utf8": "\n"
+      }
+    ]
+  },
+  {
+    "tStartMs": 2000,
+    "dDurationMs": 1600,
+    "segs": [
+      {
+        "utf8": "[Music]"
+      }
+    ]
+  },
+  {
+    "tStartMs": 3700,
+    "dDurationMs": 2300,
+    "segs": [
+      {
+        "utf8": "Back"
+      },
+      {
+        "utf8": " to",
+        "tOffsetMs": 500
+      },
+      {
+        "utf8": " speech.",
+        "tOffsetMs": 1000
+      }
+    ]
+  }
+]

--- a/testdata/subtitle-samples/technical-content.json
+++ b/testdata/subtitle-samples/technical-content.json
@@ -1,0 +1,36 @@
+[
+  {
+    "tStartMs": 0,
+    "dDurationMs": 5200,
+    "segs": [
+      {
+        "utf8": "Node.js"
+      },
+      {
+        "utf8": " v22.3.0",
+        "tOffsetMs": 800
+      },
+      {
+        "utf8": " uses",
+        "tOffsetMs": 1700
+      },
+      {
+        "utf8": " 128-bit",
+        "tOffsetMs": 2300
+      },
+      {
+        "utf8": " identifiers.",
+        "tOffsetMs": 3300
+      }
+    ]
+  },
+  {
+    "tStartMs": 5500,
+    "dDurationMs": 3500,
+    "segs": [
+      {
+        "utf8": "Call foo(bar) before API_v2 returns HTTP 204."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
本次修改主要完成了“字幕断句链路优化 + AI 断句协议升级 + 测试体系与 Playground”的建设。

## 核心处理链路

- 新增 `prepareTimedTextEvents()`，合并原来的规范化和展平处理。
- 统一完成 HTML、零宽字符、空白、重复事件清理。
- 保留换行控制和原始时间边界。
- 展平时过滤纯 `[Music]`、`[Laughter]` 等非语音片段，混合对白不误删。
- 规则断句和 AI 断句使用 `flatEvents`，统计断句使用规范化事件。
- 新增统一的规则/统计断句入口，统计断句异常时降级为规则断句。
- 优化中文、日文等无空格语言的规则断句。
- 统一最终字幕结构为 `{start,end,text,translation}`。

## AI 断句

- 默认协议升级为 `boundary-v3`。
- 用户消息简化为纯 JSON：

```json
[
  {"id":0,"text":"Hello"},
  {"id":1,"text":"world!","pauseMs":850}
]
```

- `pauseMs` 表示当前事件到下一个事件的正向时间间隔；缺失时按 `0` 处理。
- 当前默认输出恢复为 `{e,o,t}`：
  - `e`：当前字幕最后一个事件 ID。
  - `o`：模型用于原文与译文自检的原文锚点。
  - `t`：译文。
- 程序仍根据 `e` 重建原文和时间轴，不信任或显示模型返回的 `o`。
- 提示词增加 15 词、30 字符硬限制、禁止合并完整句子和严格翻译范围要求。
- 保留 `{e,t}`、旧 `{s,e,o,t}`、旧停顿等级 `p` 和 VTT 协议兼容。
- 流式和非流式共用边界游标解析逻辑。
- 支持有效前缀保留、尾部重试一次和仅对剩余部分规则降级。

## 分块和缓存

- 默认 Chunk 长度由 `2000` 调整为 `1000`，已保存配置不会被强制迁移。
- 分块严格遵守字符上限，在 80% 后优先寻找自然边界。
- 删除独立 `contextSig`。
- `promptSig` 基于完成动态变量替换后的最终系统提示词。
- `chunkHash` 纳入事件文本、时间轴和 `pauseMs`。
- 缓存版本继续保持 `segVer: 4` 和 `subtitle-chunk-v4`。

## 字幕断句 Playground

- Playground 重构为“文本翻译”和“字幕断句”两个 Tab。
- 增加当前生效配置展示、内置样本、本地 JSON 上传和源语言选择。
- 内置样本自动使用索引中的语言；本地上传必须指定语言；AI 模式可使用 AutoDetect。
- AI 请求确认改用项目封装的 `useConfirm`。
- 支持 AI 流式进度和结果展示、取消测试。
- 左侧始终显示原始 JSON，右侧支持 JSON/VTT 切换和下载。
- 编辑框默认约 5 行、上下对齐并可拖动高度。
- 完成约 900px 宽度下的响应式布局。
- 页面文案已补充多语言配置。
- 底部增加覆盖率、时间轴、长度、可读性以及 AI 请求统计。

## 测试样本与 CLI

- 新增 `testdata/subtitle-samples/` 字幕样本库和索引。
- 索引包含语言、视频链接、大小、SHA-256、标签和黄金边界信息。
- 仅 Web 构建复制样本，Chrome 扩展和用户脚本发布包不包含样本。
- 新增命令：

```bash
pnpm test:subtitle-segmentation
```

- 输出原始 JSON、flat events、规则/统计结果、VTT、指标和汇总到忽略的 `tmp/` 目录。
- 结构错误、覆盖失败、时间重叠、非语音泄漏或黄金边界变化会返回非零状态。
- CLI 和 Playground 共用断句及指标计算实现。

另外：
1、目前 `{e,o,t}` 中的 `o` 只用于模型自检，程序端尚未校验。使用 deepseek-v4-flash 测试中仍出现偶发出现译文跨字幕错位，后续可以单独增加 `o` 一致性校验和局部重试。另有断句不自然，或合并句子的情况，有待继续优化。
2、测试样本数据有待补充真实字幕数据。


https://github.com/fishjar/kiss-translator/pull/907

<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/de94cbed-d361-4909-8599-322c6e6a7b34" />
