### PR TITLE
Fix default tranboxSetting regression introduced in #944

### DIFF
--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -19,6 +19,7 @@ import {
   getSettingVersion,
   migrateSettingPromptsToV2,
   SETTINGS_VERSION_V2,
+  DEFAULT_TRANBOX_SETTING,
 } from "../config";
 import { isExt, isGm } from "./client";
 import { browser } from "./browser";
@@ -159,6 +160,7 @@ const writeSettingBackupBeforeV2 = (setting) =>
 const mergeSettingWithDefault = (setting) => ({
   ...DEFAULT_SETTING,
   ...(setting || {}),
+  tranboxSetting: { ...DEFAULT_TRANBOX_SETTING, ...(setting?.tranboxSetting || {}) },
   version: setting?.version ?? DEFAULT_SETTING.version,
 });
 export const migrateStoredSettingToV2 = async (


### PR DESCRIPTION
https://github.com/fishjar/kiss-translator/pull/944#issuecomment-5152690713  
BUG确实存在

## bug检测流程：
1. 首先安装git（#945）的版本，这个版本无划词翻译的"忽略的语言"下拉菜单选项

2. 打开网页页面A，进行中文划词，弹出翻译窗口，是该版本的正常表现

3. 然后替换本地插件文件为git(#944)的版本，在edge://extensions/界面进行插件重新加载。这个版本新增划词翻译的"忽略的语言"下拉菜单，并且插件缺省选择"中文 Chinese"

4. 刷新第2步的网页页面A，进行中文划词，仍然弹出翻译窗口，证明忽略中文的功能失效

5. 进入插件的划词翻译设置界面，临时移除"忽略的语言"下拉菜单中的"中文 Chinese"后再重新选择

6. 刷新第4步的网页页面A，进行中文划词，翻译窗口被正常拦截，此时忽略中文的缺省功能才生效

## 修复方式：

#### 1. `src/libs/storage.js` 第22行
* **变更内容**：从 `../config` 模块中新增导入 `DEFAULT_TRANBOX_SETTING`

#### 2. 配置项合并逻辑升级 `src/libs/storage.js` 第163行
* **变更内容**：在 `mergeSettingWithDefault` 函数中，为 `tranboxSetting` 字段引入了二级属性合并逻辑：
  ```javascript
  tranboxSetting: { ...DEFAULT_TRANBOX_SETTING, ...(setting?.tranboxSetting || {}) }

## 修复结果
### 按照前述的bug检测流程进行测试，更新插件后忽略中文的缺省功能可以直接正常生效

### FIX ISSUE https://github.com/fishjar/kiss-translator/issues/948