### PR TITLE
fix: ai thinking control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ package-lock.json
 *.zip
 .repomixignore
 .agents
+.claude

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -49,7 +49,7 @@ import {
   defaultSystemPromptLines,
   INPUT_PLACE_SUMMARY,
   INPUT_PLACE_CONTEXT,
-  THINKING_PARAM_MAP,
+  resolveThinkingStrategy,
   getGeminiThinkingStrategy,
   isGeminiInteractionsUrl,
 } from "../config";
@@ -432,55 +432,47 @@ const siliconflowEffortMap = {
  * 注入推理模式（Thinking）的专用控制参数。
  * 针对 DeepSeek, 阿里百炼, 硅基流动, Cerebras, OpenRouter 各大模型厂商繁杂的推理链配置参数进行统一映射注入。
  */
-const injectThinking = (body, { apiType, thinkingMode, thinkingEffort }) => {
-  if (thinkingMode === "auto") return; // 留空由模型网关自动决定
+const injectThinking = (
+  body,
+  { apiType, model, thinkingMode, thinkingEffort, thinkingCapabilities }
+) => {
+  const strategy = resolveThinkingStrategy({
+    apiType,
+    model,
+    thinkingMode,
+    thinkingEffort,
+    thinkingCapabilities,
+  });
+  if (strategy.action === "none") return;
 
-  const param = THINKING_PARAM_MAP[apiType];
-  if (!param) return;
-
-  const hasEffort = thinkingEffort && thinkingEffort !== "_default";
-
-  switch (param.type) {
+  switch (strategy.capability.protocol) {
     case "deepseek":
       body.thinking = {
-        type: thinkingMode === "enabled" ? "enabled" : "disabled",
+        type: strategy.action === "enabled" ? "enabled" : "disabled",
       };
-      if (thinkingMode === "enabled" && hasEffort) {
-        body.reasoning_effort = thinkingEffort;
+      if (strategy.effort) {
+        body.reasoning_effort = strategy.effort;
       }
       break;
     case "aliyunbailian":
       // 百炼仅支持 enable_thinking 布尔开关，不支持推理强度参数
-      body.enable_thinking = thinkingMode === "enabled";
+      body.enable_thinking = strategy.action === "enabled";
       break;
     case "siliconflow":
-      body.enable_thinking = thinkingMode === "enabled";
-      if (thinkingMode === "enabled" && hasEffort) {
+      body.enable_thinking = strategy.action === "enabled";
+      if (strategy.effort) {
         // 将抽象等级转换为硅基流动所支持的具体思考 tokens 额度
-        body.thinking_budget = siliconflowEffortMap[thinkingEffort] || 8192;
-      }
-      break;
-    case "cerebras":
-      if (thinkingMode === "disabled") {
-        body.reasoning_effort = "none";
-      } else if (hasEffort) {
-        body.reasoning_effort = thinkingEffort;
+        body.thinking_budget = siliconflowEffortMap[strategy.effort] || 8192;
       }
       break;
     case "openai":
-      if (thinkingMode === "disabled") {
-        body.reasoning_effort = "none";
-      } else if (thinkingMode === "enabled" && hasEffort) {
-        body.reasoning_effort = thinkingEffort;
-      }
+      if (strategy.effort) body.reasoning_effort = strategy.effort;
       break;
     case "openrouter":
-      if (thinkingMode === "disabled") {
-        body.reasoning = { effort: "none" };
-      } else if (thinkingMode === "enabled" && hasEffort) {
-        body.reasoning = { effort: thinkingEffort };
-      } else if (thinkingMode === "enabled") {
+      if (strategy.action === "enabled" && !strategy.effort) {
         body.reasoning = { enabled: true };
+      } else if (strategy.effort) {
+        body.reasoning = { effort: strategy.effort };
       }
       break;
     default:
@@ -639,6 +631,7 @@ const genOpenAI = ({
   apiType,
   thinkingMode,
   thinkingEffort,
+  thinkingCapabilities,
 }) => {
   const userMsg = {
     role: "user",
@@ -659,7 +652,13 @@ const genOpenAI = ({
     stream: useStream,
   };
 
-  injectThinking(body, { apiType, thinkingMode, thinkingEffort });
+  injectThinking(body, {
+    apiType,
+    model,
+    thinkingMode,
+    thinkingEffort,
+    thinkingCapabilities,
+  });
 
   const headers = {
     "Content-type": "application/json",
@@ -849,6 +848,7 @@ const genClaude = ({
   useStream = false,
   thinkingMode,
   thinkingEffort,
+  thinkingCapabilities,
 }) => {
   const userMsg = {
     role: "user",
@@ -863,13 +863,22 @@ const genClaude = ({
     stream: useStream,
   };
 
-  if (thinkingMode && thinkingMode !== "auto") {
-    if (thinkingMode === "enabled") {
-      body.thinking = { type: "adaptive" };
-      if (thinkingEffort && thinkingEffort !== "_default") {
-        body.output_config = { effort: thinkingEffort };
-      }
-    }
+  const strategy = resolveThinkingStrategy({
+    apiType: OPT_TRANS_CLAUDE,
+    model,
+    thinkingMode,
+    thinkingEffort,
+    thinkingCapabilities,
+  });
+  if (strategy.action === "enabled") {
+    body.thinking = { type: "adaptive" };
+    if (strategy.effort) body.output_config = { effort: strategy.effort };
+  } else if (strategy.action === "disabled") {
+    body.thinking = { type: "disabled" };
+  } else if (strategy.action === "effort" && strategy.effort) {
+    // 强制思考模型不能发送 disabled，只能保持 adaptive 并降到最低等级。
+    body.thinking = { type: "adaptive" };
+    body.output_config = { effort: strategy.effort };
   }
 
   const headers = {
@@ -894,6 +903,7 @@ const genOpenRouter = ({
   useStream = false,
   thinkingMode,
   thinkingEffort,
+  thinkingCapabilities,
 }) => {
   const userMsg = {
     role: "user",
@@ -916,8 +926,10 @@ const genOpenRouter = ({
 
   injectThinking(body, {
     apiType: OPT_TRANS_OPENROUTER,
+    model,
     thinkingMode,
     thinkingEffort,
+    thinkingCapabilities,
   });
 
   const headers = {
@@ -942,6 +954,7 @@ const genOrcaRouter = ({
   useStream = false,
   thinkingMode,
   thinkingEffort,
+  thinkingCapabilities,
 }) => {
   const userMsg = {
     role: "user",
@@ -964,8 +977,10 @@ const genOrcaRouter = ({
 
   injectThinking(body, {
     apiType: OPT_TRANS_ORCAROUTER,
+    model,
     thinkingMode,
     thinkingEffort,
+    thinkingCapabilities,
   });
 
   const headers = {
@@ -991,6 +1006,7 @@ const genOllama = ({
   useStream = false,
   thinkingMode,
   thinkingEffort,
+  thinkingCapabilities,
 }) => {
   const userMsg = {
     role: "user",
@@ -1012,8 +1028,10 @@ const genOllama = ({
 
   injectThinking(body, {
     apiType: OPT_TRANS_OLLAMA,
+    model,
     thinkingMode,
     thinkingEffort,
+    thinkingCapabilities,
   });
   body.stream = useStream;
 

--- a/src/apis/trans.orcarouter.test.js
+++ b/src/apis/trans.orcarouter.test.js
@@ -184,6 +184,6 @@ describe("OrcaRouter interface", () => {
 
     const body = JSON.parse(fetchData.mock.calls[0][1].body);
     expect(body).not.toHaveProperty("reasoning");
-    expect(body.reasoning_effort).toBe("medium");
+    expect(body.reasoning_effort).toBe("high");
   });
 });

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -204,13 +204,102 @@ describe("handleTranslate", () => {
 
     await translate("enabled", "xhigh");
     expect(JSON.parse(fetchData.mock.calls[2][1].body).reasoning).toEqual({
-      effort: "xhigh",
+      effort: "high",
     });
 
     await translate("disabled");
     expect(JSON.parse(fetchData.mock.calls[3][1].body).reasoning).toEqual({
       effort: "none",
     });
+  });
+
+  test("uses OpenRouter model metadata for supported and mandatory efforts", async () => {
+    fetchData.mockResolvedValue({
+      choices: [{ message: { content: "你好" } }],
+    });
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_OPENROUTER),
+      useStream: false,
+      model: "provider/mandatory-model",
+      thinkingCapabilities: {
+        model: "provider/mandatory-model",
+        supportedEfforts: ["high", "medium", "low"],
+        mandatory: true,
+      },
+    };
+
+    await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: {
+          ...apiSetting,
+          thinkingMode: "enabled",
+          thinkingEffort: "xhigh",
+        },
+        usePool: false,
+      })
+    );
+    expect(JSON.parse(fetchData.mock.calls[0][1].body).reasoning).toEqual({
+      effort: "high",
+    });
+
+    await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: { ...apiSetting, thinkingMode: "disabled" },
+        usePool: false,
+      })
+    );
+    expect(JSON.parse(fetchData.mock.calls[1][1].body).reasoning).toEqual({
+      effort: "low",
+    });
+  });
+
+  test("applies the OpenAI-compatible high/none baseline in requests", async () => {
+    fetchData.mockResolvedValue({
+      choices: [{ message: { content: "你好" } }],
+    });
+    const translate = (thinkingMode) =>
+      collectAsyncGenerator(
+        handleTranslate(["hello"], {
+          from: "en",
+          to: "zh-CN",
+          fromLang: "English",
+          toLang: "Chinese",
+          langMap: () => "",
+          glossary: "",
+          apiSetting: {
+            ...getApiSetting(OPT_TRANS_OPENAI),
+            useStream: false,
+            model: "unknown-model",
+            thinkingMode,
+          },
+          usePool: false,
+        })
+      );
+
+    await translate("auto");
+    expect(JSON.parse(fetchData.mock.calls[0][1].body)).not.toHaveProperty(
+      "reasoning_effort"
+    );
+    await translate("enabled");
+    expect(JSON.parse(fetchData.mock.calls[1][1].body).reasoning_effort).toBe(
+      "high"
+    );
+    await translate("disabled");
+    expect(JSON.parse(fetchData.mock.calls[2][1].body).reasoning_effort).toBe(
+      "none"
+    );
   });
 
   test("maps Gemini2 disabled thinking by model capability", async () => {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -249,134 +249,306 @@ export const API_SPE_TYPES = {
   ]),
 };
 
-// REVIEW: 思考模式参数映射：定义各 API 的思考开关和强度参数。
-// 这里的设计可以将 AI 推理模型的“思考过程”(Reasoning Effort) 与普通参数解耦，支持可视化调节。
-// type: 对应的厂商/平台类型；efforts: 思考强度级别列表 (如 max, high 等)，null 表示仅支持开启/关闭，无多档强度可选。
-// disableSupported: 是否允许用户手动关闭思考模式，默认 true。若为 false 则说明该模型强制开启思考（如 Claude 的部分高推理模型）。
+const THINKING_EFFORT_LABELS = {
+  max: "Max",
+  xhigh: "X-High",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+  minimal: "Minimal",
+};
+const THINKING_EFFORT_RANK = {
+  none: 0,
+  minimal: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  xhigh: 5,
+  max: 6,
+};
+const toThinkingEffortOptions = (efforts = []) =>
+  efforts.map((effort) => ({
+    value: effort,
+    label: THINKING_EFFORT_LABELS[effort] || effort,
+  }));
+
+const OPENAI_COMPAT_CAPABILITY = {
+  protocol: "openai",
+  efforts: toThinkingEffortOptions(["high"]),
+  disableEffort: "none",
+};
+
+const createThinkingCapability = (protocol, efforts, extra = {}) => ({
+  protocol,
+  efforts: efforts ? toThinkingEffortOptions(efforts) : null,
+  ...extra,
+});
+
+// 保留静态映射供旧调用方判断接口是否显示思考设置；具体模型能力统一由
+// getThinkingCapability 解析，避免界面和请求层各自维护一套等级列表。
 export const THINKING_PARAM_MAP = {
-  [OPT_TRANS_DEEPSEEK]: {
-    type: "deepseek",
-    efforts: [
-      { value: "max", label: "Max" },
-      { value: "high", label: "High" },
-    ],
-  },
-  [OPT_TRANS_OPENCODEGO]: {
-    type: "deepseek",
-    efforts: [
-      { value: "max", label: "Max" },
-      { value: "high", label: "High" },
-    ],
-  },
-  [OPT_TRANS_SILICONFLOW]: {
-    type: "siliconflow",
-    efforts: [
-      { value: "max", label: "Max (32768)" },
-      { value: "high", label: "High (16384)" },
-      { value: "medium", label: "Medium (8192)" },
-      { value: "low", label: "Low (4096)" },
-      { value: "minimal", label: "Minimal (2048)" },
-    ],
-  },
-  [OPT_TRANS_XIAOMIMIMO]: {
-    type: "deepseek",
-    efforts: null,
-  },
-  [OPT_TRANS_ALIYUNBAILIAN]: {
-    type: "aliyunbailian",
-    efforts: null,
-  },
-  [OPT_TRANS_CEREBRAS]: {
-    type: "cerebras",
-    efforts: [
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-    ],
-  },
-  [OPT_TRANS_ZAI]: {
-    type: "deepseek",
-    efforts: null,
-  },
-  [OPT_TRANS_EPHONEAI]: {
-    type: "openai",
-    efforts: [
-      { value: "xhigh", label: "X-High" },
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-      { value: "minimal", label: "Minimal" },
-    ],
-  },
-  [OPT_TRANS_OPENAI]: {
-    type: "openai",
-    efforts: [
-      { value: "xhigh", label: "X-High" },
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-      { value: "minimal", label: "Minimal" },
-    ],
-  },
-  [OPT_TRANS_GEMINI]: {
-    type: "gemini",
-    efforts: [
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-      { value: "minimal", label: "Minimal" },
-    ],
-  },
-  [OPT_TRANS_GEMINI_2]: {
-    type: "openai",
-    efforts: [
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-      { value: "minimal", label: "Minimal" },
-    ],
-  },
-  [OPT_TRANS_CLAUDE]: {
-    type: "claude",
-    disableSupported: false,
-    efforts: [
-      { value: "max", label: "Max" },
-      { value: "xhigh", label: "X-High" },
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-    ],
-  },
-  [OPT_TRANS_OLLAMA]: {
-    type: "cerebras",
-    efforts: [
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-    ],
-  },
-  [OPT_TRANS_OPENROUTER]: {
-    type: "openrouter",
-    efforts: [
-      { value: "max", label: "Max" },
-      { value: "xhigh", label: "X-High" },
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-      { value: "minimal", label: "Minimal" },
-    ],
-  },
-  // OrcaRouter 网关按 OpenAI 规范透传 reasoning_effort（none/low/medium/high/xhigh），
-  // 不接受 OpenRouter 的 reasoning: { effort } 对象形式，所以这里走 "openai" 分支。
-  [OPT_TRANS_ORCAROUTER]: {
-    type: "openai",
-    efforts: [
-      { value: "xhigh", label: "X-High" },
-      { value: "high", label: "High" },
-      { value: "medium", label: "Medium" },
-      { value: "low", label: "Low" },
-    ],
-  },
+  [OPT_TRANS_DEEPSEEK]: { type: "deepseek" },
+  [OPT_TRANS_OPENCODEGO]: { type: "deepseek" },
+  [OPT_TRANS_SILICONFLOW]: { type: "siliconflow" },
+  [OPT_TRANS_XIAOMIMIMO]: { type: "deepseek" },
+  [OPT_TRANS_ALIYUNBAILIAN]: { type: "aliyunbailian" },
+  [OPT_TRANS_CEREBRAS]: { type: "openai" },
+  [OPT_TRANS_ZAI]: { type: "deepseek" },
+  [OPT_TRANS_EPHONEAI]: { type: "openai" },
+  [OPT_TRANS_OPENAI]: { type: "openai" },
+  [OPT_TRANS_GEMINI]: { type: "gemini" },
+  [OPT_TRANS_GEMINI_2]: { type: "gemini" },
+  [OPT_TRANS_CLAUDE]: { type: "claude" },
+  [OPT_TRANS_OLLAMA]: { type: "openai" },
+  [OPT_TRANS_OPENROUTER]: { type: "openrouter" },
+  [OPT_TRANS_ORCAROUTER]: { type: "openai" },
+};
+
+const getOpenAIThinkingCapability = (model = "") => {
+  const normalizedModel = String(model).trim().toLowerCase();
+
+  if (/^gpt-5\.6(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability(
+      "openai",
+      ["max", "xhigh", "high", "medium", "low"],
+      { disableEffort: "none" }
+    );
+  }
+  if (/^gpt-5\.(?:4|2)-pro(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability("openai", ["xhigh", "high", "medium"], {
+      disableEffort: "none",
+    });
+  }
+  if (/^gpt-5-pro(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability("openai", ["high"], {
+      disableEffort: "none",
+    });
+  }
+  if (/^gpt-5\.[23]-codex(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability(
+      "openai",
+      ["xhigh", "high", "medium", "low"],
+      { disableEffort: "none" }
+    );
+  }
+  if (/^gpt-5\.(?:5|4|2)(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability(
+      "openai",
+      ["xhigh", "high", "medium", "low"],
+      { disableEffort: "none" }
+    );
+  }
+  if (/^gpt-5\.1(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability("openai", ["high", "medium", "low"], {
+      disableEffort: "none",
+    });
+  }
+  if (/^gpt-5(?:-|$)/.test(normalizedModel)) {
+    return createThinkingCapability(
+      "openai",
+      ["high", "medium", "low", "minimal"],
+      { disableEffort: "none" }
+    );
+  }
+
+  // 文档无法确认的 OpenAI 兼容模型只发送最通用的 high/none，避免猜测 xhigh、minimal 等扩展等级。
+  return OPENAI_COMPAT_CAPABILITY;
+};
+
+const normalizeOpenRouterCapability = (model, metadata) => {
+  if (!metadata || metadata.model !== model) return null;
+
+  const supportedEfforts = Array.isArray(metadata.supportedEfforts)
+    ? metadata.supportedEfforts.filter(
+        (effort) =>
+          effort !== "none" && THINKING_EFFORT_RANK[effort] !== undefined
+      )
+    : [];
+  if (!supportedEfforts.length) return null;
+
+  return createThinkingCapability("openrouter", supportedEfforts, {
+    explicitEnable: true,
+    disableEffort: metadata.mandatory ? null : "none",
+  });
+};
+
+const getClaudeThinkingCapability = (model = "") => {
+  const normalizedModel = String(model).trim().toLowerCase();
+  const supportsAdaptiveThinking =
+    /^claude-(?:opus|sonnet)-(?:[5-9](?:-|$)|4-[6-9](?:-|$))/.test(
+      normalizedModel
+    ) ||
+    /^claude-(?:fable|mythos)-5(?:-|$)/.test(normalizedModel) ||
+    normalizedModel.startsWith("claude-mythos-preview");
+
+  if (!supportsAdaptiveThinking) return null;
+
+  const mandatory =
+    /^claude-(?:fable|mythos)-5(?:-|$)/.test(normalizedModel) ||
+    normalizedModel.startsWith("claude-mythos-preview");
+  return createThinkingCapability(
+    "claude",
+    ["max", "xhigh", "high", "medium", "low"],
+    {
+      explicitEnable: true,
+      explicitDisable: !mandatory,
+    }
+  );
+};
+
+/**
+ * 返回当前接口和模型真正可用的思考能力。未知聚合接口与未知模型按 OpenAI
+ * 兼容基线处理；Gemini 和 Claude 仍保留各自原生协议，不能混用请求字段。
+ */
+export const getThinkingCapability = ({
+  apiType,
+  model = "",
+  thinkingCapabilities,
+}) => {
+  if (apiType === OPT_TRANS_GEMINI || apiType === OPT_TRANS_GEMINI_2) {
+    return createThinkingCapability(
+      "gemini",
+      getGeminiThinkingEfforts({ apiType, model }).map((item) => item.value)
+    );
+  }
+  if (apiType === OPT_TRANS_CLAUDE) {
+    return getClaudeThinkingCapability(model);
+  }
+  if (apiType === OPT_TRANS_OPENROUTER) {
+    return (
+      normalizeOpenRouterCapability(model, thinkingCapabilities) ||
+      createThinkingCapability("openrouter", ["high"], {
+        explicitEnable: true,
+        disableEffort: "none",
+      })
+    );
+  }
+  if (apiType === OPT_TRANS_OPENAI) {
+    return getOpenAIThinkingCapability(model);
+  }
+  if (apiType === OPT_TRANS_CEREBRAS && /^gpt-oss-120b(?:-|$)/i.test(model)) {
+    return createThinkingCapability("openai", ["high", "medium", "low"], {
+      explicitEnable: true,
+      disableEffort: "none",
+    });
+  }
+  if (apiType === OPT_TRANS_DEEPSEEK || apiType === OPT_TRANS_OPENCODEGO) {
+    return createThinkingCapability("deepseek", ["max", "high"], {
+      explicitEnable: true,
+      explicitDisable: true,
+    });
+  }
+  if (apiType === OPT_TRANS_XIAOMIMIMO || apiType === OPT_TRANS_ZAI) {
+    return createThinkingCapability("deepseek", null, {
+      explicitEnable: true,
+      explicitDisable: true,
+    });
+  }
+  if (apiType === OPT_TRANS_ALIYUNBAILIAN) {
+    return createThinkingCapability("aliyunbailian", null, {
+      explicitEnable: true,
+      explicitDisable: true,
+    });
+  }
+  if (apiType === OPT_TRANS_SILICONFLOW) {
+    return createThinkingCapability(
+      "siliconflow",
+      ["max", "high", "medium", "low", "minimal"],
+      { explicitEnable: true, explicitDisable: true }
+    );
+  }
+  if (THINKING_PARAM_MAP[apiType]) {
+    return OPENAI_COMPAT_CAPABILITY;
+  }
+  return null;
+};
+
+export const normalizeThinkingEffort = (effort, supportedEfforts = []) => {
+  const supported = supportedEfforts.map((item) => item.value);
+  if (!supported.length) return null;
+  if (!effort || effort === "_default") return supported[supported.length - 1];
+  if (supported.includes(effort)) return effort;
+
+  const targetRank = THINKING_EFFORT_RANK[effort];
+  if (targetRank === undefined) return supported[0];
+  return supported.reduce((closest, candidate) => {
+    const distance = Math.abs(THINKING_EFFORT_RANK[candidate] - targetRank);
+    const closestDistance = Math.abs(
+      THINKING_EFFORT_RANK[closest] - targetRank
+    );
+    return distance < closestDistance ? candidate : closest;
+  });
+};
+
+/**
+ * auto 不注入参数；enabled 优先走显式开关，否则取最高等级；disabled
+ * 优先显式关闭，不能关闭时降到模型最低等级。
+ */
+export const resolveThinkingStrategy = ({
+  apiType,
+  url = "",
+  model = "",
+  thinkingMode = "disabled",
+  thinkingEffort = "_default",
+  thinkingCapabilities,
+}) => {
+  const capability = getThinkingCapability({
+    apiType,
+    model,
+    thinkingCapabilities,
+  });
+  if (!capability || thinkingMode === "auto") {
+    return { capability, action: "none", effort: null, fallback: false };
+  }
+  if (capability.protocol === "gemini") {
+    const strategy = getGeminiThinkingStrategy({
+      apiType,
+      url,
+      model,
+      thinkingMode,
+      thinkingEffort,
+    });
+    return {
+      capability,
+      action: strategy.field ? "effort" : "none",
+      effort: strategy.value,
+      fallback: strategy.fallback,
+    };
+  }
+
+  const hasExplicitEffort = thinkingEffort && thinkingEffort !== "_default";
+  const normalizedEffort = normalizeThinkingEffort(
+    thinkingEffort,
+    capability.efforts || []
+  );
+  if (thinkingMode === "enabled") {
+    const useExplicitEnable = capability.explicitEnable && !hasExplicitEffort;
+    return {
+      capability,
+      action: useExplicitEnable ? "enabled" : "effort",
+      effort: useExplicitEnable ? null : normalizedEffort,
+      fallback: false,
+    };
+  }
+  if (capability.explicitDisable) {
+    return { capability, action: "disabled", effort: null, fallback: false };
+  }
+  if (capability.disableEffort) {
+    return {
+      capability,
+      action: "effort",
+      effort: capability.disableEffort,
+      fallback: false,
+    };
+  }
+
+  const efforts = capability.efforts || [];
+  return {
+    capability,
+    action: "effort",
+    effort: efforts[efforts.length - 1]?.value || null,
+    fallback: true,
+  };
 };
 
 export const normalizeGeminiModelName = (model = "") =>
@@ -468,7 +640,7 @@ export const getGeminiThinkingStrategy = ({
   apiType,
   url = "",
   model = "",
-  thinkingMode = "auto",
+  thinkingMode = "disabled",
   thinkingEffort = "_default",
 }) => {
   if (thinkingMode === "auto") {

--- a/src/config/api.test.js
+++ b/src/config/api.test.js
@@ -7,15 +7,25 @@ import {
   getGeminiThinkingDisableStrategy,
   getGeminiThinkingEfforts,
   getGeminiThinkingStrategy,
+  getThinkingCapability,
+  resolveThinkingStrategy,
   normalizeApiModelListUrls,
   OPT_TRANS_CLOUDFLAREAI,
   OPT_TRANS_DEEPSEEK,
+  OPT_TRANS_EPHONEAI,
+  OPT_TRANS_CEREBRAS,
+  OPT_TRANS_CLAUDE,
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
+  OPT_TRANS_ALIYUNBAILIAN,
   OPT_TRANS_MICROSOFT,
+  OPT_TRANS_SILICONFLOW,
   OPT_TRANS_TENCENT,
   OPT_TRANS_OPENAI,
+  OPT_TRANS_OPENCODEGO,
   OPT_TRANS_OPENROUTER,
+  OPT_TRANS_XIAOMIMIMO,
+  OPT_TRANS_ZAI,
 } from "./api";
 
 test("uses Tencent as the fallback default API", () => {
@@ -34,6 +44,123 @@ test("all AI APIs define a thinking mode by default", () => {
     expect(api).toBeDefined();
     expect(["auto", "enabled", "disabled"]).toContain(api.thinkingMode);
   }
+});
+
+test("keeps disabled as the initial thinking mode", () => {
+  for (const apiType of API_SPE_TYPES.ai) {
+    const api = DEFAULT_API_LIST.find((item) => item.apiType === apiType);
+    expect(api.thinkingMode).toBe("disabled");
+  }
+});
+
+describe("unified thinking capabilities", () => {
+  test.each([
+    ["gpt-5.6-sol", "low", "none", false],
+    ["gpt-5.4-pro", "medium", "none", false],
+    ["gpt-5.3-codex", "low", "none", false],
+    ["gpt-5.1", "low", "none", false],
+    ["gpt-5", "minimal", "none", false],
+    ["unknown-model", "high", "none", false],
+  ])(
+    "normalizes OpenAI model %s to lowest and disabled strategies",
+    (model, defaultEffort, disabled, fallback) => {
+      expect(
+        resolveThinkingStrategy({
+          apiType: OPT_TRANS_OPENAI,
+          model,
+          thinkingMode: "enabled",
+        }).effort
+      ).toBe(defaultEffort);
+      expect(
+        resolveThinkingStrategy({
+          apiType: OPT_TRANS_OPENAI,
+          model,
+          thinkingMode: "disabled",
+        })
+      ).toMatchObject({ effort: disabled, fallback });
+    }
+  );
+
+  test("uses the OpenAI-compatible high/none baseline for unknown gateways", () => {
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_EPHONEAI,
+        model: "provider/unknown-model",
+        thinkingMode: "enabled",
+        thinkingEffort: "xhigh",
+      })
+    ).toMatchObject({ action: "effort", effort: "high" });
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_EPHONEAI,
+        model: "provider/unknown-model",
+        thinkingMode: "disabled",
+      })
+    ).toMatchObject({ action: "effort", effort: "none" });
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_EPHONEAI,
+        model: "provider/unknown-model",
+        thinkingMode: "auto",
+      }).action
+    ).toBe("none");
+  });
+
+  test.each([
+    [OPT_TRANS_DEEPSEEK, "deepseek"],
+    [OPT_TRANS_XIAOMIMIMO, "deepseek"],
+    [OPT_TRANS_ZAI, "deepseek"],
+    [OPT_TRANS_ALIYUNBAILIAN, "aliyunbailian"],
+    [OPT_TRANS_SILICONFLOW, "siliconflow"],
+  ])("uses explicit thinking switches for %s", (apiType, protocol) => {
+    expect(
+      resolveThinkingStrategy({ apiType, thinkingMode: "auto" })
+    ).toMatchObject({ action: "none" });
+    expect(
+      resolveThinkingStrategy({ apiType, thinkingMode: "enabled" })
+    ).toMatchObject({ action: "enabled", capability: { protocol } });
+    expect(
+      resolveThinkingStrategy({ apiType, thinkingMode: "disabled" })
+    ).toMatchObject({ action: "disabled", capability: { protocol } });
+  });
+
+  test("falls back to the lowest effort for mandatory reasoning models", () => {
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_CEREBRAS,
+        model: "gpt-oss-120b",
+        thinkingMode: "disabled",
+      })
+    ).toMatchObject({ action: "effort", effort: "none", fallback: false });
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_OPENROUTER,
+        model: "google/gemini-3.5-flash",
+        thinkingMode: "disabled",
+        thinkingCapabilities: {
+          model: "google/gemini-3.5-flash",
+          supportedEfforts: ["high", "medium", "low", "minimal"],
+          mandatory: true,
+        },
+      })
+    ).toMatchObject({ action: "effort", effort: "minimal", fallback: true });
+  });
+
+  test("keeps Claude native and hides unsupported legacy models", () => {
+    expect(
+      getThinkingCapability({
+        apiType: OPT_TRANS_CLAUDE,
+        model: "claude-3-haiku-20240307",
+      })
+    ).toBeNull();
+    expect(
+      resolveThinkingStrategy({
+        apiType: OPT_TRANS_CLAUDE,
+        model: "claude-mythos-5",
+        thinkingMode: "disabled",
+      })
+    ).toMatchObject({ action: "effort", effort: "low", fallback: true });
+  });
 });
 
 test("OpenRouter uses the shared disabled thinking default", () => {

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1286,7 +1286,7 @@ export const I18N = {
     ja: `各APIの思考パラメータは統一されていません。エラーが発生した場合は「APIデフォルト」を使用してください。`,
     ko: `API별 사고 매개변수가 통일되어 있지 않습니다. 오류 발생 시 "API 기본값"을 사용하세요.`,
     tr: `API'ler arasında düşünme parametreleri farklılık gösterir. Hata ile karşılaşırsanız lütfen "API Varsayılanı" seçeneğini kullanın.`,
-    vi: "The thinking parameters vary across APIs. If you encounter errors, please use the \"API Default\" option.",
+    vi: 'The thinking parameters vary across APIs. If you encounter errors, please use the "API Default" option.',
   },
   gemini_thinking_minimum_helper: {
     zh: `当前模型不支持完全关闭思考，将自动使用最低思考级别。`,
@@ -1358,7 +1358,7 @@ export const I18N = {
     ja: `JSON形式を使用してください。例: "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0"`,
     ko: `JSON 형식을 사용하세요. 예: "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0"`,
     tr: `Örneğin, "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0" şeklinde JSON formatını kullanın.`,
-    vi: "Use JSON format, for example \"User-Agent\": \"Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0\"",
+    vi: 'Use JSON format, for example "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0"',
   },
   custom_body: {
     zh: `自定义Body参数`,
@@ -1376,7 +1376,7 @@ export const I18N = {
     ja: `JSON形式を使用してください。例: "top_p": 0.7`,
     ko: `JSON 형식을 사용하세요. 예: "top_p": 0.7`,
     tr: `JSON formatını kullanın, örneğin "top_p": 0.7`,
-    vi: "Use JSON format, for example \"top_p\": 0.7",
+    vi: 'Use JSON format, for example "top_p": 0.7',
   },
   gemini_interactions_custom_body_help: {
     zh: `使用 Interactions API 顶层 JSON 字段；Request Hook 收到的也是 Interactions 请求结构。`,
@@ -1979,7 +1979,7 @@ export const I18N = {
     ja: `1. ルールの優先順位: 個人ルール > 購読ルール > グローバルルール。「グローバルルール」はフォールバックルールのようなものです。`,
     ko: `1. 규칙 우선순위: 개인 규칙 > 구독 규칙 > 전역 규칙. "전역 규칙"은 일종의 폴백(fallback) 규칙입니다.`,
     tr: `1. Kuralların önceliği şudur: kişisel kurallar > abonelik kuralları > genel kurallar. "Genel kurallar" bir geri dönüş kuralı gibidir`,
-    vi: "1. The priority of rules is: personal rules > subscription rules > global rules. \"Global rules\" are like a fallback rule.",
+    vi: '1. The priority of rules is: personal rules > subscription rules > global rules. "Global rules" are like a fallback rule.',
   },
   rules_warn_2: {
     zh: `2、“订阅规则”选择注入后才会生效。`,
@@ -1988,7 +1988,7 @@ export const I18N = {
     ja: `2. 「購読ルール」は注入を選択した後にのみ有効になります。`,
     ko: `2. "구독 규칙"은 주입을 선택한 후에만 적용됩니다.`,
     tr: `2. "Abonelik kuralları" yalnızca enjeksiyon seçildikten sonra geçerli olacaktır.`,
-    vi: "2. \"Subscription rules\" will take effect only after injection is selected.",
+    vi: '2. "Subscription rules" will take effect only after injection is selected.',
   },
   rules_warn_3: {
     zh: `3、关于规则填写：输入框留空或下拉框选“*”表示采用全局规则。CSS选择器支持 + 号前缀表示在全局规则基础上追加，- 号表示剔除。`,
@@ -1997,7 +1997,7 @@ export const I18N = {
     ja: `3. ルールの記入について: 入力ボックスを空白にするか、ドロップダウンで「*」を選択すると、グローバルルールが使用されます。CSS セレクターはプレフィックスに対応しています。「+」はグローバルルールへの追加、「-」は除外を意味します。`,
     ko: `3. 규칙 작성 관련: 입력란을 비워두거나 드롭다운에서 "*"를 선택하면 전역 규칙이 사용됩니다. CSS 선택자는 접두사를 지원합니다. "+"는 전역 규칙에 추가, "-"는 제외를 의미합니다.`,
     tr: `3. Kuralların Doldurulmasıyla İlgili Olarak: Genel Kuralı Kullanmak İçin Giriş Kutusunu Boş Bırakın Veya Açılır Kutuda "*" Seçeneğini Seçin. Css Seçicileri Önekleri Destekler: "+" Genel Kurallara Ekleme Anlamına Gelir`,
-    vi: "3. Regarding filling in the rules: Leave the input box blank or select \"*\" in the drop-down box to use global rule. CSS selectors support prefixes: \"+\" means add to the global rules, \"-\" means exclude.",
+    vi: '3. Regarding filling in the rules: Leave the input box blank or select "*" in the drop-down box to use global rule. CSS selectors support prefixes: "+" means add to the global rules, "-" means exclude.',
   },
   sync_warn: {
     zh: `涉及隐私数据的同步请谨慎选择第三方同步服务，建议自行搭建 kiss-worker 或 WebDAV 服务。`,
@@ -2276,7 +2276,7 @@ export const I18N = {
     ja: `1. アスタリスク (*) ワイルドカードをサポートします。 2. 複数のURLは改行または英語のコンマ「,」で区切ります。`,
     ko: `1. 별표(*) 와일드카드 문자를 지원합니다. 2. 여러 URL은 줄바꿈 또는 영어 쉼표 ","로 구분합니다.`,
     tr: `1. Yıldız (*) Joker Karakterini Destekler. 2. Birden Fazla URL'Yi Yeni Satırlarla Veya Virgüllerle Ayırın "`,
-    vi: "1. Supports the asterisk (*) wildcard character. 2. Separate multiple URLs with newlines or English commas \",\".",
+    vi: '1. Supports the asterisk (*) wildcard character. 2. Separate multiple URLs with newlines or English commas ",".',
   },
   selector_helper: {
     zh: `1、需要翻译的目标元素。2、开启自动扫描页面后，本设置无效。3、遵循CSS选择器语法。`,
@@ -2420,7 +2420,7 @@ export const I18N = {
     ja: `1. 正規表現マッチングをサポート (スラッシュ不要、修飾子非対応)。 2. 複数の用語は改行またはセミコロン「;」で区切ります。 3. 用語と翻訳は英語のコンマ「,」で区切ります。 4. 翻訳がない場合は、その用語を翻訳しないものとみなします。`,
     ko: `1. 정규식 일치를 지원하며, 슬래시가 필요 없고 수정자는 지원되지 않습니다. 2. 여러 용어는 줄바꿈 또는 세미콜론 ";"으로 구분합니다. 3. 용어와 번역은 영어 쉼표 ","로 구분합니다. 4. 번역이 없는 경우 해당 용어를 번역하지 않는 것으로 간주합니다.`,
     tr: `1. Düzenli ifade eşleştirmeyi destekler, eğik çizgi gerekmez ve değiştiriciler desteklenmez. 2. Birden fazla terim yeni satır veya noktalı virgül ";" ile ayrılır. 3. Terimler ve çeviriler İngilizce virgül "," ile ayrılır. 4. Çeviri yoksa, terim çevrilmemiş olarak kabul edilir.`,
-    vi: "1. Supports regular expression matching, no slash required, and no modifiers are supported. 2. Separate multiple terms with newlines or semicolons \";\". 3. Terms and translations are separated by English commas \",\". 4. If there is no translation, the term will be deemed not to be translated.",
+    vi: '1. Supports regular expression matching, no slash required, and no modifiers are supported. 2. Separate multiple terms with newlines or semicolons ";". 3. Terms and translations are separated by English commas ",". 4. If there is no translation, the term will be deemed not to be translated.',
   },
   ai_terms: {
     zh: `AI专业术语`,
@@ -2438,7 +2438,7 @@ export const I18N = {
     ja: `1. AIによるインテリジェントな置換 (正規表現非対応)。 2. 複数の用語は改行またはセミコロン「;」で区切ります。 3. 用語と翻訳は英語のコンマ「,」で区切ります。 4. 翻訳がない場合は、その用語を翻訳しないものとみなします。`,
     ko: `1. AI 지능형 대체, 정규식을 지원하지 않습니다. 2. 여러 용어는 줄바꿈 또는 세미콜론 ";"으로 구분합니다. 3. 용어와 번역은 영어 쉼표 ","로 구분합니다. 4. 번역이 없는 경우 해당 용어를 번역하지 않는 것으로 간주합니다.`,
     tr: `1. Yapay Zekâ Destekli Akıllı Değiştirme, Düzenli Ifadeleri Desteklemez. 2. Birden Fazla Terim, Yeni Satır Veya Noktalı Virgül ";" Ile Ayrılmalıdır. 3. Terimler Ve Çeviriler, İngilizce Virgül "," Ile Ayrılmalıdır. 4. Çeviri Yoksa, Terim Çevrilmemiş Olarak Kabul Edilecektir."`,
-    vi: "1. AI intelligent replacement does not support regular expressions.2. Separate multiple terms with newlines or semicolons \";\". 3. Terms and translations are separated by English commas \",\". 4. If there is no translation, the term will be deemed not to be translated.",
+    vi: '1. AI intelligent replacement does not support regular expressions.2. Separate multiple terms with newlines or semicolons ";". 3. Terms and translations are separated by English commas ",". 4. If there is no translation, the term will be deemed not to be translated.',
   },
   text_ext_style: {
     zh: `译文附加样式`,
@@ -2611,7 +2611,7 @@ export const I18N = {
     ja: `1. br は <br> 改行を <p "kiss-p"> に置き換えます。 2. bn は \\n 改行を <p "kiss-p"> に置き換えます。 3. brToDiv と bnToDiv は <div class="kiss-p"> に置き換えます。`,
     ko: `1. br은 <br> 줄바꿈을 <p "kiss-p">로 대체합니다. 2. bn은 \\n 줄바꿈을 <p "kiss-p">로 대체합니다. 3. brToDiv 및 bnToDiv는 <div class="kiss-p">로 대체됩니다.`,
     tr: `1. br, <br> satır sonlarını <p "kiss-p"> ile değiştirir. 2. bn, \\n yeni satırı <p "kiss-p"> ile değiştirir. 3. brToDiv ve bnToDiv, <div class="kiss-p"> ile değiştirildi.`,
-    vi: "1. br replaces <br> line breaks with <p \"kiss-p\">. 2. bn replaces \\\\n newline with <p \"kiss-p\">. 3. brToDiv and bnToDiv are replaced with <div class=\"kiss-p\">.",
+    vi: '1. br replaces <br> line breaks with <p "kiss-p">. 2. bn replaces \\\\n newline with <p "kiss-p">. 3. brToDiv and bnToDiv are replaced with <div class="kiss-p">.',
   },
   import: {
     zh: `导入`,
@@ -2989,7 +2989,7 @@ export const I18N = {
     ja: `同期タイプは「KISS-Worker」である必要があり、すべて入力する必要があります。`,
     ko: `동기화 유형은 "KISS-Worker"여야 하며, 모든 항목을 빠짐없이 입력해야 합니다.`,
     tr: `Senkronizasyon Türünüz "KISS-Worker" Olmalı Ve Eksiksiz Olarak Doldurulmalıdır`,
-    vi: "Your sync type must be \"KISS-Worker\" and must be filled in completely",
+    vi: 'Your sync type must be "KISS-Worker" and must be filled in completely',
   },
   click_test: {
     zh: `点击测试`,
@@ -3115,7 +3115,7 @@ export const I18N = {
     ja: `「翻訳切り替え」ショートカット`,
     ko: `"번역 켜기" 단축키`,
     tr: `"Çeviriyi Aç/Kapat" Kısayolu`,
-    vi: "Phím tắt \"Bật/tắt Dịch\"",
+    vi: 'Phím tắt "Bật/tắt Dịch"',
   },
   toggle_transonly_shortcut: {
     zh: `"隐藏原文"快捷键`,
@@ -3124,7 +3124,7 @@ export const I18N = {
     ja: `「原文を隠す」ショートカット`,
     ko: `"원문 숨기기" 단축키`,
     tr: `"Orijinali Gizle" Kısayolu`,
-    vi: "Phím tắt \"Ẩn bản gốc\"",
+    vi: 'Phím tắt "Ẩn bản gốc"',
   },
   toggle_style_shortcut: {
     zh: `"切换样式"快捷键`,
@@ -3133,7 +3133,7 @@ export const I18N = {
     ja: `「スタイル切り替え」ショートカット`,
     ko: `"스타일 전환" 단축키`,
     tr: `"Stil Değiştir" Kısayolu`,
-    vi: "Phím tắt \"Chuyển đổi Kiểu\"",
+    vi: 'Phím tắt "Chuyển đổi Kiểu"',
   },
   toggle_popup_shortcut: {
     zh: `"打开弹窗"快捷键`,
@@ -3142,7 +3142,7 @@ export const I18N = {
     ja: `「ポップアップを開く」ショートカット`,
     ko: `"팝업 열기" 단축키`,
     tr: `"Açılır Pencereyi Aç" Kısayolu`,
-    vi: "Phím tắt \"Mở Bật lên\"",
+    vi: 'Phím tắt "Mở Bật lên"',
   },
   open_setting_shortcut: {
     zh: `"打开设置"快捷键`,
@@ -3151,7 +3151,7 @@ export const I18N = {
     ja: `「設定を開く」ショートカット`,
     ko: `"설정 열기" 단축키`,
     tr: `"Ayarı Aç" Kısayolu`,
-    vi: "Phím tắt \"Mở Cài đặt\"",
+    vi: 'Phím tắt "Mở Cài đặt"',
   },
   firefox_shortcut_edit_hint: {
     zh: `Firefox 不支持直接打开扩展快捷键管理页。请在地址栏输入 about:addons，然后点击齿轮菜单中的“管理扩展快捷键”。`,
@@ -3336,7 +3336,7 @@ export const I18N = {
     ja: `デフォルトは「AltLeft+KeyI」です`,
     ko: `기본값 "AltLeft+KeyI"`,
     tr: `Varsayılan "AltLeft+KeyI"`,
-    vi: "Default is \"AltLeft+KeyI\"",
+    vi: 'Default is "AltLeft+KeyI"',
   },
   shortcut_press_count: {
     zh: `快捷键连击次数`,
@@ -3372,7 +3372,7 @@ export const I18N = {
     ja: `記号の後に対象言語コードを追加できます。例：「/en 你好」、「/zh hello」`,
     ko: `표시 뒤에 대상 언어 코드를 추가할 수 있습니다. 예: "/en 你好", "/zh hello"`,
     tr: `İşaretin sonuna hedef dil kodu eklenebilir, örneğin: "/en 你好", "/zh hello"`,
-    vi: "The target language code can be added after the sign, such as: \"/en 你好\", \"/zh hello\"",
+    vi: 'The target language code can be added after the sign, such as: "/en 你好", "/zh hello"',
   },
   detect_lang_remote: {
     zh: `远程语言检测`,
@@ -3714,7 +3714,7 @@ export const I18N = {
     ja: `改行または英語のコンマ「,」で区切ってポーリングコールをサポートします。`,
     ko: `줄바꿈 또는 영어 쉼표 ","로 구분된 폴링 호출을 지원합니다.`,
     tr: `Anket çağrılarının yeni satırlarla veya İngilizce virgüllerle ayrılmasını destekler"`,
-    vi: "Supports polling calls separated by newlines or English commas \",\".",
+    vi: 'Supports polling calls separated by newlines or English commas ",".',
   },
   translation_element_tag: {
     zh: `译文元素标签`,
@@ -4425,7 +4425,7 @@ export const I18N = {
     ja: `選択翻訳のオン/オフは「ルール設定」で行ってください。`,
     ko: `선택 번역 활성화/비활성화는 "규칙 설정"에서 하십시오.`,
     tr: `Seçilen çeviri özelliğini açmak veya kapatmak için lütfen "Kural Ayarları"na gidin.`,
-    vi: "To turn selected translation on or off, please go to \"Rule Settings\".",
+    vi: 'To turn selected translation on or off, please go to "Rule Settings".',
   },
   mousehover_key_help: {
     zh: `当快捷键置空时表示鼠标懸停直接翻译`,
@@ -4623,7 +4623,7 @@ export const I18N = {
     ja: `クリックして「JSON 形式」に切り替え`,
     ko: `클릭하여 "JSON 형식"으로 전환`,
     tr: `"JSON Formatına Geçmek İçin Tıklayın`,
-    vi: "Click to switch to \"JSON Format\"",
+    vi: 'Click to switch to "JSON Format"',
   },
   xml_output: {
     zh: `点击切换 “XML 格式“`,
@@ -4632,7 +4632,7 @@ export const I18N = {
     ja: `クリックして「XML 形式」に切り替え`,
     ko: `클릭하여 "XML 형식"으로 전환`,
     tr: `"XML Formatına Geçmek İçin Tıklayın`,
-    vi: "Click to switch to \"XML Format\"",
+    vi: 'Click to switch to "XML Format"',
   },
   textlines_output: {
     zh: `点击切换 “多行文本格式“`,
@@ -4641,7 +4641,7 @@ export const I18N = {
     ja: `クリックして「複数行テキスト形式」に切り替え`,
     ko: `클릭하여 "여러 줄 텍스트 형식"으로 전환`,
     tr: `"Çok Satırlı Metin Formatına Geçmek İçin Tıklayın`,
-    vi: "Click to switch to \"Multi-line Text Format\"",
+    vi: 'Click to switch to "Multi-line Text Format"',
   },
   system_prompt_helper_2: {
     zh: `2. 在未完全理解默认Prompt的情况下，请勿随意修改，否则可能无法工作。`,

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1169,7 +1169,7 @@ export const I18N = {
     ja: `詳細は [こちら](${process.env.REACT_APP_HOMEPAGE}) をクリックしてください。`,
     ko: `자세한 내용은 [여기](${process.env.REACT_APP_HOMEPAGE})를 클릭하세요.`,
     tr: `Lütfen Ayrıntılar İçin [Buraya Tıkla](${process.env.REACT_APP_HOMEPAGE})`,
-    vi: "Vui lòng [nhấp vào đây](\${process.env.REACT_APP_HOMEPAGE}) để biết chi tiết.",
+    vi: `Vui lòng [nhấp vào đây](${process.env.REACT_APP_HOMEPAGE}) để biết chi tiết.`,
   },
   ui_lang: {
     zh: `界面语言`,

--- a/src/libs/modelList.js
+++ b/src/libs/modelList.js
@@ -13,8 +13,9 @@ const MODEL_KEY_PLACEHOLDER = "{{key}}";
  * @returns {boolean} 是否为 Gemini 原生模型列表 URL。
  */
 const isGeminiNativeModelListUrl = (url = "") =>
-  /\/v1(?:beta\d*)?\/models(?:[/?]|$)/i.test(url) &&
-  !/\/openai\//i.test(url);
+  /^https:\/\/generativelanguage\.googleapis\.com\/v1(?:beta\d*)?\/models(?:[/?]|$)/i.test(
+    url
+  ) && !/\/openai\//i.test(url);
 
 /**
  * 去掉 Gemini 原生模型列表返回的资源名前缀。
@@ -63,12 +64,13 @@ const addUniqueModel = (models, seen, model) => {
  * @param {unknown} data 模型列表接口返回的 JSON 数据。
  * @returns {string[]} 标准化、去重后的模型名称列表。
  */
-export function parseModelListResponse(data) {
+export function parseModelCatalogResponse(data) {
   if (!data || typeof data !== "object") {
-    return [];
+    return { models: [], thinkingCapabilities: {} };
   }
 
   const models = [];
+  const thinkingCapabilities = {};
   const seen = new Set();
   // 兼容 OpenAI-compatible 的 `data` 和 Gemini/Ollama 的 `models` 两种列表字段。
   const lists = [data.data, data.models].filter(Array.isArray);
@@ -92,10 +94,40 @@ export function parseModelListResponse(data) {
         (value) => typeof value === "string" && value.trim()
       );
       addUniqueModel(models, seen, model);
+
+      const normalizedModel = stripGeminiModelPrefix(model?.trim?.() || "");
+      if (
+        normalizedModel &&
+        item.reasoning &&
+        typeof item.reasoning === "object"
+      ) {
+        // OpenRouter 会在 Models API 中动态公布各模型的推理等级和强制推理状态。
+        // 这里只保留请求规范化需要的字段，避免把整条易变的模型记录写入设置。
+        const rawEfforts = item.reasoning.supported_efforts;
+        const supportedEfforts =
+          rawEfforts === null
+            ? ["max", "xhigh", "high", "medium", "low", "minimal"]
+            : Array.isArray(rawEfforts)
+              ? rawEfforts
+              : [];
+        if (supportedEfforts.length) {
+          thinkingCapabilities[normalizedModel] = {
+            model: normalizedModel,
+            supportedEfforts,
+            defaultEffort: item.reasoning.default_effort,
+            defaultEnabled: item.reasoning.default_enabled,
+            mandatory: item.reasoning.mandatory === true,
+          };
+        }
+      }
     });
   });
 
-  return models;
+  return { models, thinkingCapabilities };
+}
+
+export function parseModelListResponse(data) {
+  return parseModelCatalogResponse(data).models;
 }
 
 /**
@@ -193,7 +225,7 @@ export function createModelListRequest({ apiType, modelListUrl, key }) {
  * @param {number} [params.httpTimeout] 请求超时时间配置。
  * @returns {Promise<string[]>} 可用于模型下拉选项的模型名称列表。
  */
-export async function fetchModelList({
+export async function fetchModelCatalog({
   apiType,
   modelListUrl,
   key,
@@ -204,7 +236,7 @@ export async function fetchModelList({
   const request = createModelListRequest({ apiType, modelListUrl, key });
 
   if (!request) {
-    return [];
+    return { models: [], thinkingCapabilities: {} };
   }
 
   const data = await fnPolyfill({
@@ -218,5 +250,11 @@ export async function fetchModelList({
     },
   });
 
-  return parseModelListResponse(data);
+  return parseModelCatalogResponse(data);
+}
+
+// 兼容只消费字符串模型 ID 的现有调用方。
+export async function fetchModelList(params) {
+  const catalog = await fetchModelCatalog(params);
+  return catalog.models;
 }

--- a/src/libs/modelList.test.js
+++ b/src/libs/modelList.test.js
@@ -1,4 +1,8 @@
-import { createModelListRequest, parseModelListResponse } from "./modelList";
+import {
+  createModelListRequest,
+  parseModelCatalogResponse,
+  parseModelListResponse,
+} from "./modelList";
 import {
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
@@ -34,6 +38,35 @@ describe("modelList", () => {
         ],
       })
     ).toEqual(["qwen/qwen3.7-flash", "anthropic/claude-opus-5-fast"]);
+  });
+
+  test("preserves OpenRouter reasoning capabilities by model ID", () => {
+    expect(
+      parseModelCatalogResponse({
+        data: [
+          {
+            id: "google/gemini-3.5-flash",
+            reasoning: {
+              supported_efforts: ["high", "medium", "low", "minimal"],
+              default_effort: "medium",
+              default_enabled: true,
+              mandatory: true,
+            },
+          },
+        ],
+      })
+    ).toEqual({
+      models: ["google/gemini-3.5-flash"],
+      thinkingCapabilities: {
+        "google/gemini-3.5-flash": {
+          model: "google/gemini-3.5-flash",
+          supportedEfforts: ["high", "medium", "low", "minimal"],
+          defaultEffort: "medium",
+          defaultEnabled: true,
+          mandatory: true,
+        },
+      },
+    });
   });
 
   test("parses Gemini model lists", () => {
@@ -119,8 +152,7 @@ describe("modelList", () => {
         key: "gemini-key",
       })
     ).toEqual({
-      input:
-        "https://generativelanguage.googleapis.com/v1beta/openai/models",
+      input: "https://generativelanguage.googleapis.com/v1beta/openai/models",
       init: {
         method: "GET",
         headers: {

--- a/src/views/Options/Apis.js
+++ b/src/views/Options/Apis.js
@@ -41,7 +41,7 @@ import { useApiList, useApiItem } from "../../hooks/Api";
 import { useConfirm } from "../../hooks/Confirm";
 import { resolveApiPromptSettings } from "../../config/prompt";
 import { apiTranslate } from "../../apis";
-import { fetchModelList } from "../../libs/modelList";
+import { fetchModelCatalog } from "../../libs/modelList";
 import Box from "@mui/material/Box";
 import ReusableAutocomplete from "./ReusableAutocomplete";
 import ShowMoreButton from "./ShowMoreButton";
@@ -90,8 +90,8 @@ import {
   BUILTIN_PLACETAGS,
   OPT_TRANS_AZUREAI,
   THINKING_PARAM_MAP,
-  getGeminiThinkingDisableStrategy,
-  getGeminiThinkingEfforts,
+  getThinkingCapability,
+  resolveThinkingStrategy,
   DEFAULT_NOBATCH_PROMPT_SLUG,
   DEFAULT_BATCH_PROMPT_SLUG,
   DEFAULT_SUBTITLE_PROMPT_SLUG,
@@ -313,6 +313,9 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   const [formData, setFormData] = useState(() => api || {});
   const [showMore, setShowMore] = useState(false);
   const [modelOptions, setModelOptions] = useState([]);
+  const [modelThinkingCapabilities, setModelThinkingCapabilities] = useState(
+    {}
+  );
   const [modelListStatus, setModelListStatus] = useState("idle");
   const [modelListError, setModelListError] = useState("");
   const requestedModelListKeyRef = useRef("");
@@ -325,6 +328,7 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   useLayoutEffect(() => {
     setShowMore(false);
     setModelOptions([]);
+    setModelThinkingCapabilities({});
     setModelListStatus("idle");
     setModelListError("");
     requestedModelListKeyRef.current = "";
@@ -366,6 +370,15 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
         newData.sortOrder = value ? 999 : 0;
       }
 
+      if (name === "model") {
+        const capabilities = modelThinkingCapabilities[value];
+        if (capabilities) {
+          newData.thinkingCapabilities = capabilities;
+        } else {
+          delete newData.thinkingCapabilities;
+        }
+      }
+
       return newData;
     });
   };
@@ -405,7 +418,18 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   };
 
   const handleSave = () => {
-    update(activeFormData);
+    const nextFormData = { ...activeFormData };
+    if (
+      thinkingParam &&
+      nextFormData.thinkingEffort &&
+      nextFormData.thinkingEffort !== "_default" &&
+      !thinkingEfforts?.some(
+        (effort) => effort.value === nextFormData.thinkingEffort
+      )
+    ) {
+      nextFormData.thinkingEffort = "_default";
+    }
+    update(nextFormData);
     if (activeFormData.isDisabled || activeFormData.sortOrder === -1) {
       onCollapse?.();
     }
@@ -470,6 +494,7 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
     aiTerms = "",
     thinkingMode = "disabled",
     thinkingEffort = "_default",
+    thinkingCapabilities,
     batchPromptSlug = "",
     nobatchPromptSlug = "",
     subtitlePromptSlug = "",
@@ -481,23 +506,34 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
   useEffect(() => {
     setModelListStatus("idle");
     setModelListError("");
+    setModelThinkingCapabilities({});
     requestedModelListKeyRef.current = "";
   }, [modelListUrl, key]);
 
-  const thinkingParam = THINKING_PARAM_MAP[apiType];
-  const thinkingEfforts =
-    apiType === OPT_TRANS_GEMINI || apiType === OPT_TRANS_GEMINI_2
-      ? getGeminiThinkingEfforts({ apiType, model })
-      : thinkingParam?.efforts;
+  const effectiveThinkingCapabilities =
+    modelThinkingCapabilities[model] || thinkingCapabilities;
+  const thinkingCapability = getThinkingCapability({
+    apiType,
+    model,
+    thinkingCapabilities: effectiveThinkingCapabilities,
+  });
+  const thinkingParam = THINKING_PARAM_MAP[apiType] && thinkingCapability;
+  const thinkingEfforts = thinkingCapability?.efforts;
   const selectedThinkingEffort = thinkingEfforts?.some(
     (effort) => effort.value === thinkingEffort
   )
     ? thinkingEffort
     : "_default";
   const thinkingDisableStrategy =
-    thinkingMode === "disabled" &&
-    (apiType === OPT_TRANS_GEMINI || apiType === OPT_TRANS_GEMINI_2)
-      ? getGeminiThinkingDisableStrategy({ apiType, url, model })
+    thinkingMode === "disabled"
+      ? resolveThinkingStrategy({
+          apiType,
+          url,
+          model,
+          thinkingMode,
+          thinkingEffort,
+          thinkingCapabilities: effectiveThinkingCapabilities,
+        })
       : null;
   const selectedBatchPromptSlug = Object.prototype.hasOwnProperty.call(
     activeFormData,
@@ -582,19 +618,32 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
     setModelListError("");
 
     try {
-      const nextModelOptions = await fetchModelList({
+      const catalog = await fetchModelCatalog({
         apiType,
         modelListUrl,
         key,
         httpTimeout,
       });
+      const nextModelOptions = catalog.models;
       setModelOptions(nextModelOptions);
+      setModelThinkingCapabilities(catalog.thinkingCapabilities);
+      setFormData((prevData) => {
+        const baseData = prevData?.apiSlug === apiSlug ? prevData : api || {};
+        const capabilities = catalog.thinkingCapabilities[baseData.model];
+        const newData = { ...baseData };
+        if (capabilities) {
+          newData.thinkingCapabilities = capabilities;
+        } else {
+          delete newData.thinkingCapabilities;
+        }
+        return newData;
+      });
       setModelListStatus(nextModelOptions.length > 0 ? "success" : "empty");
     } catch (err) {
       setModelListStatus("error");
       setModelListError(err?.message || String(err));
     }
-  }, [apiSlug, apiType, httpTimeout, key, modelListStatus, modelListUrl]);
+  }, [api, apiSlug, apiType, httpTimeout, key, modelListStatus, modelListUrl]);
 
   return (
     <Stack spacing={3}>
@@ -1121,11 +1170,9 @@ function ApiFields({ apiSlug, deleteApi, copyApi, onCollapse }) {
                 <MenuItem value="enabled">
                   {i18n("thinking_mode_enabled")}
                 </MenuItem>
-                {thinkingParam.disableSupported !== false && (
-                  <MenuItem value="disabled">
-                    {i18n("thinking_mode_disabled")}
-                  </MenuItem>
-                )}
+                <MenuItem value="disabled">
+                  {i18n("thinking_mode_disabled")}
+                </MenuItem>
               </TextField>
             </Grid>
             {thinkingMode === "enabled" && thinkingEfforts && (

--- a/src/views/Options/Apis.test.js
+++ b/src/views/Options/Apis.test.js
@@ -7,7 +7,7 @@ import {
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
 } from "../../config";
-import { fetchModelList } from "../../libs/modelList";
+import { fetchModelCatalog } from "../../libs/modelList";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 HTMLElement.prototype.scrollTo = jest.fn();
@@ -47,7 +47,7 @@ jest.mock("../../apis", () => ({
 }));
 
 jest.mock("../../libs/modelList", () => ({
-  fetchModelList: jest.fn(),
+  fetchModelCatalog: jest.fn(),
 }));
 
 jest.mock("./ReusableAutocomplete", () => {
@@ -162,7 +162,10 @@ describe("Apis model list", () => {
   });
 
   test("loads model list once when model input is focused", async () => {
-    fetchModelList.mockResolvedValue(["gpt-4o", "gpt-4.1"]);
+    fetchModelCatalog.mockResolvedValue({
+      models: ["gpt-4o", "gpt-4.1"],
+      thinkingCapabilities: {},
+    });
     const view = await renderApis();
     const modelInput = getInput(view.container, "model");
 
@@ -176,14 +179,64 @@ describe("Apis model list", () => {
       await Promise.resolve();
     });
 
-    expect(fetchModelList).toHaveBeenCalledTimes(1);
-    expect(fetchModelList).toHaveBeenCalledWith({
+    expect(fetchModelCatalog).toHaveBeenCalledTimes(1);
+    expect(fetchModelCatalog).toHaveBeenCalledWith({
       apiType: OPT_TRANS_OPENAI,
       modelListUrl: "https://api.openai.com/v1/models",
       key: "sk-test",
       httpTimeout: 30,
     });
     expect(modelInput.getAttribute("data-options")).toContain("gpt-4o");
+
+    view.unmount();
+  });
+
+  test("saves OpenRouter reasoning metadata for the selected model", async () => {
+    fetchModelCatalog.mockResolvedValue({
+      models: ["provider/mandatory-model"],
+      thinkingCapabilities: {
+        "provider/mandatory-model": {
+          model: "provider/mandatory-model",
+          supportedEfforts: ["high", "low"],
+          mandatory: true,
+        },
+      },
+    });
+    const update = jest.fn();
+    const view = await renderApis(
+      createApi({
+        apiSlug: "OpenRouter",
+        apiName: "OpenRouter",
+        apiType: "OpenRouter",
+        model: "provider/mandatory-model",
+        modelListUrl: "https://openrouter.ai/api/v1/models",
+        thinkingMode: "disabled",
+      }),
+      update
+    );
+    const modelInput = getInput(view.container, "model");
+
+    await act(async () => {
+      Simulate.focus(modelInput);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(view.container.textContent).toContain(
+      "gemini_thinking_minimum_helper"
+    );
+
+    await act(async () => {
+      Simulate.click(getSaveButton(view.container));
+    });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinkingCapabilities: {
+          model: "provider/mandatory-model",
+          supportedEfforts: ["high", "low"],
+          mandatory: true,
+        },
+      })
+    );
 
     view.unmount();
   });
@@ -197,7 +250,7 @@ describe("Apis model list", () => {
       await Promise.resolve();
     });
 
-    expect(fetchModelList).not.toHaveBeenCalled();
+    expect(fetchModelCatalog).not.toHaveBeenCalled();
 
     view.unmount();
   });
@@ -231,7 +284,7 @@ describe("Apis model list", () => {
   });
 
   test("shows fetch failure without clearing model", async () => {
-    fetchModelList.mockRejectedValue(new Error("network failed"));
+    fetchModelCatalog.mockRejectedValue(new Error("network failed"));
     const view = await renderApis();
     const modelInput = getInput(view.container, "model");
 
@@ -249,7 +302,7 @@ describe("Apis model list", () => {
   });
 
   test("resets model list error when url or key changes", async () => {
-    fetchModelList.mockRejectedValue(new Error("network failed"));
+    fetchModelCatalog.mockRejectedValue(new Error("network failed"));
     const view = await renderApis();
     const modelInput = getInput(view.container, "model");
     const modelListUrlInput = getInput(view.container, "modelListUrl");


### PR DESCRIPTION
整理模型关闭思考的参数。

@Baneik 有空可以帮忙看看最新代码是否符合预期：

接口默认：不注入任何思考控制参数。
开启思考：
  - 如果思考强度为接口默认，只注入开启参数，不注入强度参数。如果没有开启参数，则传入最低等级强度参数。
  - 如果选择了思考强度，则使用选择的强度参数。
关闭思考：能关闭就关闭，否则使用模型最低支持等级。

新建接口：默认关闭思考，思考强度接口默认。