### PR TITLE
fix: 修复模型列表重复显示

### DIFF
--- a/src/libs/modelList.js
+++ b/src/libs/modelList.js
@@ -72,10 +72,13 @@ export function parseModelListResponse(data) {
         return;
       }
 
-      // 按常见字段依次尝试；去重逻辑会避免同一模型被重复加入。
-      addUniqueModel(models, seen, item.id);
-      addUniqueModel(models, seen, item.name);
-      addUniqueModel(models, seen, item.baseModelId);
+      // 每条记录只对应一个可填入 `model` 的值。OpenRouter 等接口会同时返回
+      // `id`（请求使用的模型 ID）和 `name`（展示标题），因此必须优先选择
+      // `id`，不能把同一模型的多个描述字段都展开成下拉选项。
+      const model = [item.id, item.name, item.baseModelId].find(
+        (value) => typeof value === "string" && value.trim()
+      );
+      addUniqueModel(models, seen, model);
     });
   });
 

--- a/src/libs/modelList.test.js
+++ b/src/libs/modelList.test.js
@@ -15,6 +15,23 @@ describe("modelList", () => {
     ).toEqual(["gpt-4o", "deepseek-chat"]);
   });
 
+  test("uses OpenRouter model IDs instead of also listing display names", () => {
+    expect(
+      parseModelListResponse({
+        data: [
+          {
+            id: "qwen/qwen3.7-flash",
+            name: "Qwen: Qwen3.7 Flash",
+          },
+          {
+            id: "anthropic/claude-opus-5-fast",
+            name: "Claude Opus 5 (Fast)",
+          },
+        ],
+      })
+    ).toEqual(["qwen/qwen3.7-flash", "anthropic/claude-opus-5-fast"]);
+  });
+
   test("parses Gemini model lists", () => {
     expect(
       parseModelListResponse({


### PR DESCRIPTION
## 改动

OpenRouter 模型列表同时返回模型 ID 和展示名称，原解析逻辑会将两者都加入选项，导致同一模型重复显示。

修改后优先使用实际模型 ID，每条模型记录只生成一个选项。

## 效果

| 修改前 | 修改后 |
| --- | --- |
|<img width="280" height="352" alt="Before" src="https://github.com/user-attachments/assets/2c6fd0b6-094d-483e-a70c-3e2ba1e54ee9" /> | <img width="285" height="282" alt="After" src="https://github.com/user-attachments/assets/afd6b57e-04b4-4e22-adbe-3250d06cbf5b" />|

## 验证

相关单元测试与 Chrome 扩展构建均已通过。
