### PR TITLE
Support Gemini dual protocols and thinking controls

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -50,7 +50,8 @@ import {
   INPUT_PLACE_SUMMARY,
   INPUT_PLACE_CONTEXT,
   THINKING_PARAM_MAP,
-  getGeminiThinkingDisableStrategy,
+  getGeminiThinkingStrategy,
+  isGeminiInteractionsUrl,
 } from "../config";
 import { msAuth } from "../libs/auth";
 import { genDeeplFree } from "./deepl";
@@ -321,9 +322,6 @@ const geminiInteractionText = (res) =>
         .map((content) => content.text)
         .join("")
     : "";
-
-const isGeminiInteractionsUrl = (url = "") =>
-  /\/v1(?:beta\d*)?\/interactions(?:[/?]|$)/i.test(url);
 
 const geminiResponseText = (res) =>
   Array.isArray(res?.steps)
@@ -686,6 +684,7 @@ const genGemini = ({
     .replaceAll(INPUT_PLACE_MODEL, model)
     .replaceAll(INPUT_PLACE_KEY, key);
 
+  // 官方 Interactions 与 generateContent 的请求体、上下文和流式事件均不同，必须按 URL 分流。
   if (isGeminiInteractionsUrl(url)) {
     const userMsg = {
       type: "user_input",
@@ -696,21 +695,15 @@ const genGemini = ({
       temperature,
     };
 
-    if (thinkingMode === "disabled") {
-      const strategy = getGeminiThinkingDisableStrategy({
-        apiType,
-        url,
-        model,
-      });
-      if (strategy.field === "thinking_level") {
-        generationConfig.thinking_level = strategy.value;
-      }
-    } else if (
-      thinkingMode === "enabled" &&
-      thinkingEffort &&
-      thinkingEffort !== "_default"
-    ) {
-      generationConfig.thinking_level = thinkingEffort;
+    const strategy = getGeminiThinkingStrategy({
+      apiType,
+      url,
+      model,
+      thinkingMode,
+      thinkingEffort,
+    });
+    if (strategy.field) {
+      generationConfig[strategy.field] = strategy.value;
     }
 
     const body = {
@@ -718,6 +711,7 @@ const genGemini = ({
       system_instruction: systemPrompt,
       input: [...hisMsgs, userMsg],
       stream: useStream,
+      // Interactions 默认会在服务端保存会话；翻译历史由客户端维护，因此显式关闭存储。
       store: false,
       generation_config: generationConfig,
     };
@@ -729,7 +723,7 @@ const genGemini = ({
     return { url, body, headers, userMsg };
   }
 
-  // 自定义代理 URL 继续兼容 Legacy generateContent 协议。
+  // 自定义代理通常只实现 generateContent，不能随官方默认端点一起强制迁移协议。
   if (useStream) {
     url = url.replace(":generateContent", ":streamGenerateContent");
     url += (url.includes("?") ? "&" : "?") + "alt=sse";
@@ -746,17 +740,17 @@ const genGemini = ({
     },
   };
 
-  if (thinkingMode === "disabled") {
-    const strategy = getGeminiThinkingDisableStrategy({ apiType, url, model });
-    if (strategy.field) {
-      body.generationConfig.thinkingConfig = {
-        [strategy.field]: strategy.value,
-      };
-    }
-  } else if (thinkingMode && thinkingMode !== "auto") {
-    if (thinkingEffort && thinkingEffort !== "_default") {
-      body.generationConfig.thinkingConfig = { thinkingLevel: thinkingEffort };
-    }
+  const strategy = getGeminiThinkingStrategy({
+    apiType,
+    url,
+    model,
+    thinkingMode,
+    thinkingEffort,
+  });
+  if (strategy.field) {
+    body.generationConfig.thinkingConfig = {
+      [strategy.field]: strategy.value,
+    };
   }
 
   Object.assign(body, {
@@ -820,11 +814,15 @@ const genGemini2 = ({
     stream: useStream,
   };
 
-  if (thinkingMode === "disabled") {
-    const strategy = getGeminiThinkingDisableStrategy({ apiType, url, model });
+  const strategy = getGeminiThinkingStrategy({
+    apiType,
+    url,
+    model,
+    thinkingMode,
+    thinkingEffort,
+  });
+  if (strategy.field) {
     body[strategy.field] = strategy.value;
-  } else {
-    injectThinking(body, { apiType, thinkingMode, thinkingEffort });
   }
 
   const headers = {
@@ -2065,7 +2063,7 @@ export const handleSubtitle = async ({
       // REVIEW: 本地 AI (Gemini Nano) 强大的降级容灾容错逻辑！
       // 字幕翻译时，如果开启了推理链 (Thinking)，可能会因推理产生大量额外 Token，
       // 触发 Gemini 发生 finishReason === "MAX_TOKENS" 的阶段性提前截断中止。
-      // 遇到该截断限制时，此处自动将推理降到 minimal 并重新发送重试，
+      // 遇到该截断限制时，此处自动将推理降到当前模型支持的最低等级并重新发送重试，
       // 尽量保留输出 token 以取得完整字幕。
       const outputWasTruncated = Array.isArray(res?.steps)
         ? res?.status === "incomplete" || res?.status === "budget_exceeded"

--- a/src/apis/trans.subtitle.test.js
+++ b/src/apis/trans.subtitle.test.js
@@ -267,7 +267,7 @@ describe("handleSubtitle", () => {
     ]);
   });
 
-  test("uses Gemini response_format and retries incomplete interactions at minimal thinking", async () => {
+  test("uses Gemini response_format and retries incomplete interactions at minimum thinking", async () => {
     fetchData
       .mockResolvedValueOnce({
         status: "incomplete",
@@ -312,7 +312,7 @@ describe("handleSubtitle", () => {
       mime_type: "application/json",
     });
     expect(firstBody.generation_config.thinking_level).toBe("high");
-    expect(retryBody.generation_config.thinking_level).toBe("minimal");
+    expect(retryBody.generation_config.thinking_level).toBe("low");
     expect(result).toEqual([
       {
         start: 0,

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -19,6 +19,7 @@ import { handleTranslate } from "./trans";
 import {
   DEFAULT_API_LIST,
   GEMINI_GENERATE_CONTENT_URL,
+  GEMINI_INTERACTIONS_URL,
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
   OPT_TRANS_OPENAI,
@@ -26,9 +27,6 @@ import {
 import { fetchData, fetchStream } from "../libs/fetch";
 import { trustedTypesHelper } from "../libs/trustedTypes";
 import { clearMsgHistory } from "./history";
-
-const GEMINI_INTERACTIONS_URL =
-  "https://generativelanguage.googleapis.com/v1beta2/interactions";
 
 const getApiSetting = (apiType) => ({
   ...DEFAULT_API_LIST.find((api) => api.apiType === apiType),
@@ -111,6 +109,7 @@ describe("handleTranslate", () => {
       store: false,
       generation_config: {
         max_output_tokens: expect.any(Number),
+        thinking_level: "low",
         temperature: 0.7,
       },
     });
@@ -119,6 +118,54 @@ describe("handleTranslate", () => {
     expect(body.generation_config).not.toHaveProperty("top_p");
     expect(body.generation_config).not.toHaveProperty("top_k");
     expect(result).toEqual([{ id: 0, result: ["你好", "en"] }]);
+  });
+
+  test("applies all three thinking modes to Gemini Interactions", async () => {
+    fetchData.mockResolvedValue({
+      status: "completed",
+      steps: [
+        {
+          type: "model_output",
+          content: [{ type: "text", text: "你好" }],
+        },
+      ],
+    });
+    const translate = (thinkingMode, thinkingEffort = "_default") =>
+      collectAsyncGenerator(
+        handleTranslate(["hello"], {
+          from: "en",
+          to: "zh-CN",
+          fromLang: "English",
+          toLang: "Chinese",
+          langMap: () => "",
+          glossary: "",
+          apiSetting: {
+            ...getApiSetting(OPT_TRANS_GEMINI),
+            useStream: false,
+            model: "gemini-3-pro-preview",
+            thinkingMode,
+            thinkingEffort,
+          },
+          usePool: false,
+        })
+      );
+
+    await translate("auto", "high");
+    expect(
+      JSON.parse(fetchData.mock.calls[0][1].body).generation_config
+    ).not.toHaveProperty("thinking_level");
+
+    await translate("enabled", "medium");
+    expect(
+      JSON.parse(fetchData.mock.calls[1][1].body).generation_config
+        .thinking_level
+    ).toBe("high");
+
+    await translate("disabled");
+    expect(
+      JSON.parse(fetchData.mock.calls[2][1].body).generation_config
+        .thinking_level
+    ).toBe("low");
   });
 
   test("maps Gemini2 disabled thinking by model capability", async () => {
@@ -166,8 +213,68 @@ describe("handleTranslate", () => {
       })
     );
     expect(JSON.parse(fetchData.mock.calls[0][1].body).reasoning_effort).toBe(
-      "low"
+      "minimal"
     );
+  });
+
+  test("enables Gemini2 thinking at the highest effort by default", async () => {
+    fetchData.mockResolvedValue({
+      choices: [{ message: { content: "你好" } }],
+    });
+
+    await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...getApiSetting(OPT_TRANS_GEMINI_2),
+          useStream: false,
+          model: "gemini-3.6-flash",
+          thinkingMode: "enabled",
+          thinkingEffort: "_default",
+        },
+        usePool: false,
+      })
+    );
+
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).reasoning_effort).toBe(
+      "high"
+    );
+  });
+
+  test("uses thinkingBudget when enabling Gemini 2.5 through generateContent", async () => {
+    fetchData.mockResolvedValueOnce({
+      candidates: [{ content: { parts: [{ text: "你好" }] } }],
+    });
+
+    await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...getApiSetting(OPT_TRANS_GEMINI),
+          url: GEMINI_GENERATE_CONTENT_URL,
+          useStream: false,
+          model: "gemini-2.5-flash-lite",
+          thinkingMode: "enabled",
+          thinkingEffort: "_default",
+        },
+        usePool: false,
+      })
+    );
+
+    const body = JSON.parse(fetchData.mock.calls[0][1].body);
+    expect(body.generationConfig.thinkingConfig).toEqual({
+      thinkingBudget: -1,
+    });
   });
 
   test("keeps Legacy Gemini safety settings and applies temperature", async () => {
@@ -195,6 +302,7 @@ describe("handleTranslate", () => {
           ...getApiSetting(OPT_TRANS_GEMINI),
           url: GEMINI_GENERATE_CONTENT_URL,
           useStream: false,
+          model: "gemini-3.5-flash",
           temperature: 0.7,
           thinkingMode: "disabled",
         },
@@ -205,7 +313,7 @@ describe("handleTranslate", () => {
     const body = JSON.parse(fetchData.mock.calls[0][1].body);
     expect(body.generationConfig).toMatchObject({
       temperature: 0.7,
-      thinkingConfig: { thinkingLevel: "low" },
+      thinkingConfig: { thinkingLevel: "minimal" },
     });
     expect(body.safetySettings).toHaveLength(4);
   });

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -30,6 +30,8 @@ export const INPUT_PLACE_MODEL = "{{model}}"; // AI 模型名称占位符
 export const INPUT_PLACE_GLOSSARY = "{{glossary}}"; // 专业术语表占位符
 
 export const GEMINI_GENERATE_CONTENT_URL = `https://generativelanguage.googleapis.com/v1beta/models/${INPUT_PLACE_MODEL}:generateContent`;
+export const GEMINI_INTERACTIONS_URL =
+  "https://generativelanguage.googleapis.com/v1/interactions";
 
 // --- 划词翻译词典服务商 ---
 // export const OPT_DICT_BAIDU = "Baidu";
@@ -322,12 +324,12 @@ export const THINKING_PARAM_MAP = {
       { value: "high", label: "High" },
       { value: "medium", label: "Medium" },
       { value: "low", label: "Low" },
+      { value: "minimal", label: "Minimal" },
     ],
   },
   [OPT_TRANS_GEMINI_2]: {
     type: "openai",
     efforts: [
-      { value: "xhigh", label: "X-High" },
       { value: "high", label: "High" },
       { value: "medium", label: "Medium" },
       { value: "low", label: "Low" },
@@ -377,42 +379,167 @@ export const THINKING_PARAM_MAP = {
 };
 
 export const normalizeGeminiModelName = (model = "") =>
-  String(model).trim().replace(/^models\//i, "").toLowerCase();
+  String(model)
+    .trim()
+    .replace(/^models\//i, "")
+    .toLowerCase();
 
-const isGemini25Flash = (model) => model.startsWith("gemini-2.5-flash");
+export const isGeminiInteractionsUrl = (url = "") =>
+  /\/v1(?:beta\d*)?\/interactions(?:[/?]|$)/i.test(url);
+
+const GEMINI_EFFORT_OPTIONS = {
+  high: { value: "high", label: "High" },
+  medium: { value: "medium", label: "Medium" },
+  low: { value: "low", label: "Low" },
+  minimal: { value: "minimal", label: "Minimal" },
+};
+const GEMINI_EFFORT_RANK = { minimal: 0, low: 1, medium: 2, high: 3 };
+const GEMINI25_BUDGETS = {
+  minimal: 1024,
+  low: 1024,
+  medium: 8192,
+  high: 24576,
+};
+
+const isGemini25 = (model) => model.startsWith("gemini-2.5-");
+const isGemini25FlashLite = (model) =>
+  model.startsWith("gemini-2.5-flash-lite");
 const isGemini25Pro = (model) => model.startsWith("gemini-2.5-pro");
-const isGemini3 = (model) => model.startsWith("gemini-3");
-const isGemini25NonPro = (model) =>
-  model.startsWith("gemini-2.5-") && !isGemini25Pro(model);
+const isGemini25NonPro = (model) => isGemini25(model) && !isGemini25Pro(model);
+const isGemini31Pro = (model) => model.startsWith("gemini-3.1-pro");
+const isGemini3Pro = (model) => model.startsWith("gemini-3-pro");
+const isGemini31FlashLiteImage = (model) =>
+  model.startsWith("gemini-3.1-flash-lite-image");
+
+const toGeminiEffortOptions = (efforts) =>
+  efforts.map((effort) => GEMINI_EFFORT_OPTIONS[effort]);
+
+/**
+ * Gemini 不同模型支持的 thinkingLevel 并不一致。UI 与请求构造共用这份能力表，
+ * 避免界面允许选择一个最终会被官方接口拒绝的等级。
+ */
+export const getGeminiThinkingEfforts = ({ apiType, model = "" }) => {
+  if (apiType === OPT_TRANS_GEMINI_2) {
+    return toGeminiEffortOptions(["high", "medium", "low", "minimal"]);
+  }
+
+  const normalizedModel = normalizeGeminiModelName(model);
+  if (isGemini25(normalizedModel)) {
+    return toGeminiEffortOptions(["high", "medium", "low"]);
+  }
+  if (isGemini31FlashLiteImage(normalizedModel)) {
+    return toGeminiEffortOptions(["high", "minimal"]);
+  }
+  if (isGemini31Pro(normalizedModel)) {
+    return toGeminiEffortOptions(["high", "medium", "low"]);
+  }
+  if (isGemini3Pro(normalizedModel)) {
+    return toGeminiEffortOptions(["high", "low"]);
+  }
+  if (
+    normalizedModel.startsWith("gemini-3") &&
+    normalizedModel.includes("flash")
+  ) {
+    return toGeminiEffortOptions(["high", "medium", "low", "minimal"]);
+  }
+  return toGeminiEffortOptions(["high", "medium", "low"]);
+};
+
+const normalizeGeminiThinkingEffort = (effort, supportedEfforts) => {
+  const supported = supportedEfforts.map((item) => item.value);
+  if (supported.includes(effort)) return effort;
+  if (!effort || effort === "_default") return supported[0];
+
+  const targetRank = GEMINI_EFFORT_RANK[effort];
+  if (targetRank === undefined) return supported[0];
+  return supported.reduce((closest, candidate) => {
+    const distance = Math.abs(GEMINI_EFFORT_RANK[candidate] - targetRank);
+    const closestDistance = Math.abs(GEMINI_EFFORT_RANK[closest] - targetRank);
+    return distance < closestDistance ? candidate : closest;
+  });
+};
+
+/**
+ * 将三态思考设置转换为当前协议和模型真正支持的参数。
+ * auto 完全不注入参数；enabled 优先显式开启，否则取最高等级；disabled 无法关闭时取最低等级。
+ */
+export const getGeminiThinkingStrategy = ({
+  apiType,
+  url = "",
+  model = "",
+  thinkingMode = "auto",
+  thinkingEffort = "_default",
+}) => {
+  if (thinkingMode === "auto") {
+    return { field: null, value: null, fallback: false };
+  }
+
+  const normalizedModel = normalizeGeminiModelName(model);
+  const supportedEfforts = getGeminiThinkingEfforts({ apiType, model });
+  const lowestEffort = supportedEfforts[supportedEfforts.length - 1].value;
+  const requestedEffort = normalizeGeminiThinkingEffort(
+    thinkingEffort,
+    supportedEfforts
+  );
+
+  if (apiType === OPT_TRANS_GEMINI_2) {
+    if (thinkingMode === "disabled" && isGemini25NonPro(normalizedModel)) {
+      return { field: "reasoning_effort", value: "none", fallback: false };
+    }
+    return {
+      field: "reasoning_effort",
+      value: thinkingMode === "enabled" ? requestedEffort : lowestEffort,
+      fallback: thinkingMode === "disabled",
+    };
+  }
+
+  if (isGeminiInteractionsUrl(url)) {
+    // Interactions 对 2.5 Flash-Lite 不提供关闭参数；省略等级即可保留模型默认的不思考状态。
+    if (thinkingMode === "disabled" && isGemini25FlashLite(normalizedModel)) {
+      return { field: null, value: null, fallback: false };
+    }
+    return {
+      field: "thinking_level",
+      value: thinkingMode === "enabled" ? requestedEffort : lowestEffort,
+      fallback: thinkingMode === "disabled",
+    };
+  }
+
+  // generateContent 的 Gemini 2.5 使用 token 预算，Gemini 3 才使用 thinkingLevel。
+  if (isGemini25(normalizedModel)) {
+    if (thinkingMode === "enabled") {
+      return {
+        field: "thinkingBudget",
+        value:
+          thinkingEffort === "_default"
+            ? -1
+            : GEMINI25_BUDGETS[requestedEffort],
+        fallback: false,
+      };
+    }
+    return isGemini25Pro(normalizedModel)
+      ? { field: "thinkingBudget", value: 128, fallback: true }
+      : { field: "thinkingBudget", value: 0, fallback: false };
+  }
+
+  return {
+    field: "thinkingLevel",
+    value: thinkingMode === "enabled" ? requestedEffort : lowestEffort,
+    fallback: thinkingMode === "disabled",
+  };
+};
 
 export const getGeminiThinkingDisableStrategy = ({
   apiType,
   url = "",
   model = "",
 }) => {
-  const normalizedModel = normalizeGeminiModelName(model);
-
-  if (apiType === OPT_TRANS_GEMINI_2) {
-    if (isGemini25NonPro(normalizedModel)) {
-      return { field: "reasoning_effort", value: "none", fallback: false };
-    }
-    return {
-      field: "reasoning_effort",
-      value: "low",
-      fallback: true,
-    };
-  }
-
-  if (isGemini25Flash(normalizedModel)) {
-    return { field: "thinkingBudget", value: 0, fallback: false };
-  }
-  if (isGemini25Pro(normalizedModel)) {
-    return { field: "thinkingBudget", value: 128, fallback: true };
-  }
-  if (isGemini3(normalizedModel)) {
-    return { field: "thinkingLevel", value: "low", fallback: true };
-  }
-  return { field: "thinkingLevel", value: "low", fallback: true };
+  return getGeminiThinkingStrategy({
+    apiType,
+    url,
+    model,
+    thinkingMode: "disabled",
+  });
 };
 
 export const BUILTIN_STONES = [
@@ -1056,7 +1183,8 @@ const defaultApiOpts = {
   },
   [OPT_TRANS_GEMINI]: {
     ...defaultApi,
-    url: GEMINI_GENERATE_CONTENT_URL,
+    // 官方 Gemini 默认使用 GA 的 Interactions；用户自定义 URL 仍由运行时按协议自动分流。
+    url: GEMINI_INTERACTIONS_URL,
     modelListUrl: "https://generativelanguage.googleapis.com/v1beta/models",
     model: "gemini-3.6-flash",
     ...defaultAiApiOpts,
@@ -1064,7 +1192,8 @@ const defaultApiOpts = {
   [OPT_TRANS_GEMINI_2]: {
     ...defaultApi,
     url: `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`,
-    modelListUrl: "https://generativelanguage.googleapis.com/v1beta/openai/models",
+    modelListUrl:
+      "https://generativelanguage.googleapis.com/v1beta/openai/models",
     model: "gemini-3.6-flash",
     ...defaultAiApiOpts,
   },

--- a/src/config/api.test.js
+++ b/src/config/api.test.js
@@ -3,7 +3,10 @@ import {
   DEFAULT_API_LIST,
   DEFAULT_API_TYPE,
   GEMINI_GENERATE_CONTENT_URL,
+  GEMINI_INTERACTIONS_URL,
   getGeminiThinkingDisableStrategy,
+  getGeminiThinkingEfforts,
+  getGeminiThinkingStrategy,
   normalizeApiModelListUrls,
   OPT_TRANS_CLOUDFLAREAI,
   OPT_TRANS_DEEPSEEK,
@@ -32,13 +35,13 @@ test("all AI APIs define a thinking mode by default", () => {
   }
 });
 
-test("Gemini uses the generateContent endpoint while the model list stays on v1beta", () => {
+test("Gemini uses stable Interactions while the model list stays on v1beta", () => {
   const gemini = DEFAULT_API_LIST.find(
     (api) => api.apiType === OPT_TRANS_GEMINI
   );
 
   expect(gemini).toMatchObject({
-    url: GEMINI_GENERATE_CONTENT_URL,
+    url: GEMINI_INTERACTIONS_URL,
     modelListUrl: "https://generativelanguage.googleapis.com/v1beta/models",
     model: "gemini-3.6-flash",
     thinkingMode: "disabled",
@@ -56,7 +59,7 @@ test("Gemini2 defaults to a model that can disable thinking", () => {
   });
 });
 
-test("maps Gemini disabled thinking by API URL and model capability", () => {
+test("maps Gemini disabled thinking by protocol and model capability", () => {
   expect(
     getGeminiThinkingDisableStrategy({
       apiType: OPT_TRANS_GEMINI,
@@ -74,29 +77,113 @@ test("maps Gemini disabled thinking by API URL and model capability", () => {
   expect(
     getGeminiThinkingDisableStrategy({
       apiType: OPT_TRANS_GEMINI,
-      url: "https://proxy.example.com/v1/models/{{model}}:generateContent",
-      model: "gemini-3.5-flash",
+      url: GEMINI_GENERATE_CONTENT_URL,
+      model: "gemini-3-pro-preview",
     })
   ).toEqual({ field: "thinkingLevel", value: "low", fallback: true });
   expect(
     getGeminiThinkingDisableStrategy({
       apiType: OPT_TRANS_GEMINI,
-      url: "https://proxy.example.com/v1/models/{{model}}:generateContent",
-      model: "custom-model",
+      url: GEMINI_INTERACTIONS_URL,
+      model: "gemini-3.6-flash",
     })
-  ).toEqual({ field: "thinkingLevel", value: "low", fallback: true });
+  ).toEqual({ field: "thinking_level", value: "minimal", fallback: true });
+  expect(
+    getGeminiThinkingDisableStrategy({
+      apiType: OPT_TRANS_GEMINI,
+      url: GEMINI_INTERACTIONS_URL,
+      model: "gemini-2.5-flash-lite",
+    })
+  ).toEqual({ field: null, value: null, fallback: false });
   expect(
     getGeminiThinkingDisableStrategy({
       apiType: OPT_TRANS_GEMINI_2,
       model: "custom-model",
     })
-  ).toEqual({ field: "reasoning_effort", value: "low", fallback: true });
+  ).toEqual({ field: "reasoning_effort", value: "minimal", fallback: true });
   expect(
     getGeminiThinkingDisableStrategy({
       apiType: OPT_TRANS_GEMINI_2,
-      model: "gemini-3.5-flash",
+      model: "gemini-3.1-pro-preview",
     })
-  ).toEqual({ field: "reasoning_effort", value: "low", fallback: true });
+  ).toEqual({ field: "reasoning_effort", value: "minimal", fallback: true });
+});
+
+test("maps enabled Gemini thinking and normalizes unsupported efforts", () => {
+  expect(
+    getGeminiThinkingStrategy({
+      apiType: OPT_TRANS_GEMINI,
+      url: GEMINI_GENERATE_CONTENT_URL,
+      model: "gemini-2.5-flash-lite",
+      thinkingMode: "enabled",
+      thinkingEffort: "_default",
+    })
+  ).toEqual({ field: "thinkingBudget", value: -1, fallback: false });
+  expect(
+    getGeminiThinkingStrategy({
+      apiType: OPT_TRANS_GEMINI,
+      url: GEMINI_GENERATE_CONTENT_URL,
+      model: "gemini-2.5-pro",
+      thinkingMode: "enabled",
+      thinkingEffort: "medium",
+    })
+  ).toEqual({ field: "thinkingBudget", value: 8192, fallback: false });
+  expect(
+    getGeminiThinkingStrategy({
+      apiType: OPT_TRANS_GEMINI,
+      url: GEMINI_INTERACTIONS_URL,
+      model: "gemini-3-pro-preview",
+      thinkingMode: "enabled",
+      thinkingEffort: "medium",
+    })
+  ).toEqual({ field: "thinking_level", value: "high", fallback: false });
+  expect(
+    getGeminiThinkingStrategy({
+      apiType: OPT_TRANS_GEMINI_2,
+      model: "gemini-3.6-flash",
+      thinkingMode: "enabled",
+      thinkingEffort: "_default",
+    })
+  ).toEqual({ field: "reasoning_effort", value: "high", fallback: false });
+});
+
+test("keeps interface-default Gemini thinking free of extra parameters", () => {
+  expect(
+    getGeminiThinkingStrategy({
+      apiType: OPT_TRANS_GEMINI,
+      url: GEMINI_INTERACTIONS_URL,
+      model: "gemini-3.6-flash",
+      thinkingMode: "auto",
+      thinkingEffort: "high",
+    })
+  ).toEqual({ field: null, value: null, fallback: false });
+});
+
+test("filters native Gemini thinking efforts by model capability", () => {
+  expect(
+    getGeminiThinkingEfforts({
+      apiType: OPT_TRANS_GEMINI,
+      model: "gemini-3.1-pro-preview",
+    }).map((item) => item.value)
+  ).toEqual(["high", "medium", "low"]);
+  expect(
+    getGeminiThinkingEfforts({
+      apiType: OPT_TRANS_GEMINI,
+      model: "gemini-3-pro-preview",
+    }).map((item) => item.value)
+  ).toEqual(["high", "low"]);
+  expect(
+    getGeminiThinkingEfforts({
+      apiType: OPT_TRANS_GEMINI,
+      model: "gemini-3.1-flash-lite-image",
+    }).map((item) => item.value)
+  ).toEqual(["high", "minimal"]);
+  expect(
+    getGeminiThinkingEfforts({
+      apiType: OPT_TRANS_GEMINI,
+      model: "gemini-3.6-flash",
+    }).map((item) => item.value)
+  ).toEqual(["high", "medium", "low", "minimal"]);
 });
 
 describe("normalizeApiModelListUrls", () => {

--- a/src/libs/stream.js
+++ b/src/libs/stream.js
@@ -150,6 +150,7 @@ export function getStreamDelta(json, apiType) {
       // OpenAI 兼容协议的大模型 delta 提取逻辑
       return json.choices?.[0]?.delta?.content || "";
     case OPT_TRANS_GEMINI: {
+      // 两套 Gemini 协议共用同一接口类型：Interactions 带事件类型，generateContent 返回 candidates。
       const eventType = json.event_type || json.type;
       if (eventType === "error") {
         const error = new Error(

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -91,6 +91,7 @@ import {
   OPT_TRANS_AZUREAI,
   THINKING_PARAM_MAP,
   getGeminiThinkingDisableStrategy,
+  getGeminiThinkingEfforts,
   DEFAULT_NOBATCH_PROMPT_SLUG,
   DEFAULT_BATCH_PROMPT_SLUG,
   DEFAULT_SUBTITLE_PROMPT_SLUG,
@@ -484,6 +485,15 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   }, [modelListUrl, key]);
 
   const thinkingParam = THINKING_PARAM_MAP[apiType];
+  const thinkingEfforts =
+    apiType === OPT_TRANS_GEMINI || apiType === OPT_TRANS_GEMINI_2
+      ? getGeminiThinkingEfforts({ apiType, model })
+      : thinkingParam?.efforts;
+  const selectedThinkingEffort = thinkingEfforts?.some(
+    (effort) => effort.value === thinkingEffort
+  )
+    ? thinkingEffort
+    : "_default";
   const thinkingDisableStrategy =
     thinkingMode === "disabled" &&
     (apiType === OPT_TRANS_GEMINI || apiType === OPT_TRANS_GEMINI_2)
@@ -712,25 +722,26 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
                   onChange={handleChange}
                 />
               </Grid>
-              {apiType !== OPT_TRANS_GEMINI && apiType !== OPT_TRANS_GEMINI_2 && (
-                <Grid item xs={12} sm={12} md={6} lg={3}>
-                  <ValidationInput
-                    size="small"
-                    fullWidth
-                    label={"Temperature (0.0-2.0)"}
-                    type="number"
-                    name="temperature"
-                    value={temperature}
-                    onChange={handleChange}
-                    min={0.0}
-                    max={2.0}
-                    isFloat={true}
-                    inputProps={{
-                      step: 0.1,
-                    }}
-                  />
-                </Grid>
-              )}
+              {apiType !== OPT_TRANS_GEMINI &&
+                apiType !== OPT_TRANS_GEMINI_2 && (
+                  <Grid item xs={12} sm={12} md={6} lg={3}>
+                    <ValidationInput
+                      size="small"
+                      fullWidth
+                      label={"Temperature (0.0-2.0)"}
+                      type="number"
+                      name="temperature"
+                      value={temperature}
+                      onChange={handleChange}
+                      min={0.0}
+                      max={2.0}
+                      isFloat={true}
+                      inputProps={{
+                        step: 0.1,
+                      }}
+                    />
+                  </Grid>
+                )}
               <Grid item xs={12} sm={12} md={6} lg={3}>
                 <ValidationInput
                   size="small"
@@ -1117,18 +1128,18 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
                 )}
               </TextField>
             </Grid>
-            {thinkingMode === "enabled" && thinkingParam.efforts && (
+            {thinkingMode === "enabled" && thinkingEfforts && (
               <Grid item xs={12} sm={12} md={6} lg={3}>
                 <TextField
                   select
                   fullWidth
                   size="small"
                   name="thinkingEffort"
-                  value={thinkingEffort}
+                  value={selectedThinkingEffort}
                   label={i18n("thinking_effort")}
                   onChange={handleChange}
                 >
-                  {thinkingParam.efforts.map((e) => (
+                  {thinkingEfforts.map((e) => (
                     <MenuItem key={e.value} value={e.value}>
                       {e.label}
                     </MenuItem>

--- a/src/views/Options/Apis.test.js
+++ b/src/views/Options/Apis.test.js
@@ -338,3 +338,26 @@ describe("Apis temperature input", () => {
     gemini2View.unmount();
   });
 });
+
+describe("Apis Gemini thinking efforts", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("falls back to the default selection for an unsupported saved effort", async () => {
+    const view = await renderApis(
+      createApi({
+        apiSlug: OPT_TRANS_GEMINI,
+        apiType: OPT_TRANS_GEMINI,
+        model: "gemini-3-pro-preview",
+        thinkingMode: "enabled",
+        thinkingEffort: "medium",
+      })
+    );
+    const effortInput = getInput(view.container, "thinkingEffort");
+    expect(effortInput.value).toBe("_default");
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Supersedes #983.

Thanks to @EndlessEnding for investigating the `minimal` effort and the Gemini 3.1 Pro capability differences. This replacement keeps that model-specific behavior while using protocol-aware request construction.

## Changes

- use the stable `v1/interactions` endpoint for newly created built-in Gemini interfaces while keeping the Models API separate
- dispatch Gemini requests by URL: `/interactions` uses the Interactions schema/events, while `:generateContent` and custom proxies keep the generateContent protocol
- preserve existing saved URLs; no settings migration is introduced
- implement the three thinking modes consistently:
  - interface default (`auto`) injects no thinking parameter
  - enabled uses the requested supported effort, or the model's highest supported effort
  - disabled turns thinking off when supported, or falls back to the model's lowest supported effort
- filter effort options by Gemini model and normalize stale/unsupported saved values again at request time
- support Gemini 2.5 `thinkingBudget`, Gemini 3 `thinkingLevel`, and Gemini OpenAI-compatible `reasoning_effort`
- set `store: false` for stateless translation requests through Interactions
- add concise Chinese comments around protocol routing, thinking fallbacks, storage, and response parsing

Official references:

- https://ai.google.dev/gemini-api/docs/interactions-overview
- https://ai.google.dev/api/interactions-api-v1
- https://ai.google.dev/gemini-api/docs/generate-content/thinking
- https://ai.google.dev/gemini-api/docs/openai

## Validation

- 7 focused Jest suites, 86 tests passed
- Prettier check passed for all changed files
- `git diff --check`
- Chrome production build through `src/scripts/build-task.mjs --target=chrome` with `CI=true`

No live Gemini request was made because no API key was used during validation.