### PR TITLE
feat: 支持聚合翻译批次并发

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -687,14 +687,30 @@ export const apiTranslate = async ({
   } else if (useBatchFetch && API_SPE_TYPES.batch.has(apiType)) {
     // 2.2 支持批量翻译的传统接口 (如 Google/Microsoft/DeepL 等)
     // 使用 BatchQueue 进行零散文本大合并，节省网络交互次数，大幅提升网页整页翻译的载入速度
-    const { apiSlug, batchInterval, batchSize, batchLength, useStream } =
-      apiSetting;
+    const {
+      apiSlug,
+      batchInterval,
+      batchSize,
+      batchLength,
+      batchConcurrency,
+      useStream,
+      useContext,
+    } = apiSetting;
     const enableStream = useStream && API_SPE_TYPES.stream.has(apiType);
-    const key = `${apiSlug}_${fromLang}_${toLang}_${enableStream ? "stream" : "batch"}_${promptSig}`;
+    const configuredBatchConcurrency = Number(batchConcurrency);
+    const effectiveBatchConcurrency =
+      useContext && API_SPE_TYPES.context.has(apiType)
+        ? 1
+        : Number.isFinite(configuredBatchConcurrency) &&
+            configuredBatchConcurrency >= 1
+          ? Math.floor(configuredBatchConcurrency)
+          : 1;
+    const key = `${apiSlug}_${fromLang}_${toLang}_${enableStream ? "stream" : "batch"}_${promptSig}_${effectiveBatchConcurrency}`;
     const queue = getBatchQueue(key, handleTranslate, {
       batchInterval,
       batchSize,
       batchLength,
+      batchConcurrency: effectiveBatchConcurrency,
     });
 
     translation = await queue.addTask(text, {

--- a/src/apis/index.test.js
+++ b/src/apis/index.test.js
@@ -492,6 +492,46 @@ describe("apiTranslate prompt queue isolation", () => {
     expect(signedTexts[0]).not.toContain("prompt_a");
     expect(signedTexts[1]).not.toContain("prompt_b");
   });
+
+  test("passes configured batch concurrency and isolates its queue", async () => {
+    await apiTranslate({
+      text: "hello",
+      fromLang: "en",
+      toLang: "zh-CN",
+      apiSetting: {
+        ...getOpenAiApiSetting("batch prompt A"),
+        batchConcurrency: 3,
+        useContext: false,
+      },
+      useCache: false,
+    });
+
+    expect(getBatchQueue).toHaveBeenCalledWith(
+      expect.stringMatching(/_3$/),
+      handleTranslate,
+      expect.objectContaining({ batchConcurrency: 3 })
+    );
+  });
+
+  test("forces batch concurrency to one for context sessions", async () => {
+    await apiTranslate({
+      text: "hello",
+      fromLang: "en",
+      toLang: "zh-CN",
+      apiSetting: {
+        ...getOpenAiApiSetting("batch prompt A"),
+        batchConcurrency: 4,
+        useContext: true,
+      },
+      useCache: false,
+    });
+
+    expect(getBatchQueue).toHaveBeenCalledWith(
+      expect.stringMatching(/_1$/),
+      handleTranslate,
+      expect.objectContaining({ batchConcurrency: 1 })
+    );
+  });
 });
 
 describe("apiTranslate non-batch stream", () => {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -10,6 +10,7 @@ export const DEFAULT_FETCH_INTERVAL = 100; // 默认任务间隔时间 (单位�
 export const DEFAULT_BATCH_INTERVAL = 400; // 批处理合并请求的等待延迟时间 (单位：毫秒)
 export const DEFAULT_BATCH_SIZE = 20; // 每次翻译请求最多合并发送的 DOM 段落数量
 export const DEFAULT_BATCH_LENGTH = 10000; // 每次翻译请求发送的最大字符数限制
+export const DEFAULT_BATCH_CONCURRENCY = 1; // 同时执行的聚合批次数量
 export const DEFAULT_CONTEXT_SIZE = 3; // AI 翻译时保留的上下文会话历史轮数
 
 // --- 翻译内容替换占位符 ---
@@ -834,6 +835,7 @@ const defaultApi = {
   batchInterval: DEFAULT_BATCH_INTERVAL, // 批处理请求间隔时间
   batchSize: DEFAULT_BATCH_SIZE, // 每次最多发送段落数量
   batchLength: DEFAULT_BATCH_LENGTH, // 每次发送最大文字数量
+  batchConcurrency: DEFAULT_BATCH_CONCURRENCY, // 同时执行的聚合批次数量
   useBatchFetch: false, // 是否启用聚合发送请求
   useStream: false, // 是否启用流式传输
   streamRenderMode: "disabled", // 流式渲染模式：disabled/realtime/segment

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -3787,6 +3787,22 @@ export const I18N = {
     ko: `일괄 요청 최대 텍스트 길이(1000-100000)`,
     tr: `Toplama Istekleri İçin Maksimum Metin Uzunluğu (1000-100000)`,
   },
+  batch_concurrency: {
+    zh: `聚合批次并发数(1-100)`,
+    en: `Concurrent aggregation batches (1-100)`,
+    zh_TW: `彙整批次並行數(1-100)`,
+    ja: `同時実行する一括リクエスト数(1-100)`,
+    ko: `동시 일괄 요청 수(1-100)`,
+    tr: `Eşzamanlı Toplama Grubu Sayısı (1-100)`,
+  },
+  batch_concurrency_context_hint: {
+    zh: `上下文会话要求批次按顺序执行，因此并发数固定为 1`,
+    en: `Context sessions require ordered batches, so concurrency is fixed at 1`,
+    zh_TW: `上下文會話要求批次依序執行，因此並行數固定為 1`,
+    ja: `コンテキスト利用時は順序を保つため、同時実行数は1に固定されます`,
+    ko: `컨텍스트 세션은 순차 실행이 필요하므로 동시 실행 수는 1로 고정됩니다`,
+    tr: `Bağlam oturumları sıralı gruplar gerektirdiğinden eşzamanlılık 1 olarak sabitlenir`,
+  },
   use_stream: {
     zh: `是否启用流式传输`,
     en: `Whether to enable streaming`,

--- a/src/libs/batchQueue.js
+++ b/src/libs/batchQueue.js
@@ -2,6 +2,7 @@ import {
   DEFAULT_BATCH_INTERVAL,
   DEFAULT_BATCH_SIZE,
   DEFAULT_BATCH_LENGTH,
+  DEFAULT_BATCH_CONCURRENCY,
 } from "../config";
 
 /**
@@ -14,6 +15,7 @@ import {
  * @param {number} [options.batchInterval] - 触发批处理的最大延迟等待时间（毫秒）
  * @param {number} [options.batchSize] - 触发批处理的最大任务条数上限
  * @param {number} [options.batchLength] - 整个批次中所有文本内容的最大字符长度上限，防止超长报错
+ * @param {number} [options.batchConcurrency] - 同时执行的最大批次数
  * @returns {object} 返回具有 addTask 和 destroy 方法的实例对象
  */
 const BatchQueue = (
@@ -22,10 +24,17 @@ const BatchQueue = (
     batchInterval = DEFAULT_BATCH_INTERVAL,
     batchSize = DEFAULT_BATCH_SIZE,
     batchLength = DEFAULT_BATCH_LENGTH,
+    batchConcurrency = DEFAULT_BATCH_CONCURRENCY,
   } = {}
 ) => {
   const queue = []; // 存储待处理翻译任务的队列
-  let isProcessing = false; // 当前队列是否正在处理中
+  const configuredBatchConcurrency = Number(batchConcurrency);
+  const concurrency =
+    Number.isFinite(configuredBatchConcurrency) &&
+    configuredBatchConcurrency >= 1
+      ? Math.floor(configuredBatchConcurrency)
+      : DEFAULT_BATCH_CONCURRENCY;
+  let activeBatchCount = 0; // 当前正在执行的批次数
   let timer = null; // 用于延迟处理任务的定时器
 
   /**
@@ -41,12 +50,12 @@ const BatchQueue = (
       timer = null;
     }
 
-    // 如果队列为空或已经在处理中，则直接返回
-    if (queue.length === 0 || isProcessing) {
+    // 如果队列为空或已经达到批次并发上限，则直接返回
+    if (queue.length === 0 || activeBatchCount >= concurrency) {
       return;
     }
 
-    isProcessing = true;
+    activeBatchCount++;
 
     let tasksToProcess = [];
     let currentBatchLength = 0;
@@ -71,7 +80,7 @@ const BatchQueue = (
     }
 
     if (tasksToProcess.length === 0) {
-      isProcessing = false;
+      activeBatchCount--;
       return;
     }
 
@@ -150,7 +159,7 @@ const BatchQueue = (
         }
       });
     } finally {
-      isProcessing = false;
+      activeBatchCount--;
       // 如果队列中还有残留任务，判断是否立即继续处理还是延迟等待
       if (queue.length > 0) {
         if (queue.length >= batchSize) {
@@ -166,7 +175,7 @@ const BatchQueue = (
    * 安排下一次队列的延迟防抖执行
    */
   const scheduleProcessing = () => {
-    if (!isProcessing && !timer && queue.length > 0) {
+    if (activeBatchCount < concurrency && !timer && queue.length > 0) {
       timer = setTimeout(processQueue, batchInterval);
     }
   };

--- a/src/libs/batchQueue.test.js
+++ b/src/libs/batchQueue.test.js
@@ -1,0 +1,191 @@
+import { getBatchQueue } from "./batchQueue";
+
+let queueId = 0;
+const createBatchQueue = (taskFn, options) =>
+  getBatchQueue(`batch-queue-test-${queueId++}`, taskFn, options);
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const flushQueueScheduling = async () => {
+  await flushPromises();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+};
+
+describe("BatchQueue batch concurrency", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("keeps batches serial by default", async () => {
+    const batches = [deferred(), deferred()];
+    const taskFn = jest
+      .fn()
+      .mockImplementationOnce(() => batches[0].promise)
+      .mockImplementationOnce(() => batches[1].promise);
+    const queue = createBatchQueue(taskFn, { batchSize: 1 });
+
+    const first = queue.addTask("first");
+    const second = queue.addTask("second");
+
+    expect(taskFn).toHaveBeenCalledTimes(1);
+    batches[0].resolve([["一", ""]]);
+    await expect(first).resolves.toEqual(["一", ""]);
+    await flushQueueScheduling();
+    expect(taskFn).toHaveBeenCalledTimes(2);
+
+    batches[1].resolve([["二", ""]]);
+    await expect(second).resolves.toEqual(["二", ""]);
+  });
+
+  test("starts up to the configured number of batches", async () => {
+    const batches = [deferred(), deferred(), deferred()];
+    const taskFn = jest
+      .fn()
+      .mockImplementationOnce(() => batches[0].promise)
+      .mockImplementationOnce(() => batches[1].promise)
+      .mockImplementationOnce(() => batches[2].promise);
+    const queue = createBatchQueue(taskFn, {
+      batchSize: 1,
+      batchConcurrency: 2,
+    });
+
+    const first = queue.addTask("first");
+    const second = queue.addTask("second");
+    const third = queue.addTask("third");
+
+    expect(taskFn).toHaveBeenCalledTimes(2);
+    batches[1].resolve([["二", ""]]);
+    await expect(second).resolves.toEqual(["二", ""]);
+    await flushQueueScheduling();
+    expect(taskFn).toHaveBeenCalledTimes(3);
+
+    batches[0].resolve([["一", ""]]);
+    batches[2].resolve([["三", ""]]);
+    await expect(first).resolves.toEqual(["一", ""]);
+    await expect(third).resolves.toEqual(["三", ""]);
+  });
+
+  test("releases a concurrency slot when a batch fails", async () => {
+    const batches = [deferred(), deferred()];
+    const error = new Error("batch failed");
+    const taskFn = jest
+      .fn()
+      .mockImplementationOnce(() => batches[0].promise)
+      .mockImplementationOnce(() => batches[1].promise);
+    const queue = createBatchQueue(taskFn, {
+      batchSize: 1,
+      batchConcurrency: 1,
+    });
+
+    const failed = queue.addTask("failed");
+    const next = queue.addTask("next");
+    const failedExpectation = expect(failed).rejects.toThrow("batch failed");
+
+    batches[0].reject(error);
+    await failedExpectation;
+    await flushQueueScheduling();
+    expect(taskFn).toHaveBeenCalledTimes(2);
+
+    batches[1].resolve([["继续", ""]]);
+    await expect(next).resolves.toEqual(["继续", ""]);
+  });
+
+  test("holds a slot until an async generator finishes", async () => {
+    const generatorGate = deferred();
+    const nextBatch = deferred();
+    const taskFn = jest
+      .fn()
+      .mockImplementationOnce(async function* firstGenerator() {
+        yield { id: 0, result: ["完成", ""] };
+        await generatorGate.promise;
+      })
+      .mockImplementationOnce(() => nextBatch.promise);
+    const queue = createBatchQueue(taskFn, {
+      batchSize: 1,
+      batchConcurrency: 1,
+    });
+
+    const first = queue.addTask("first");
+    const second = queue.addTask("second");
+
+    await expect(first).resolves.toEqual(["完成", ""]);
+    expect(taskFn).toHaveBeenCalledTimes(1);
+
+    generatorGate.resolve();
+    await flushQueueScheduling();
+    expect(taskFn).toHaveBeenCalledTimes(2);
+
+    nextBatch.resolve([["下一批", ""]]);
+    await expect(second).resolves.toEqual(["下一批", ""]);
+  });
+
+  test("waits for batchInterval when a batch is not full", async () => {
+    jest.useFakeTimers();
+    const taskFn = jest.fn().mockResolvedValue([["完成", ""]]);
+    const queue = createBatchQueue(taskFn, {
+      batchInterval: 100,
+      batchSize: 2,
+      batchConcurrency: 2,
+    });
+
+    const task = queue.addTask("only");
+    jest.advanceTimersByTime(99);
+    expect(taskFn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await flushPromises();
+    expect(taskFn).toHaveBeenCalledTimes(1);
+    await expect(task).resolves.toEqual(["完成", ""]);
+  });
+
+  test("keeps task results isolated when concurrent batches finish out of order", async () => {
+    const firstBatch = deferred();
+    const secondBatch = deferred();
+    const taskFn = jest
+      .fn()
+      .mockImplementationOnce(() => firstBatch.promise)
+      .mockImplementationOnce(() => secondBatch.promise);
+    const queue = createBatchQueue(taskFn, {
+      batchSize: 2,
+      batchConcurrency: 2,
+    });
+
+    const results = [
+      queue.addTask("a"),
+      queue.addTask("b"),
+      queue.addTask("c"),
+      queue.addTask("d"),
+    ];
+    expect(taskFn).toHaveBeenCalledTimes(2);
+
+    secondBatch.resolve([
+      ["C", ""],
+      ["D", ""],
+    ]);
+    firstBatch.resolve([
+      ["A", ""],
+      ["B", ""],
+    ]);
+
+    await expect(Promise.all(results)).resolves.toEqual([
+      ["A", ""],
+      ["B", ""],
+      ["C", ""],
+      ["D", ""],
+    ]);
+  });
+});

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -79,6 +79,7 @@ import {
   DEFAULT_BATCH_INTERVAL,
   DEFAULT_BATCH_SIZE,
   DEFAULT_BATCH_LENGTH,
+  DEFAULT_BATCH_CONCURRENCY,
   DEFAULT_CONTEXT_SIZE,
   OPT_ALL_TRANS_TYPES,
   OPT_LANGS_LIST,
@@ -453,6 +454,7 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
     batchInterval = DEFAULT_BATCH_INTERVAL,
     batchSize = DEFAULT_BATCH_SIZE,
     batchLength = DEFAULT_BATCH_LENGTH,
+    batchConcurrency = DEFAULT_BATCH_CONCURRENCY,
     useContext = false,
     contextSize = DEFAULT_CONTEXT_SIZE,
     tone = "neutral",
@@ -469,6 +471,8 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
     subtitlePromptSlug = "",
     dictPromptSlug = "",
   } = activeFormData;
+  const contextForcesSerialBatch =
+    useContext && API_SPE_TYPES.context.has(apiType);
 
   useEffect(() => {
     setModelListStatus("idle");
@@ -849,6 +853,25 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
                 onChange={handleChange}
                 min={1000}
                 max={100000}
+              />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+              <ValidationInput
+                size="small"
+                fullWidth
+                label={i18n("batch_concurrency")}
+                type="number"
+                name="batchConcurrency"
+                value={contextForcesSerialBatch ? 1 : batchConcurrency}
+                onChange={handleChange}
+                min={1}
+                max={100}
+                disabled={contextForcesSerialBatch}
+                helperText={
+                  contextForcesSerialBatch
+                    ? i18n("batch_concurrency_context_hint")
+                    : ""
+                }
               />
             </Grid>
           </Grid>

--- a/src/views/Options/Apis.test.js
+++ b/src/views/Options/Apis.test.js
@@ -275,3 +275,29 @@ describe("Apis model list", () => {
     view.unmount();
   });
 });
+
+describe("Apis batch concurrency", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("disables batch concurrency at one when context is enabled", async () => {
+    const view = await renderApis(
+      createApi({
+        useBatchFetch: true,
+        batchConcurrency: 4,
+        useContext: true,
+      })
+    );
+    const concurrencyInput = getInput(view.container, "batchConcurrency");
+
+    expect(concurrencyInput.value).toBe("1");
+    expect(concurrencyInput.disabled).toBe(true);
+    expect(view.container.textContent).toContain(
+      "batch_concurrency_context_hint"
+    );
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## 功能说明

- 新增可配置的 `batchConcurrency`，默认值为 `1`
- 支持同一聚合翻译队列内多个批次并发执行
- 开启上下文会话时强制使用单批次串行，避免会话历史乱序
- 在 API 设置页面增加“聚合批次并发数”配置项

## 问题背景

原有 `BatchQueue` 使用 `isProcessing` 布尔值控制执行状态，导致开启聚合翻译后，同一队列中的批次始终串行执行。

因此，即使提高 `fetchLimit`，聚合翻译也无法利用请求池的并发能力。

## 兼容性

批次并发默认值为 `1`，现有用户的行为保持不变。

并发限制只作用于单个现有批处理队列，不改变原有按 API、源语言、目标语言、流式模式和提示词划分队列的逻辑。

底层请求仍受 `fetchLimit` 和 `fetchInterval` 限制。

## 补充讨论

当前源语言设置为 `auto` 时，逐节点语言检测可能产生 `auto`、`en` 等不同的 `fromLang`，进而被分配到不同的批处理队列，可能使实际请求并发数远高于配置的并发数。

本 PR 暂不修改原有队列划分逻辑，希望作者评估：当用户配置的源语言为 `auto` 时，批处理队列是否可以不再按照检测后的 `fromLang` 拆分，或改用稳定的源语言配置值作为队列 Key。

## 测试

新增测试覆盖：

- 默认串行行为
- 多批次并发执行
- 并发上限控制
- 批次失败后释放执行槽位
- 异步生成器完整生命周期
- 聚合等待时间
- 批次乱序完成时的结果隔离
- 上下文模式强制并发数为 `1`

Closes #934 