### PR TITLE
feat: 完善 OpenRouter 推理控制

### DIFF
--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -475,8 +475,12 @@ const injectThinking = (body, { apiType, thinkingMode, thinkingEffort }) => {
       }
       break;
     case "openrouter":
-      if (hasEffort) {
+      if (thinkingMode === "disabled") {
+        body.reasoning = { effort: "none" };
+      } else if (thinkingMode === "enabled" && hasEffort) {
         body.reasoning = { effort: thinkingEffort };
+      } else if (thinkingMode === "enabled") {
+        body.reasoning = { enabled: true };
       }
       break;
     default:

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -23,6 +23,7 @@ import {
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
   OPT_TRANS_OPENAI,
+  OPT_TRANS_OPENROUTER,
 } from "../config";
 import { fetchData, fetchStream } from "../libs/fetch";
 import { trustedTypesHelper } from "../libs/trustedTypes";
@@ -166,6 +167,50 @@ describe("handleTranslate", () => {
       JSON.parse(fetchData.mock.calls[2][1].body).generation_config
         .thinking_level
     ).toBe("low");
+  });
+
+  test("maps all OpenRouter thinking modes to the unified reasoning object", async () => {
+    fetchData.mockResolvedValue({
+      choices: [{ message: { content: "你好" } }],
+    });
+    const translate = (thinkingMode, thinkingEffort = "_default") =>
+      collectAsyncGenerator(
+        handleTranslate(["hello"], {
+          from: "en",
+          to: "zh-CN",
+          fromLang: "English",
+          toLang: "Chinese",
+          langMap: () => "",
+          glossary: "",
+          apiSetting: {
+            ...getApiSetting(OPT_TRANS_OPENROUTER),
+            useStream: false,
+            thinkingMode,
+            thinkingEffort,
+          },
+          usePool: false,
+        })
+      );
+
+    await translate("auto", "high");
+    expect(JSON.parse(fetchData.mock.calls[0][1].body)).not.toHaveProperty(
+      "reasoning"
+    );
+
+    await translate("enabled");
+    expect(JSON.parse(fetchData.mock.calls[1][1].body).reasoning).toEqual({
+      enabled: true,
+    });
+
+    await translate("enabled", "xhigh");
+    expect(JSON.parse(fetchData.mock.calls[2][1].body).reasoning).toEqual({
+      effort: "xhigh",
+    });
+
+    await translate("disabled");
+    expect(JSON.parse(fetchData.mock.calls[3][1].body).reasoning).toEqual({
+      effort: "none",
+    });
   });
 
   test("maps Gemini2 disabled thinking by model capability", async () => {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -357,8 +357,9 @@ export const THINKING_PARAM_MAP = {
   },
   [OPT_TRANS_OPENROUTER]: {
     type: "openrouter",
-    disableSupported: false,
     efforts: [
+      { value: "max", label: "Max" },
+      { value: "xhigh", label: "X-High" },
       { value: "high", label: "High" },
       { value: "medium", label: "Medium" },
       { value: "low", label: "Low" },

--- a/src/config/api.test.js
+++ b/src/config/api.test.js
@@ -15,6 +15,7 @@ import {
   OPT_TRANS_MICROSOFT,
   OPT_TRANS_TENCENT,
   OPT_TRANS_OPENAI,
+  OPT_TRANS_OPENROUTER,
 } from "./api";
 
 test("uses Tencent as the fallback default API", () => {
@@ -33,6 +34,18 @@ test("all AI APIs define a thinking mode by default", () => {
     expect(api).toBeDefined();
     expect(["auto", "enabled", "disabled"]).toContain(api.thinkingMode);
   }
+});
+
+test("OpenRouter uses the shared disabled thinking default", () => {
+  const openrouter = DEFAULT_API_LIST.find(
+    (api) => api.apiType === OPT_TRANS_OPENROUTER
+  );
+
+  expect(openrouter).toMatchObject({
+    model: "openai/gpt-4o",
+    thinkingMode: "disabled",
+    thinkingEffort: "_default",
+  });
 });
 
 test("Gemini uses stable Interactions while the model list stays on v1beta", () => {


### PR DESCRIPTION
## 背景

OpenRouter 目前只显示“接口默认”和“开启思考”，没有“关闭思考”选项；开启思考但选择接口默认强度时，也没有向接口发送明确的启用参数。

根据 OpenRouter 的推理参数文档，接口支持通过统一的 `reasoning` 对象启用、关闭推理以及设置推理强度。本次改动补全这些控制，使 OpenRouter 与其他支持思考模式的翻译接口保持一致。

## 改动

- 为 OpenRouter 显示“关闭思考”选项
- 补充 `max` 和 `xhigh` 推理强度
- 按设置生成对应的 OpenRouter 请求参数：
  - 接口默认：不发送 `reasoning`
  - 开启 + 接口默认强度：发送 `reasoning: { enabled: true }`
  - 开启 + 指定强度：发送 `reasoning: { effort }`
  - 关闭：发送 `reasoning: { effort: "none" }`
- 保持与其他 AI 接口一致的默认配置：`disabled + _default`
- 增加请求参数映射和默认配置测试
- 本次不增加设置迁移，也不根据模型列表动态修改可选项

## 实测

通过 OpenRouter 官方接口及插件测试功能进行了验证：

- `openai/gpt-4o`
  - 选择“关闭思考”后正常返回
  - 响应中没有推理内容
- `deepseek/deepseek-v4-flash` 使用相同测试内容：
  - 关闭思考：正常返回，没有推理内容
  - `minimal`：正常返回，产生 92 个推理 token
  - `max`：正常返回，产生 198 个推理 token

结果表明，关闭及不同推理强度会被 OpenRouter 实际处理，并影响模型返回的推理 token 用量。

## 兼容性与待讨论事项

### 1. 默认 `disabled` 的实际行为发生变化

现有 OpenRouter 默认配置已经是 `thinkingMode: "disabled"`，但原请求代码没有处理该模式，因此修改前实际不会发送推理参数，效果更接近“接口默认”。

本次改动后，`disabled` 会真正发送：

```json
{
  "reasoning": {
    "effort": "none"
  }
}
```

对于强制思考模型，这可能导致请求失败。通过 OpenRouter 官方接口测试 `google/gemini-3.5-flash-lite`：

- 不发送 `reasoning` 时 HTTP 200
- 发送 `reasoning: { effort: "none" }` 时 HTTP 400
- 返回错误：`Reasoning is mandatory for this endpoint and cannot be disabled.`

当前 [KISS Translator 在 OpenRouter 近期使用模型](https://openrouter.ai/apps/url/https%3A%2F%2Ffishjar.github.io%2Fkiss-translator) 的前 10 中，`google/gemini-3.6-flash` 的模型能力信息也标记为 `mandatory: true` 强制思考。因此，现有默认配置在本次改动后的实际行为变化，需要在合并前确认是否可以接受。

### 2. 是否应将 OpenRouter 默认值改为 `auto`

将新建和重置的 OpenRouter 配置默认值改为 `auto`，可以避免默认关闭强制思考模型。

但是，即使修改默认值，已有用户保存的 `disabled` 配置也不会自动变成 `auto`。如果需要改变已有配置，还需要单独讨论是否增加设置迁移；本 PR 暂不进行迁移。

### 3. 是否应根据模型能力动态调整选项

OpenRouter 的 `/api/v1/models` 会返回部分模型的推理能力信息，包括是否强制推理以及支持的推理强度。后续可以考虑根据当前模型动态隐藏或限制不支持的设置。

需要同时考虑：

- 模型列表接口可能不可访问或请求失败
- 用户可能手动填写模型名
- 用户选择列表模型后仍可能手动修改模型名
- 模型能力信息可能变化
- 动态调整选项可能导致已保存设置在模型变化后被隐藏

本 PR 采用静态选项，接口不兼容时由现有测试功能显示实际错误。是否引入模型能力驱动的设置选项，留待评审讨论。

## 验证

- `pnpm test src/apis/trans.translate.test.js src/config/api.test.js --runInBand`
  - 2 个测试套件、30 个测试通过
- `git diff --check`
- Chrome 生产构建成功

## 参考

- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- https://openrouter.ai/api/v1/models
