### PR TITLE
Feature/ignore target languages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: true
+  core-js-pure: true

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -3541,21 +3541,21 @@ export const I18N = {
     ko: `선택한 텍스트를 더블클릭하여 번역`,
     tr: `Çevirmek İçin Seçilen Metni Çift Tıklayın`,
   },
-  disable_tranbtn_on_tolang: {
-    zh: `目标语言不弹窗`,
-    en: `Disable popup when target language is detected`,
-    zh_TW: `目標語言不彈窗`,
-    ja: `対象言語が検出された場合、ポップアップを無効にする`,
-    ko: `대상 언어가 감지되면 팝업을 비활성화`,
-    tr: `Hedef dil algılandığında açılır pencereyi devre dışı bırak`,
+  selection_skip_langs: {
+    zh: `忽略的语言`,
+    en: `Ignore Languages`,
+    zh_TW: `忽略的語言`,
+    ja: `無視する言語`,
+    ko: `무시할 언어`,
+    tr: `Dilleri Yoksay`,
   },
-  disable_tranbtn_on_tolang_helper: {
-    zh: `开启后，若划选文本已是目标语言，则不显示翻译弹窗`,
-    en: `When enabled, if the selected text is already in the target language, the translation popup will not be displayed`,
-    zh_TW: `開啟後，若選取文字已是目標語言，則不顯示翻譯彈窗`,
-    ja: `有効にすると、選択したテキストがすでに対象言語の場合、翻訳ポップアップは表示されません`,
-    ko: `활성화되면 선택한 텍스트가 이미 대상 언어인 경우 번역 팝업이 표시되지 않습니다`,
-    tr: `Etkinleştirildiğinde, seçilen metin zaten hedef dildeyse, çeviri açılır penceresi görüntülenmez`,
+  selection_skip_langs_helper: {
+    zh: `列表中的语言不弹窗（设定后，第二目标语言互译功能将自动禁用）`,
+    en: `Don't show popup for languages in this list (when enabled, will automatically disable bidirectional translation for the second target language)`,
+    zh_TW: `列表中的語言不彈窗（設定後，第二目標語言的互譯功能將自動禁用）`,
+    ja: `リスト内の言語はポップアップを表示しません（有効にすると、第二の対象言語の双方向翻訳機能が自動的に無効になります）`,
+    ko: `목록에 있는 언어는 팝업을 표시하지 않습니다 (활성화 시, 두 번째 대상 언어의 양방향 번역 기능이 자동으로 비활성화됩니다)`,
+    tr: `Bu listedeki diller için açılır pencere gösterilmez (etkinleştirildiğinde, ikinci hedef dil için çift yönlü çeviri işlevi otomatik olarak devre dışı bırakılır)`,
   },
 
   translate_start_hook: {

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -3542,18 +3542,20 @@ export const I18N = {
     tr: `Çevirmek İçin Seçilen Metni Çift Tıklayın`,
   },
   disable_tranbtn_on_tolang: {
-    zh: `检测到划词为目标语言时，禁用划词翻译弹窗
-    （开启后会自动禁用第二目标语言选项的互译功能）`,
-    en: `Disable pop-up when target language detected
-    (Enabling this will automatically disable the mutual translation function of the second target language option)`,
-    zh_TW: `偵測到目標語言時停用劃詞彈窗
-    （啟用後會自動停用第二目標語言選項的互譯功能）`,
-    ja: `対象言語が検出された場合はポップアップを無効化
-    （有効にすると、2番目の対象言語オプションの相互翻訳機能が自動的に無効化されます）`,
-    ko: `대상 언어 감지 시 팝업 비활성화
-    (활성화하면 두 번째 대상 언어 옵션의 상호 번역 기능이 자동으로 비활성화됩니다)`,
-    tr: `Hedef dil algılandığında açılır pencereyi devre dışı bırak
-    (Bunu etkinleştirmek, ikinci hedef dil seçeneğinin karşılıklı çeviri işlevini otomatik olarak devre dışı bırakır)`,
+    zh: `目标语言不弹窗`,
+    en: `Disable popup when target language is detected`,
+    zh_TW: `目標語言不彈窗`,
+    ja: `対象言語が検出された場合、ポップアップを無効にする`,
+    ko: `대상 언어가 감지되면 팝업을 비활성화`,
+    tr: `Hedef dil algılandığında açılır pencereyi devre dışı bırak`,
+  },
+  disable_tranbtn_on_tolang_helper: {
+    zh: `开启后，若划选文本已是目标语言，则不显示翻译弹窗`,
+    en: `When enabled, if the selected text is already in the target language, the translation popup will not be displayed`,
+    zh_TW: `開啟後，若選取文字已是目標語言，則不顯示翻譯彈窗`,
+    ja: `有効にすると、選択したテキストがすでに対象言語の場合、翻訳ポップアップは表示されません`,
+    ko: `활성화되면 선택한 텍스트가 이미 대상 언어인 경우 번역 팝업이 표시되지 않습니다`,
+    tr: `Etkinleştirildiğinde, seçilen metin zaten hedef dildeyse, çeviri açılır penceresi görüntülenmez`,
   },
 
   translate_start_hook: {

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -3541,6 +3541,21 @@ export const I18N = {
     ko: `선택한 텍스트를 더블클릭하여 번역`,
     tr: `Çevirmek İçin Seçilen Metni Çift Tıklayın`,
   },
+  disable_tranbtn_on_tolang: {
+    zh: `检测到划词为目标语言时，禁用划词翻译弹窗
+    （开启后会自动禁用第二目标语言选项的互译功能）`,
+    en: `Disable pop-up when target language detected
+    (Enabling this will automatically disable the mutual translation function of the second target language option)`,
+    zh_TW: `偵測到目標語言時停用劃詞彈窗
+    （啟用後會自動停用第二目標語言選項的互譯功能）`,
+    ja: `対象言語が検出された場合はポップアップを無効化
+    （有効にすると、2番目の対象言語オプションの相互翻訳機能が自動的に無効化されます）`,
+    ko: `대상 언어 감지 시 팝업 비활성화
+    (활성화하면 두 번째 대상 언어 옵션의 상호 번역 기능이 자동으로 비활성화됩니다)`,
+    tr: `Hedef dil algılandığında açılır pencereyi devre dışı bırak
+    (Bunu etkinleştirmek, ikinci hedef dil seçeneğinin karşılıklı çeviri işlevini otomatik olarak devre dışı bırakır)`,
+  },
+
   translate_start_hook: {
     zh: `翻译开始钩子函数`,
     en: `Translate Start Hook`,

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -112,6 +112,7 @@ export const OPT_TRANBOX_BTN_POSITION_ALL = [
 export const OPT_TRANBOX_INTERACT_CLICK = "click"; // 单击翻译框内选中文本触发新翻译
 export const OPT_TRANBOX_INTERACT_DBLCLICK = "dblclick"; // 双击翻译框内选中文本触发新翻译
 export const DEFAULT_TRANBOX_SHORTCUT = ["AltLeft", "KeyS"]; // 呼出划词翻译面板的键盘快捷键
+
 export const DEFAULT_TRANBOX_SETTING = {
   transOpen: true, // 是否启用划词翻译功能
   blacklist: "", // 划词翻译禁用的域名列表
@@ -134,6 +135,8 @@ export const DEFAULT_TRANBOX_SETTING = {
   triggerMode: OPT_TRANBOX_TRIGGER_CLICK, // 划词触发翻译的行为模式
   btnPositionMode: OPT_TRANBOX_BTN_POSITION_FIXED, // 划词后弹出按钮的定位模式
   tranboxInteractMode: "-", // 翻译框内交互模式（"-"表示禁用）
+  disableTranBtnOnToLang: true, // 检测到选中文本为翻译目标语言时，禁用划词翻译按钮弹出
+
   // extStyles: "", // 附加样式
   enDict: OPT_DICT_BING, // 默认英文网络词典数据源
   enSug: OPT_SUG_YOUDAO, // 英文输入联想建议源

--- a/src/config/setting.js
+++ b/src/config/setting.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_HTTP_TIMEOUT,
   OPT_TRANS_MICROSOFT,
   DEFAULT_API_LIST,
+  OPT_LANGS_TO,
 } from "./api";
 import {
   CURRENT_SETTINGS_VERSION,
@@ -113,6 +114,12 @@ export const OPT_TRANBOX_INTERACT_CLICK = "click"; // 单击翻译框内选中�
 export const OPT_TRANBOX_INTERACT_DBLCLICK = "dblclick"; // 双击翻译框内选中文本触发新翻译
 export const DEFAULT_TRANBOX_SHORTCUT = ["AltLeft", "KeyS"]; // 呼出划词翻译面板的键盘快捷键
 
+// 划词翻译"忽略的语言"下拉选项：将 zh-CN/zh-TW 合并为单个 "zh" 条目
+export const OPT_SKIPLANGS_SELECTION = [
+  ["zh", "中文 Chinese"],
+  ...OPT_LANGS_TO.filter(([code]) => code !== "zh-CN" && code !== "zh-TW"),
+];
+
 export const DEFAULT_TRANBOX_SETTING = {
   transOpen: true, // 是否启用划词翻译功能
   blacklist: "", // 划词翻译禁用的域名列表
@@ -135,7 +142,7 @@ export const DEFAULT_TRANBOX_SETTING = {
   triggerMode: OPT_TRANBOX_TRIGGER_CLICK, // 划词触发翻译的行为模式
   btnPositionMode: OPT_TRANBOX_BTN_POSITION_FIXED, // 划词后弹出按钮的定位模式
   tranboxInteractMode: "-", // 翻译框内交互模式（"-"表示禁用）
-  disableTranBtnOnToLang: true, // 检测到选中文本为翻译目标语言时，禁用划词翻译按钮弹出
+  skipLangs: ["zh"], // 忽略的语言：划词检测到列表内语言时不弹窗
 
   // extStyles: "", // 附加样式
   enDict: OPT_DICT_BING, // 默认英文网络词典数据源

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -302,7 +302,7 @@ export default function useSelectionController({
   );
 
   // 判断当前划词是否应被拦截 (不弹出翻译按钮/翻译框)。
-  // 命中条件：纯数字、检测语言命中黑名单、或与目标语言匹配 (简体/繁体统一视为 zh)。
+  // 命中条件：纯数字、或与目标语言匹配 (简体/繁体统一视为 zh)。
   const shouldSuppressSelection = useCallback(
     async (text) => {
       if (isPureNumberText(text)) return true;
@@ -340,7 +340,7 @@ export default function useSelectionController({
       pendingSelectionRef.current = snapshot;
       setSelText(snapshot.text);
 
-      // 目标语言/黑名单/纯数字命中时，统一禁用划词按钮与翻译框弹出
+      // 目标语言/纯数字命中时，统一禁用划词按钮与翻译框弹出
       if (await shouldSuppressSelection(snapshot.text)) {
         setShowBtn(false);
         setShowBox(false);

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -1,6 +1,12 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { sleep, limitNumber } from "../libs/utils";
 import { isMobile } from "../libs/mobile";
+import {
+  detectLangFast,
+  isPureNumberText,
+  normalizeZhLang,
+  quickDetectLang,
+} from "../libs/detectFast";
 import useAutoHideTranBtn from "./useAutoHideTranBtn";
 import {
   APP_CONSTS,
@@ -227,6 +233,8 @@ export default function useSelectionController({
     btnOffsetX = 0,
     btnOffsetY = 0,
     tranboxInteractMode = "-",
+    disableTranBtnOnToLang = true,
+    toLang = "zh-CN",
   } = tranboxSetting;
 
   const [showBox, setShowBox] = useState(false);
@@ -293,8 +301,37 @@ export default function useSelectionController({
     []
   );
 
+  // 判断当前划词是否应被拦截 (不弹出翻译按钮/翻译框)。
+  // 命中条件：纯数字、检测语言命中黑名单、或与目标语言匹配 (简体/繁体统一视为 zh)。
+  const shouldSuppressSelection = useCallback(
+    async (text) => {
+      if (isPureNumberText(text)) return true;
+      if (typeof text !== "string" || !text.trim()) return false;
+
+      // 先进行同步字符集快判（零开销），能明确识别的语言直接走判定
+      const quickLang = quickDetectLang(text);
+      // 短文本：只有字符集能明确识别时才继续判定（避免拉丁短词误判）
+      if (text.length < 4 && !quickLang) return false;
+
+      // 快判有结果则直接用，否则对较长文本走完整异步检测
+      const lang = quickLang || (await detectLangFast(text));
+      if (!lang) return false;
+
+      const normLang = normalizeZhLang(lang);
+      if (
+        disableTranBtnOnToLang &&
+        toLang &&
+        normalizeZhLang(toLang) === normLang
+      ) {
+        return true;
+      }
+      return false;
+    },
+    [disableTranBtnOnToLang, toLang]
+  );
+
   const processSelectionSnapshot = useCallback(
-    (snapshot) => {
+    async (snapshot) => {
       if (!snapshot?.text) {
         setShowBtn(false);
         return;
@@ -302,6 +339,13 @@ export default function useSelectionController({
 
       pendingSelectionRef.current = snapshot;
       setSelText(snapshot.text);
+
+      // 目标语言/黑名单/纯数字命中时，统一禁用划词按钮与翻译框弹出
+      if (await shouldSuppressSelection(snapshot.text)) {
+        setShowBtn(false);
+        setShowBox(false);
+        return;
+      }
 
       // 翻译框内交互模式：拦截面板内选区，等待用户单击/双击触发
       if (snapshot.source === "panel" && tranboxInteractMode !== "-") {
@@ -362,6 +406,7 @@ export default function useSelectionController({
       commitSelectionSnapshot,
       boxSize,
       setBoxPosition,
+      shouldSuppressSelection,
     ]
   );
 
@@ -394,7 +439,7 @@ export default function useSelectionController({
         target
       );
 
-      processSelectionSnapshot(snapshot);
+      await processSelectionSnapshot(snapshot);
     },
     [createSelectionSnapshot, processSelectionSnapshot]
   );

--- a/src/hooks/useSelectionController.js
+++ b/src/hooks/useSelectionController.js
@@ -233,8 +233,7 @@ export default function useSelectionController({
     btnOffsetX = 0,
     btnOffsetY = 0,
     tranboxInteractMode = "-",
-    disableTranBtnOnToLang = true,
-    toLang = "zh-CN",
+    skipLangs = [],
   } = tranboxSetting;
 
   const [showBox, setShowBox] = useState(false);
@@ -318,16 +317,12 @@ export default function useSelectionController({
       if (!lang) return false;
 
       const normLang = normalizeZhLang(lang);
-      if (
-        disableTranBtnOnToLang &&
-        toLang &&
-        normalizeZhLang(toLang) === normLang
-      ) {
+      if (skipLangs.includes(normLang)) {
         return true;
       }
       return false;
     },
-    [disableTranBtnOnToLang, toLang]
+    [skipLangs]
   );
 
   const processSelectionSnapshot = useCallback(

--- a/src/hooks/useSelectionController.test.js
+++ b/src/hooks/useSelectionController.test.js
@@ -69,7 +69,7 @@ function TestController({
   boxSize = { w: 320, h: 240 },
   setBoxPosition = jest.fn(),
   toLang = "zh-CN",
-  disableTranBtnOnToLang = true,
+  skipLangs = [],
 }) {
   const state = useSelectionController({
     tranboxSetting: {
@@ -80,7 +80,7 @@ function TestController({
       btnOffsetY: 0,
       tranboxInteractMode,
       toLang,
-      disableTranBtnOnToLang,
+      skipLangs,
     },
     followSelection,
     boxOffsetX: 0,
@@ -589,8 +589,8 @@ describe("useSelectionController", () => {
     });
   });
 
-  test("hides the button when the selected language matches the target language", async () => {
-    const controller = renderController();
+  test("hides the button when the selected language is in skipLangs", async () => {
+    const controller = renderController({ skipLangs: ["zh"] });
     const pageParagraph = createParagraph("The library is open.");
 
     detectLangFast.mockResolvedValue("zh-CN");
@@ -606,8 +606,8 @@ describe("useSelectionController", () => {
     });
   });
 
-  test("treats traditional Chinese as the target language via zh normalization", async () => {
-    const controller = renderController();
+  test("treats traditional Chinese as zh via normalization in skipLangs", async () => {
+    const controller = renderController({ skipLangs: ["zh"] });
     const pageParagraph = createParagraph("The library is open.");
 
     detectLangFast.mockResolvedValue("zh-TW");
@@ -636,8 +636,23 @@ describe("useSelectionController", () => {
     });
   });
 
-  test("shows the button when the target-language suppression is disabled", async () => {
-    const controller = renderController({ disableTranBtnOnToLang: false });
+  test("suppresses the button when skipLangs includes the detected language", async () => {
+    const controller = renderController({ skipLangs: ["en"] });
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("en");
+    currentSelection = makeSelection("some english text here", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(false);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("shows the button when skipLangs is empty and detected lang differs from toLang", async () => {
+    const controller = renderController({ skipLangs: [], toLang: "ja" });
     const pageParagraph = createParagraph("The library is open.");
 
     detectLangFast.mockResolvedValue("zh-CN");

--- a/src/hooks/useSelectionController.test.js
+++ b/src/hooks/useSelectionController.test.js
@@ -10,6 +10,16 @@ jest.mock("../libs/mobile", () => ({
   isMobile: false,
 }));
 
+jest.mock("../libs/detectFast", () => {
+  const actual = jest.requireActual("../libs/detectFast");
+  return {
+    ...actual,
+    detectLangFast: jest.fn(),
+  };
+});
+
+import { detectLangFast } from "../libs/detectFast";
+
 function makeSelection(text, container, rectOverride) {
   const rect = rectOverride || {
     left: 10,
@@ -58,6 +68,8 @@ function TestController({
   boxOffsetY = 0,
   boxSize = { w: 320, h: 240 },
   setBoxPosition = jest.fn(),
+  toLang = "zh-CN",
+  disableTranBtnOnToLang = true,
 }) {
   const state = useSelectionController({
     tranboxSetting: {
@@ -67,6 +79,8 @@ function TestController({
       btnOffsetX: 0,
       btnOffsetY: 0,
       tranboxInteractMode,
+      toLang,
+      disableTranBtnOnToLang,
     },
     followSelection,
     boxOffsetX: 0,
@@ -158,6 +172,8 @@ describe("useSelectionController", () => {
     jest.useFakeTimers();
     document.body.innerHTML = "";
     currentSelection = null;
+    detectLangFast.mockReset();
+    detectLangFast.mockResolvedValue("");
     windowGetSelectionSpy = jest
       .spyOn(window, "getSelection")
       .mockImplementation(() => currentSelection);
@@ -567,6 +583,101 @@ describe("useSelectionController", () => {
       x: 20,
       y: 0,
     });
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("hides the button when the selected language matches the target language", async () => {
+    const controller = renderController();
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("zh-CN");
+    currentSelection = makeSelection("这是一段中文文本", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.selectedText).toBe("这是一段中文文本");
+    expect(controller.state.showBtn).toBe(false);
+    expect(controller.state.showBox).toBe(false);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("treats traditional Chinese as the target language via zh normalization", async () => {
+    const controller = renderController();
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("zh-TW");
+    currentSelection = makeSelection("這是一段繁體中文", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(false);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("shows the button when the selected language differs from the target", async () => {
+    const controller = renderController();
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("en");
+    currentSelection = makeSelection("some english text here", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(true);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("shows the button when the target-language suppression is disabled", async () => {
+    const controller = renderController({ disableTranBtnOnToLang: false });
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("zh-CN");
+    currentSelection = makeSelection("这是一段中文文本", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(true);
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("hides the button for pure-number selections of any length", async () => {
+    const controller = renderController();
+    const pageParagraph = createParagraph("The library is open.");
+
+    currentSelection = makeSelection("1234567890", pageParagraph);
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(false);
+    expect(detectLangFast).not.toHaveBeenCalled();
+
+    act(() => {
+      controller.root.unmount();
+    });
+  });
+
+  test("shows the button when language detection times out or fails", async () => {
+    const controller = renderController();
+    const pageParagraph = createParagraph("The library is open.");
+
+    detectLangFast.mockResolvedValue("");
+    currentSelection = makeSelection(
+      "some undetectable text here",
+      pageParagraph
+    );
+    await dispatchWindowMouseup();
+
+    expect(controller.state.showBtn).toBe(true);
 
     act(() => {
       controller.root.unmount();

--- a/src/libs/detectFast.js
+++ b/src/libs/detectFast.js
@@ -1,0 +1,176 @@
+/**
+ * @file detectFast.js
+ * @description 划词翻译拦截专用的轻量本地语言检测模块。仅依赖基础配置与浏览器原生 API，
+ * 不引入翻译 API 栈，供内容脚本高频调用场景（如选区语言判定）使用。
+ */
+
+import { OPT_LANGS_MAP } from "../config";
+import { browser } from "./browser";
+import { kissLog } from "./log";
+
+const DETECT_CACHE_LIMIT = 100; // 检测结果缓存条数上限，防止长会话内存膨胀
+const DETECT_TIMEOUT = 100; // 本地语言检测超时阈值 (ms)
+const MAX_DETECT_TEXT_LEN = 300; // 参与检测的文本长度上限
+const detectCache = new Map();
+
+// 字符集快判所需的正则
+const RE_CJK = /[\u4e00-\u9fff]/g;
+const RE_HIRAGANA = /[\u3040-\u309f]/g;
+const RE_KATAKANA = /[\u30a0-\u30ff]/g;
+const RE_HANGUL = /[\uac00-\ud7af\u1100-\u11ff\u3130-\u318f]/g;
+const RE_CYRILLIC = /[\u0400-\u04ff]/g;
+const RE_GREEK = /[\u0370-\u03ff]/g;
+const RE_LATIN = /[a-zA-Z]/g;
+
+// 区分简体/繁体中文的常用独有字形
+const SIMP_CHARS = new Set(
+  "国华门车东发风见机体为还这各个样时经长运边开来后别问应当设过对给现进们动两从远义学话谁网达问题单数业农产说认门".split(
+    ""
+  )
+);
+const TRAD_CHARS = new Set(
+  "國華門車東發風見機體為還這各個樣時經長運邊開來後別問應當設過對給現進們動兩從遠義學話誰網達問題單數業農產說認門".split(
+    ""
+  )
+);
+
+/**
+ * 基于字符集对文本进行快速的同步语言判断。
+ * @param {string} text 待检测文本
+ * @returns {string} 语言代码 (zh-CN / zh-TW / ja / ko / ru / el / en / de / fr / es，无法确定时返回 "")
+ */
+/**
+ * 基于字符集对文本进行快速的同步语言判断。
+ * 零异步开销，适用于划词热路径的初步筛选。
+ * @param {string} text 待检测文本
+ * @returns {string} 语言代码 (zh-CN / zh-TW / ja / ko / ru / el / en / de / fr / es，无法确定时返回 "")
+ */
+export function quickDetectLang(text) {
+  const count = (re) => (text.match(re) || []).length;
+  const cjk = count(RE_CJK);
+  const hiragana = count(RE_HIRAGANA);
+  const katakana = count(RE_KATAKANA);
+  const hangul = count(RE_HANGUL);
+  const cyrillic = count(RE_CYRILLIC);
+  const greek = count(RE_GREEK);
+  const latin = count(RE_LATIN);
+
+  // 日语文本必然夹杂假名
+  if (hiragana > 0 || katakana > 0) return "ja";
+  if (hangul > 0) return "ko";
+  if (cyrillic > 0) return "ru";
+  if (greek > 0) return "el";
+  if (cjk > 0) return detectZhVariant(text);
+
+  // 拉丁字符集区分英/德/法/西：依据变音字母与高频词计分
+  return detectLatinVariant(text, latin) || "";
+}
+
+function detectZhVariant(text) {
+  let trad = 0;
+  let simp = 0;
+  for (const ch of text) {
+    if (TRAD_CHARS.has(ch)) trad++;
+    else if (SIMP_CHARS.has(ch)) simp++;
+  }
+  return trad > simp ? "zh-TW" : "zh-CN";
+}
+
+function detectLatinVariant(text, latinCount) {
+  if (!latinCount) return "";
+  const lower = text.toLowerCase();
+  const countWord = (re) => (lower.match(re) || []).length;
+  const score = { en: 0, de: 0, fr: 0, es: 0 };
+
+  score.en += countWord(/\b(the|and|is|of|to|in|that|it|you|for|with|on)\b/g);
+  score.de +=
+    countWord(/\b(der|die|das|und|ist|nicht|ein|eine|mit|auf|ich)\b/g) +
+    countWord(/[äöüß]/g);
+  score.fr +=
+    countWord(/\b(le|la|les|de|des|et|un|une|est|que|pour)\b/g) +
+    countWord(/[çœàâêîôûëïü]/g);
+  score.es +=
+    countWord(/\b(el|la|los|las|de|que|y|no|en|un|por|es)\b/g) +
+    countWord(/[ñ¿¡]/g);
+
+  let best = "";
+  let bestScore = 0;
+  for (const [lang, s] of Object.entries(score)) {
+    if (s > bestScore) {
+      best = lang;
+      bestScore = s;
+    }
+  }
+  // 仅当有多个独立信号时采纳，避免单点误判
+  return bestScore >= 2 ? best : "";
+}
+
+/**
+ * 将中文简体/繁体归一为统一前缀 "zh"，用于判定时忽略简繁差异。
+ * @param {string} lang 语言代码
+ * @returns {string} 归一化后的语言代码
+ */
+export const normalizeZhLang = (lang) => {
+  if (typeof lang !== "string" || !lang) return "";
+  return /^zh(-|$)/i.test(lang) ? "zh" : lang;
+};
+
+/**
+ * 判断文本是否为纯数字内容 (允许空白与常见分隔符)。
+ * @param {string} text 待检测文本
+ * @returns {boolean} 是否纯数字
+ */
+export const isPureNumberText = (text) => {
+  if (typeof text !== "string" || !text.trim()) return false;
+  return /^[\d\s.,，、\-/:：%]+$/.test(text.trim()) && /\d/.test(text);
+};
+
+function setCache(key, value) {
+  if (detectCache.size >= DETECT_CACHE_LIMIT) {
+    const oldestKey = detectCache.keys().next().value;
+    detectCache.delete(oldestKey);
+  }
+  detectCache.set(key, value);
+}
+
+/**
+ * 供划词翻译拦截使用的轻量本地语言检测：
+ * 先做字符集同步快判，失败后再尝试浏览器 i18n API (带超时与缓存)。
+ * 任何异常/超时均返回空字符串，由调用方走默认行为，保证不误杀。
+ * @param {string} text 待检测文本
+ * @returns {Promise<string>} 语言代码，失败时返回 ""
+ */
+export const detectLangFast = async (text) => {
+  if (typeof text !== "string" || !text.trim()) return "";
+
+  const key =
+    text.length <= MAX_DETECT_TEXT_LEN
+      ? text
+      : text.slice(0, MAX_DETECT_TEXT_LEN);
+  if (detectCache.has(key)) return detectCache.get(key);
+
+  const sample = text.slice(0, MAX_DETECT_TEXT_LEN);
+  let lang = quickDetectLang(sample);
+
+  if (!lang) {
+    try {
+      const res = await Promise.race([
+        Promise.resolve(browser?.i18n?.detectLanguage?.(sample)),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("detect timeout")), DETECT_TIMEOUT)
+        ),
+      ]);
+      const detected = res?.languages?.[0]?.language;
+      if (res?.isReliable && detected && OPT_LANGS_MAP.has(detected)) {
+        lang = detected;
+      } else if (detected?.startsWith("zh")) {
+        lang = detected === "zh-TW" ? "zh-TW" : "zh-CN";
+      }
+    } catch (err) {
+      kissLog("detect lang fast", err);
+    }
+  }
+
+  setCache(key, lang || "");
+  return lang || "";
+};

--- a/src/libs/detectFast.test.js
+++ b/src/libs/detectFast.test.js
@@ -1,0 +1,86 @@
+import {
+  detectLangFast,
+  isPureNumberText,
+  normalizeZhLang,
+} from "./detectFast";
+
+describe("isPureNumberText", () => {
+  test("accepts plain numbers of any length", () => {
+    expect(isPureNumberText("12345")).toBe(true);
+    expect(isPureNumberText("42")).toBe(true);
+  });
+
+  test("accepts numbers with separators and whitespace", () => {
+    expect(isPureNumberText("3.14")).toBe(true);
+    expect(isPureNumberText("1,000,000")).toBe(true);
+    expect(isPureNumberText("2024-07-31")).toBe(true);
+    expect(isPureNumberText("50%")).toBe(true);
+    expect(isPureNumberText(" 123 ")).toBe(true);
+  });
+
+  test("rejects mixed content", () => {
+    expect(isPureNumberText("abc123")).toBe(false);
+    expect(isPureNumberText("2024年")).toBe(false);
+    expect(isPureNumberText("")).toBe(false);
+    expect(isPureNumberText("   ")).toBe(false);
+  });
+});
+
+describe("normalizeZhLang", () => {
+  test("merges simplified and traditional Chinese", () => {
+    expect(normalizeZhLang("zh-CN")).toBe("zh");
+    expect(normalizeZhLang("zh-TW")).toBe("zh");
+    expect(normalizeZhLang("zh")).toBe("zh");
+  });
+
+  test("keeps other languages unchanged", () => {
+    expect(normalizeZhLang("en")).toBe("en");
+    expect(normalizeZhLang("ja")).toBe("ja");
+  });
+
+  test("handles empty input", () => {
+    expect(normalizeZhLang("")).toBe("");
+    expect(normalizeZhLang(null)).toBe("");
+    expect(normalizeZhLang(undefined)).toBe("");
+  });
+});
+
+describe("detectLangFast", () => {
+  test("detects simplified Chinese by charset", async () => {
+    expect(
+      await detectLangFast("这是一个用于测试划词翻译功能的中文句子。")
+    ).toBe("zh-CN");
+  });
+
+  test("detects traditional Chinese by charset", async () => {
+    expect(
+      await detectLangFast("這是一個用於測試劃詞翻譯功能的繁體中文句子。")
+    ).toBe("zh-TW");
+  });
+
+  test("detects Japanese by kana presence", async () => {
+    expect(
+      await detectLangFast("これは翻訳機能をテストするための日本語の文章です。")
+    ).toBe("ja");
+  });
+
+  test("detects Korean by hangul", async () => {
+    expect(
+      await detectLangFast(
+        "이것은 번역 기능을 테스트하기 위한 한국어 문장입니다."
+      )
+    ).toBe("ko");
+  });
+
+  test("detects Russian by cyrillic", async () => {
+    expect(
+      await detectLangFast("Это русское предложение для тестирования перевода.")
+    ).toBe("ru");
+  });
+
+  test("returns empty string for empty or short input", async () => {
+    expect(await detectLangFast("")).toBe("");
+    expect(await detectLangFast("   ")).toBe("");
+    expect(await detectLangFast(null)).toBe("");
+  });
+});

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -103,6 +103,7 @@ export default function Tranbox() {
     aiDictApiSlug = "-",
     aiDictPromptSlug = PROMPT_MODE_FOLLOW_API,
     blacklist = "",
+    disableTranBtnOnToLang = true,
   } = tranboxSetting;
 
   return (
@@ -121,6 +122,24 @@ export default function Tranbox() {
             />
           }
           label={i18n("toggle_selection_translate")}
+          sx={{ width: "fit-content" }}
+        />
+
+        {/* 开关：检测到选中文本为翻译目标语言时，禁用划词翻译按钮弹出 */}
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              name="disableTranBtnOnToLang"
+              checked={disableTranBtnOnToLang}
+              onChange={() => {
+                updateTranbox({
+                  disableTranBtnOnToLang: !disableTranBtnOnToLang,
+                });
+              }}
+            />
+          }
+          label={i18n("disable_tranbtn_on_tolang")}
           sx={{ width: "fit-content" }}
         />
 

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -20,6 +20,7 @@ import {
   PROMPT_MODE_FOLLOW_API,
   getDictionaryPromptOptions,
   getPromptDisplayName,
+  OPT_SKIPLANGS_SELECTION,
 } from "../../config";
 import ShortcutInput from "./ShortcutInput";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -103,7 +104,7 @@ export default function Tranbox() {
     aiDictApiSlug = "-",
     aiDictPromptSlug = PROMPT_MODE_FOLLOW_API,
     blacklist = "",
-    disableTranBtnOnToLang = true,
+    skipLangs = ["zh"],
   } = tranboxSetting;
 
   return (
@@ -125,33 +126,25 @@ export default function Tranbox() {
           sx={{ width: "fit-content" }}
         />
 
-        {/* 开关：检测到选中文本为翻译目标语言时，禁用划词翻译按钮弹出 */}
-        <FormControlLabel
-          control={
-            <Switch
-              size="small"
-              name="disableTranBtnOnToLang"
-              checked={disableTranBtnOnToLang}
-              onChange={() => {
-                updateTranbox({
-                  disableTranBtnOnToLang: !disableTranBtnOnToLang,
-                });
-              }}
-            />
-          }
-          label={
-            <>
-              {i18n("disable_tranbtn_on_tolang")}
-              <Box
-                component="p"
-                sx={{ fontSize: "0.65rem", color: "text.secondary", m: 0 }}
-              >
-                {i18n("disable_tranbtn_on_tolang_helper")}
-              </Box>
-            </>
-          }
-          sx={{ width: "fit-content" }}
-        />
+        {/* 多选下拉：划词检测到列表内的语言时不弹出按钮 */}
+        <TextField
+          select
+          size="small"
+          label={i18n("selection_skip_langs")}
+          helperText={i18n("selection_skip_langs_helper")}
+          name="skipLangs"
+          value={skipLangs}
+          onChange={handleChange}
+          SelectProps={{
+            multiple: true,
+          }}
+        >
+          {OPT_SKIPLANGS_SELECTION.map(([langKey, langName]) => (
+            <MenuItem key={langKey} value={langKey}>
+              {langName}
+            </MenuItem>
+          ))}
+        </TextField>
 
         {/* 各项具体参数网格配置区 */}
         <Box>

--- a/src/views/Options/Tranbox.js
+++ b/src/views/Options/Tranbox.js
@@ -139,7 +139,17 @@ export default function Tranbox() {
               }}
             />
           }
-          label={i18n("disable_tranbtn_on_tolang")}
+          label={
+            <>
+              {i18n("disable_tranbtn_on_tolang")}
+              <Box
+                component="p"
+                sx={{ fontSize: "0.65rem", color: "text.secondary", m: 0 }}
+              >
+                {i18n("disable_tranbtn_on_tolang_helper")}
+              </Box>
+            </>
+          }
           sx={{ width: "fit-content" }}
         />
 


### PR DESCRIPTION
## Summary

在划词翻译设置中新增开关选项：「检测到划词为目标语言时，禁用划词翻译弹窗」（默认开启）。当选中的文本被检测为 **目标语言（toLang）** 或 **纯数字** 时，自动隐藏翻译按钮与弹窗，减少不必要的界面打扰。

<img width="1315" height="590" alt="ScreenShot_2026-07-31_233613_583" src="https://github.com/user-attachments/assets/2c79c06f-e877-49cb-90d8-d23676a5514e" />


---

## Main Changes

### New: `src/libs/detectFast.js` (+ test)

轻量语言检测模块，**不引入翻译 API 栈**（避免 query-string 等 ESM 被打入内容脚本热路径）。

| 函数 | 说明 |
|------|------|
|`isPureNumberText(text)` | 纯数字检测，"12345""3.14""2024-07-31""50%" 等任意长度均直接拦截 |
| `quickDetectLang(text)` | 同步字符集快判（零异步）。通过 Unicode 范围秒识 CJK / 日文假名 / 韩文 / 西里尔 / 希腊；拉丁语通过**高频词+变音符号计分**区分 en/de/fr/es，得分≥2 才采纳 |
| `detectLangFast(text)` | 先走 `quickDetectLang`，无结果时降级到 `browser.i18n.detectLanguage`（WebExtensions 本地 API），带 **100ms 超时**保护（`Promise.race`） |
| `normalizeZhLang(lang)` | zh-CN/zh-TW 统一归一为 `"zh"`，防止简繁不一致导致误判 |
| LRU 缓存 | 100 条 FIFO，重复选择相同文本复用检测结果 |

### Modified: `src/hooks/useSelectionController.js`

在 `processSelectionSnapshot` 最前面插入异步回调 `shouldSuppressSelection`，统一作用于翻译按钮的所有触发模式（click/hover/select/dblclick）：

```
mouseup → sleep(200ms) → createSelectionSnapshot → processSelectionSnapshot
                                                          │
                                              shouldSuppressSelection(text)
                                                          │
              ┌──────────────────────────────────────────────────────────────────────────
              │  ① isPureNumberText? → 拦截纯数字的划词文本                                                                 
              │                                                                          
              │  ② quickDetectLang(text) ← 同步字符集快判                                 
              │     ├─ 中/日/韩/俄/希腊 等 → 走④                                     
              │     └─ 未命中 & 长度 < 4 → 不拦截(拉丁短词豁免)                              
              │                                                                        
              │  ③ 长度 ≥ 4 且快判无结果                                                  
              │     → detectLangFast(text) ← 异步100ms超时                               
              │                                                                         
              │  ④ normalizeZhLang(lang) vs toLang                                      
              │     ├─ 匹配 → 拦截按钮                                        
              │     ├─ 不匹配 → 弹出按钮                                                     
              │     └─ 失败/超时 → 弹出按钮(故障开放)                                           
              └──────────────────────────────────────────────────────────────────────────
                                                          │
                                                   显示按钮或弹窗
```

### Modified: `src/views/Options/Tranbox.js`

MUI Switch 开关，控制 `disableTranBtnOnToLang` 配置项。

---

## Design Decisions

1. **只比对 toLang，不比对 toLang2**  
   由于 toLang2 是反向翻译的目标语言。若拦截 toLang2，则会破坏核心功能。因此开启此开关时自动禁用 toLang2 互译。

2. **故障开放（Fail-open）**  
   任何检测失败、超时或浏览器 API 不可用时，均返回空字符串并正常弹出按钮，防止 UI 死点。

3. **短拉丁文本豁免**  
   长度 < 4 且字符集快判无结果（如 "hi"、"the"、"OK"）→ 直接放行；而同样短的"你好"因 CJK 字符集命中 → 正常拦截。

4. **zh 归一化**  
   zh-CN 和 zh-TW 统一视为 "zh"，确保简体/繁体混合或用户设置繁体为目标语言时也能正确拦截。

5. **拉丁文本的识别** 
   由于quickDetectLang和browser.i18n.detectLanguage的设计原因，划词识别拉丁语系文本时，更多的词组合可以暴露出更多语言统计特征，因此划的词越多则语言判断越准确。

7. **零额外网络依赖**  
   该功能的整个检测流程均为浏览器的本地API。

Fix #938 

---

## subsequent improvement
如果当前的划词拦截机制效果良好，可以考虑在划词设置界面再增加一个语言黑名单的配置选项，在现有"目标语言拦截"功能协同下，支持自定义排除语种的划词弹窗。