### PR TITLE
feat: auto-hide floating button when entering video

### DIFF
--- a/src/hooks/useFullscreenDetect.js
+++ b/src/hooks/useFullscreenDetect.js
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+function getFullscreenElement() {
+  return (
+    document.fullscreenElement ||
+    document.webkitFullscreenElement ||
+    document.mozFullScreenElement ||
+    document.msFullscreenElement ||
+    null
+  );
+}
+
+function isVideoFullscreenElement(element) {
+  if (!element) {
+    return false;
+  }
+
+  if (element.tagName === "VIDEO") {
+    return true;
+  }
+
+  return Boolean(element.querySelector?.("video"));
+}
+
+/**
+ * 检测当前页面中的视频是否处于全屏状态。
+ * 仅在 video 元素本身或其容器进入全屏时返回 true，
+ * 不把浏览器自身的 F11 全屏误判为视频全屏。
+ * @returns {{ isVideoFullscreen: boolean }}
+ */
+export function useFullscreenDetect() {
+  const [isVideoFullscreen, setIsVideoFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      const element = getFullscreenElement();
+      setIsVideoFullscreen(isVideoFullscreenElement(element));
+    };
+
+    handleFullscreenChange();
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
+    document.addEventListener("mozfullscreenchange", handleFullscreenChange);
+    document.addEventListener("msfullscreenchange", handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      document.removeEventListener(
+        "webkitfullscreenchange",
+        handleFullscreenChange
+      );
+      document.removeEventListener(
+        "mozfullscreenchange",
+        handleFullscreenChange
+      );
+      document.removeEventListener(
+        "msfullscreenchange",
+        handleFullscreenChange
+      );
+    };
+  }, []);
+
+  return { isVideoFullscreen };
+}

--- a/src/views/Action/ContentFab.js
+++ b/src/views/Action/ContentFab.js
@@ -2,10 +2,11 @@ import Fab from "@mui/material/Fab";
 import TranslateIcon from "@mui/icons-material/Translate";
 import ThemeProvider from "../../hooks/Theme";
 import Draggable from "./Draggable";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { SettingProvider } from "../../hooks/Setting";
 import { MSG_TRANS_TOGGLE, MSG_POPUP_TOGGLE } from "../../config";
 import useWindowSize from "../../hooks/WindowSize";
+import { useFullscreenDetect } from "../../hooks/useFullscreenDetect";
 
 /**
  * 内容页悬浮翻译球 (Floating Action Button) 组件
@@ -18,6 +19,12 @@ export default function ContentFab({
   const fabWidth = 40; // 悬浮球的固定宽度 40px
   const windowSize = useWindowSize();
   const [moved, setMoved] = useState(false); // 标记是否发生了拖动
+  const [showFab, setShowFab] = useState(true);
+  const { isVideoFullscreen } = useFullscreenDetect();
+
+  useEffect(() => {
+    setShowFab(!isVideoFullscreen);
+  }, [isVideoFullscreen]);
 
   // 拖拽开始时的回调
   const handleStart = useCallback(() => {
@@ -61,6 +68,7 @@ export default function ContentFab({
           key="fab"
           snapEdge // 启用贴边吸附隐藏效果
           {...fabProps}
+          show={showFab}
           onStart={handleStart}
           onMove={handleMove}
           handler={


### PR DESCRIPTION
## 描述
实现了在视频全屏播放时自动隐藏悬浮翻译球的功能。

## 改动内容
- 新增 `useFullscreenDetect` Hook，用于检测视频全屏状态
- 改造 `ContentFab` 组件，在视频全屏时隐藏 FAB
- 仅识别真正的视频全屏，不误伤浏览器 F11 全屏

## 关闭的 Issue
Closes #930

## 测试方法
1. 打开包含视频的网站（YouTube、B站等）
2. 确认普通状态下悬浮球可见
3. 进入视频全屏，确认悬浮球隐藏
4. 退出全屏，确认悬浮球恢复显示
5. 按 F11 进入浏览器全屏，悬浮球应保持可见

## 浏览器兼容性
使用标准 API，功能跨浏览器通用，无特定浏览器限制。

Fix #930