### PR TITLE
Preserve internal whitespace in translation text

### DIFF
--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -2614,9 +2614,6 @@ overflow-wrap: anywhere !important;`;
           });
         }
 
-        // 换行符替换
-        text = text.replace(/\r?\n/g, () => pushReplace(`&#10;`));
-
         return escapeHTML(text);
       }
 
@@ -2703,7 +2700,13 @@ overflow-wrap: anywhere !important;`;
       return tag;
     }
 
-    const processedString = nodes.map(traverse).join("").trim();
+    let processedString = nodes.map(traverse).join("").trim();
+
+    // 先清理整个翻译片段两端的源码排版空白，再保护正文内部的换行和 Tab。
+    // 不能逐个 trim 文本节点，否则会破坏行内元素之间的必要空格。
+    processedString = processedString.replace(/\r?\n|\t/g, (whitespace) =>
+      pushReplace(whitespace === "\t" ? "&#9;" : "&#10;")
+    );
 
     return [processedString, placeholderMap];
   }

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -194,6 +194,75 @@ describe("Translator rule styles", () => {
     expect(requestedTexts.every((text) => text.trim())).toBe(true);
   });
 
+  test("trims source indentation before creating whitespace placeholders", async () => {
+    document.body.innerHTML =
+      '<main id="root"><span id="target">\n\t\t1. Overall Structure\n\t</span></main>';
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "#target",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    expect(apiTranslate).toHaveBeenCalledTimes(1);
+    expect(apiTranslate.mock.calls[0][0].text).toBe("1. Overall Structure");
+  });
+
+  test("protects and restores internal newlines and tabs", async () => {
+    const sourceText = "First\tcolumn\nSecond line";
+    apiTranslate.mockImplementation(({ text }) =>
+      Promise.resolve({ trText: text, isSame: false })
+    );
+    document.body.innerHTML =
+      '<main id="root"><span id="target"></span></main>';
+    document.getElementById("target").textContent = sourceText;
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "#target",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    const requestedText = apiTranslate.mock.calls[0][0].text;
+    const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+
+    expect(requestedText).toBe("First{1}column{2}Second line");
+    expect(requestedText).not.toContain("\t");
+    expect(requestedText).not.toContain("\n");
+    expect(inner.textContent).toBe(sourceText);
+  });
+
+  test("keeps literal backslash-t text unchanged", async () => {
+    const sourceText = "Show \\t literally";
+    apiTranslate.mockImplementation(({ text }) =>
+      Promise.resolve({ trText: text, isSame: false })
+    );
+    document.body.innerHTML =
+      '<main id="root"><span id="target"></span></main>';
+    document.getElementById("target").textContent = sourceText;
+
+    createTranslator(
+      {
+        autoScan: "false",
+        selector: "#target",
+      },
+      { minLength: 0 }
+    );
+    await flushAsync();
+
+    const requestedText = apiTranslate.mock.calls[0][0].text;
+    const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+
+    expect(requestedText).toBe(sourceText);
+    expect(inner.textContent).toBe(sourceText);
+  });
+
   test("still translates mixed inline text groups", async () => {
     apiTranslate.mockResolvedValue({
       trText: "Translated mixed inline content",
@@ -218,6 +287,11 @@ describe("Translator rule styles", () => {
     expect(apiTranslate).toHaveBeenCalled();
     expect(combinedRequestedText).toContain("Text");
     expect(combinedRequestedText).toContain("tail");
+    expect(
+      requestedTexts.some(
+        (text) => text.startsWith("Text ") && text.endsWith(" tail")
+      )
+    ).toBe(true);
     expect(wrapper).not.toBeNull();
     expect(wrapper.textContent).toBe("Translated mixed inline content");
   });


### PR DESCRIPTION
清除原文句首或句尾的 \t

https://github.com/fishjar/kiss-translator/issues/994