### PR TITLE
fix: 缓存Youtube字幕轨道

### DIFF
--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -555,10 +555,10 @@ export class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
-      const captionUrl = captionTrack.baseUrl.startsWith("https")
-        ? captionTrack.baseUrl
-        : window.location.origin + captionTrack.baseUrl;
-      const capUrl = new URL(captionUrl);
+      if (!captionTrack.baseUrl.startsWith("https")) {
+        captionTrack.baseUrl = window.location.origin + captionTrack.baseUrl;
+      }
+      const capUrl = new URL(captionTrack.baseUrl);
       const events = await getSubtitleEvents(capUrl, potUrl, responseText);
       if (this.#isStaleProcessing(processingVersion)) return;
 

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -555,10 +555,10 @@ export class YouTubeCaptionProvider {
         logger.debug("Youtube Provider: CaptionTrack not found:", videoId);
         return;
       }
-      if (!captionTrack.baseUrl.startsWith("https")) {
-        captionTrack.baseUrl = window.location.origin + captionTrack.baseUrl;
-      }
-      const capUrl = new URL(captionTrack.baseUrl);
+      const captionUrl = captionTrack.baseUrl.startsWith("https")
+        ? captionTrack.baseUrl
+        : window.location.origin + captionTrack.baseUrl;
+      const capUrl = new URL(captionUrl);
       const events = await getSubtitleEvents(capUrl, potUrl, responseText);
       if (this.#isStaleProcessing(processingVersion)) return;
 

--- a/src/subtitle/youtubeCaptionTracks.js
+++ b/src/subtitle/youtubeCaptionTracks.js
@@ -89,9 +89,8 @@ export function findCaptionTrack(captionTracks, lang, kind) {
   }
 
   if (!captionTrack) {
-    // REVIEW: 这里沿用原有 pop() 行为。它会修改 captionTracks 数组，
-    // 后续若要修复副作用，应单独改为下标读取或克隆数组。
-    captionTrack = captionTracks.pop();
+    // Keep cached track metadata immutable.
+    captionTrack = captionTracks[captionTracks.length - 1];
   }
 
   // Chat/弹幕字幕轨道自动降级为正常字幕轨道。
@@ -123,18 +122,11 @@ export function findCaptionTrack(captionTracks, lang, kind) {
   return captionTrack;
 }
 
-/**
- * 请求 YouTube 播放页 HTML，并解析当前视频的字幕轨列表与原始描述。
- *
- * @param {string} videoId 当前视频 ID。
- * @returns {Promise<{captionTracks?: Array<object>, fullDescription?: string}>} 字幕轨配置与视频描述。
- */
-export async function getCaptionTracks(videoId) {
+let captionTracksCache = null;
+
+async function fetchCaptionTracks(videoId) {
   try {
     const url = `https://www.youtube.com/watch?v=${videoId}`;
-    // REVIEW: 每次处理字幕都会重新 fetch 播放页并正则匹配 ytInitialPlayerResponse。
-    // 这会造成二次网页下载，也可能在高频使用时被 YouTube 视为异常流量。
-    // 后续可优先从当前页面全局对象或客户端内部 API 读取。
     const html = await fetch(url).then((r) => r.text());
     const match = html.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/s);
     if (!match) return {};
@@ -148,6 +140,33 @@ export async function getCaptionTracks(videoId) {
     logger.info("Youtube Provider: get captionTracks", err);
     return {};
   }
+}
+
+/**
+ * Fetch and cache the current video's caption metadata.
+ * Reuses an in-flight request when multiple tracks arrive for the same video.
+ *
+ * @param {string} videoId Current video ID.
+ * @returns {Promise<{captionTracks?: Array<object>, fullDescription?: string}>}
+ */
+export async function getCaptionTracks(videoId) {
+  if (captionTracksCache?.videoId === videoId) {
+    return captionTracksCache.promise;
+  }
+
+  const promise = fetchCaptionTracks(videoId);
+  captionTracksCache = { videoId, promise };
+  const result = await promise;
+
+  // Do not retain failed or incomplete metadata; a later request can retry.
+  if (
+    !result.captionTracks?.length &&
+    captionTracksCache?.promise === promise
+  ) {
+    captionTracksCache = null;
+  }
+
+  return result;
 }
 
 /**

--- a/src/subtitle/youtubeCaptionTracks.test.js
+++ b/src/subtitle/youtubeCaptionTracks.test.js
@@ -1,6 +1,7 @@
 import {
   buildTrackKey,
   findCaptionTrack,
+  getCaptionTracks,
   isChatCaptionTrack,
   isSameLang,
 } from "./youtubeCaptionTracks.js";
@@ -13,6 +14,20 @@ jest.mock("../libs/log.js", () => ({
 }));
 
 describe("youtubeCaptionTracks", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete global.fetch;
+    }
+  });
+
   test("matches language families by their leading language code", () => {
     expect(isSameLang("zh-CN", "zh-TW")).toBe(true);
     expect(isSameLang("en", "fr")).toBe(false);
@@ -54,12 +69,62 @@ describe("youtubeCaptionTracks", () => {
     expect(findCaptionTrack([chat, normal], "en", null)).toBe(normal);
   });
 
-  test("keeps the existing pop fallback behavior when no track matches", () => {
+  test("does not mutate tracks when using the fallback", () => {
     const tracks = [{ languageCode: "de" }];
 
     expect(findCaptionTrack(tracks, "en", null)).toEqual({
       languageCode: "de",
     });
-    expect(tracks).toHaveLength(0);
+    expect(tracks).toHaveLength(1);
+  });
+
+  test("reuses one page request for concurrent tracks of the same video", async () => {
+    const playerResponse = {
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [{ languageCode: "en" }],
+        },
+      },
+    };
+    global.fetch.mockResolvedValue({
+      text: async () =>
+        `ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};`,
+    });
+
+    const results = await Promise.all([
+      getCaptionTracks("cache-video-1"),
+      getCaptionTracks("cache-video-1"),
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(results[0].captionTracks).toHaveLength(1);
+    expect(results[1].captionTracks).toHaveLength(1);
+  });
+
+  test("fetches again when the video changes", async () => {
+    global.fetch.mockResolvedValue({
+      text: async () =>
+        'ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"languageCode":"en"}]}}};',
+    });
+
+    await getCaptionTracks("cache-video-2");
+    await getCaptionTracks("cache-video-3");
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("allows a retry after invalid page metadata", async () => {
+    global.fetch
+      .mockResolvedValueOnce({ text: async () => "invalid response" })
+      .mockResolvedValueOnce({
+        text: async () =>
+          'ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"languageCode":"en"}]}}};',
+      });
+
+    await getCaptionTracks("retry-video");
+    const result = await getCaptionTracks("retry-video");
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.captionTracks).toHaveLength(1);
   });
 });


### PR DESCRIPTION
原始逻辑，字幕翻译每次切换字幕轨道，都会重新请求一个html页面，从中解析。
这非常的不优雅，也会拖慢性能

增加了对字幕轨道的缓存机制，以videoid为键，临时缓存当前视频的字幕轨道信息

实测，轨道切换速度犹如火箭，效果立竿见影

影响范围：fallback和手动切换，二者速率都有提升
实测视频：https://t.me/kisstranslator/13047