### PR TITLE
feat: 添加 OpenRouter 应用归因

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -853,7 +853,7 @@ const genOpenRouter = ({
   const headers = {
     "Content-type": "application/json",
     Authorization: `Bearer ${key}`,
-    "HTTP-Referer": "https://github.com/fishjar/kiss-translator",
+    "HTTP-Referer": "https://fishjar.github.io/kiss-translator/",
     "X-OpenRouter-Title": "KISS Translator",
   };
 

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -853,6 +853,8 @@ const genOpenRouter = ({
   const headers = {
     "Content-type": "application/json",
     Authorization: `Bearer ${key}`,
+    "HTTP-Referer": "https://github.com/fishjar/kiss-translator",
+    "X-OpenRouter-Title": "KISS Translator",
   };
 
   return { url, body, headers, userMsg };


### PR DESCRIPTION
## 改动

为 OpenRouter 请求增加应用归因 Header：

- `HTTP-Referer`: `https://github.com/fishjar/kiss-translator`
- `X-OpenRouter-Title`: `KISS Translator`

仅影响 OpenRouter 请求，不改变请求内容和其他翻译服务。

## 效果

方便用户在 OpenRouter Logs 的 `App` 列中识别来自 KISS Translator 的请求：

下图中，上方为增加归因后的请求

<img width="1405" height="150" alt="OpenRouter Logs 中 KISS Translator 归因前后对比" src="https://github.com/user-attachments/assets/6a0cad87-6a52-487e-9bf4-1d72eb488e4d" />

参考文档：https://openrouter.ai/docs/app-attribution