### PR TITLE
fix: normalize coarse YouTube captions for AI segmentation

### DIFF
--- a/src/scripts/test-subtitle-segmentation.js
+++ b/src/scripts/test-subtitle-segmentation.js
@@ -94,7 +94,7 @@ async function run() {
     await fs.mkdir(sampleDir, { recursive: true });
 
     const { events, flatEvents, filteredNonSpeechCount } =
-      prepareTimedTextEvents(rawEvents);
+      prepareTimedTextEvents(rawEvents, fromLang);
     await writeJson(path.join(sampleDir, "raw.json"), sourceValue);
     await writeJson(path.join(sampleDir, "flat-events.json"), flatEvents);
 

--- a/src/subtitle/YouTubeCaptionProvider.js
+++ b/src/subtitle/YouTubeCaptionProvider.js
@@ -577,8 +577,10 @@ export class YouTubeCaptionProvider {
         return;
       }
 
-      const { events: subtitleEvents, flatEvents } =
-        prepareTimedTextEvents(events);
+      const { events: subtitleEvents, flatEvents } = prepareTimedTextEvents(
+        events,
+        fromLang
+      );
       if (!flatEvents?.length) {
         logger.debug("Youtube Provider: flatEvents not got:", videoId);
         return;

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -52,7 +52,7 @@ describe("coarse timedtext normalization", () => {
       {
         tStartMs: 1200,
         dDurationMs: 3400,
-        segs: [{ utf8: "The quick brown fox." }],
+        segs: [{ utf8: "The quick brown fox.", acAsrConf: 0 }],
       },
     ];
     const prepared = prepareTimedTextEvents(rawEvents);
@@ -108,6 +108,54 @@ describe("coarse timedtext normalization", () => {
         _ei: 3,
       },
     ]);
+  });
+
+  test("leaves manually authored sentence-level captions unchanged", () => {
+    const rawEvents = [
+      {
+        tStartMs: 1200,
+        dDurationMs: 3400,
+        segs: [{ utf8: "The quick brown fox." }],
+      },
+    ];
+
+    expect(prepareTimedTextEvents(rawEvents).flatEvents).toEqual([
+      { text: "The quick brown fox.", start: 1200, end: 4600 },
+    ]);
+  });
+
+  test("caps coarse ASR words at the next event without overlaps or lost text", () => {
+    const rawEvents = [
+      {
+        tStartMs: 0,
+        dDurationMs: 6000,
+        segs: [{ utf8: "one two six", acAsrConf: 0 }],
+      },
+      {
+        tStartMs: 3000,
+        dDurationMs: 1000,
+        segs: [{ utf8: "next", acAsrConf: 0 }],
+      },
+    ];
+
+    const { flatEvents } = prepareTimedTextEvents(rawEvents);
+
+    expect(flatEvents).toEqual([
+      { text: "one", start: 0, end: 1000 },
+      { text: "two", start: 1000, end: 2000 },
+      { text: "six", start: 2000, end: 3000 },
+      { text: "next", start: 3000, end: 4000 },
+    ]);
+    expect(flatEvents.map((event) => event.text).join(" ")).toBe(
+      "one two six next"
+    );
+    expect(
+      flatEvents.every(
+        (event, index) =>
+          index === flatEvents.length - 1 ||
+          event.end <= flatEvents[index + 1].start
+      )
+    ).toBe(true);
   });
 
   test("leaves word-level offsets unchanged", () => {

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -4,7 +4,10 @@ import {
   eventsToSubtitles,
 } from "./youtubeAiSegmentation";
 import { mapBoundaryItemToCue } from "./subtitleBoundaryProtocol";
-import { prepareTimedTextEvents } from "./youtubeSubtitleProcessing";
+import {
+  formatSubtitles,
+  prepareTimedTextEvents,
+} from "./youtubeSubtitleProcessing";
 
 jest.mock("../libs/log.js", () => ({
   LogLevel: {
@@ -198,6 +201,61 @@ describe("coarse timedtext normalization", () => {
       { text: "six", start: 2000, end: 3000 },
       { text: "next", start: 5000, end: 6000 },
     ]);
+  });
+
+  test("looks past a same-timestamp newline for the next usable boundary", () => {
+    const { flatEvents } = prepareTimedTextEvents([
+      {
+        tStartMs: 1000,
+        dDurationMs: 6000,
+        segs: [{ utf8: "one two six", acAsrConf: 0 }],
+      },
+      {
+        tStartMs: 1000,
+        aAppend: 1,
+        segs: [{ utf8: "\n" }],
+      },
+      {
+        tStartMs: 4000,
+        dDurationMs: 1000,
+        segs: [{ utf8: "next", acAsrConf: 0 }],
+      },
+    ]);
+
+    expect(flatEvents).toEqual([
+      { text: "one", start: 1000, end: 2000 },
+      { text: "two", start: 2000, end: 3000 },
+      { text: "six", start: 3000, end: 4000 },
+      { text: "next", start: 4000, end: 5000 },
+    ]);
+  });
+
+  test("preserves Korean ASR spaces in AI and rule-based reconstruction", () => {
+    const prepared = prepareTimedTextEvents(
+      [
+        {
+          tStartMs: 1000,
+          dDurationMs: 3000,
+          segs: [{ utf8: "오늘 날씨 정말 좋다", acAsrConf: 0 }],
+        },
+      ],
+      "ko"
+    );
+
+    expect(prepared.flatEvents).toEqual([
+      { text: "오늘 날씨 정말 좋다", start: 1000, end: 4000 },
+    ]);
+    expect(
+      mapBoundaryItemToCue(
+        { e: 0, t: "좋은 날씨" },
+        prepared.flatEvents,
+        0,
+        "ko"
+      ).text
+    ).toBe("오늘 날씨 정말 좋다");
+    expect(formatSubtitles(prepared.flatEvents, "ko")[0].text).toBe(
+      "오늘 날씨 정말 좋다"
+    );
   });
 
   test("leaves word-level offsets unchanged", () => {

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -3,6 +3,7 @@ import {
   createAiChunkScheduler,
   eventsToSubtitles,
 } from "./youtubeAiSegmentation";
+import { mapBoundaryItemToCue } from "./subtitleBoundaryProtocol";
 import { prepareTimedTextEvents } from "./youtubeSubtitleProcessing";
 
 jest.mock("../libs/log.js", () => ({
@@ -44,6 +45,117 @@ const subtitle = {
   _si: 0,
   _ei: 1,
 };
+
+describe("coarse timedtext normalization", () => {
+  test("expands a coarse phrase for AI boundaries and reconstructs adjacent cue times", async () => {
+    const rawEvents = [
+      {
+        tStartMs: 1200,
+        dDurationMs: 3400,
+        segs: [{ utf8: "The quick brown fox." }],
+      },
+    ];
+    const prepared = prepareTimedTextEvents(rawEvents);
+    const apiSubtitle = jest.fn(({ events }) => {
+      let nextIndex = 0;
+      return Promise.resolve(
+        [
+          { e: 1, t: "敏捷的狐狸" },
+          { e: 3, t: "棕色狐狸。" },
+        ].map((item) => {
+          const cue = mapBoundaryItemToCue(item, events, nextIndex, "en");
+          nextIndex = item.e + 1;
+          return cue;
+        })
+      );
+    });
+
+    const result = await aiSegment({
+      videoId: "video-coarse-captions",
+      fromLang: "en",
+      toLang: "zh-CN",
+      chunkEvents: prepared.flatEvents,
+      segApiSetting: { apiSlug: "openai" },
+      apiSubtitle,
+      docInfo: {},
+      formatSubtitles: jest.fn(() => []),
+      clearSegmentTranslation: false,
+      setting: {},
+    });
+
+    expect(prepared.events).toEqual(rawEvents);
+    expect(apiSubtitle.mock.calls[0][0].events).toEqual([
+      { text: "The", start: 1200, end: 1800 },
+      { text: "quick", start: 1800, end: 2800 },
+      { text: "brown", start: 2800, end: 3800 },
+      { text: "fox.", start: 3800, end: 4600 },
+    ]);
+    expect(result).toEqual([
+      {
+        start: 1200,
+        end: 2800,
+        text: "The quick",
+        translation: "敏捷的狐狸",
+        _si: 0,
+        _ei: 1,
+      },
+      {
+        start: 2800,
+        end: 4600,
+        text: "brown fox.",
+        translation: "棕色狐狸。",
+        _si: 2,
+        _ei: 3,
+      },
+    ]);
+  });
+
+  test("leaves word-level offsets unchanged", () => {
+    const rawEvents = [
+      {
+        tStartMs: 2000,
+        dDurationMs: 1500,
+        segs: [
+          { utf8: "hello", tOffsetMs: 0 },
+          { utf8: "world.", tOffsetMs: 600 },
+        ],
+      },
+    ];
+
+    expect(prepareTimedTextEvents(rawEvents)).toMatchObject({
+      events: rawEvents,
+      flatEvents: [
+        { text: "hello", start: 2000, end: 2600 },
+        { text: "world.", start: 2600, end: 3500 },
+      ],
+    });
+  });
+
+  test.each([
+    ["empty", { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "" }] }, []],
+    [
+      "line break",
+      {
+        tStartMs: 0,
+        dDurationMs: 0,
+        aAppend: 1,
+        segs: [{ utf8: "\n" }],
+      },
+      [],
+    ],
+    [
+      "non-space text",
+      {
+        tStartMs: 0,
+        dDurationMs: 1000,
+        segs: [{ utf8: "今天我们测试" }],
+      },
+      [{ text: "今天我们测试", start: 0, end: 1000 }],
+    ],
+  ])("does not synthetically split %s segments", (_name, event, expected) => {
+    expect(prepareTimedTextEvents([event]).flatEvents).toEqual(expected);
+  });
+});
 
 describe("aiSegment recovery", () => {
   test("sends only speech events after timedtext preparation", async () => {

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -158,6 +158,22 @@ describe("coarse timedtext normalization", () => {
     ).toBe(true);
   });
 
+  test("coarse ASR -> duplicate -> next effective event", () => {
+    const event = (utf8, tStartMs, dDurationMs) => ({
+      tStartMs,
+      dDurationMs,
+      segs: [{ utf8, acAsrConf: 0 }],
+    });
+    const coarseEvent = event("one two six", 0, 6000);
+    const { flatEvents } = prepareTimedTextEvents([
+      coarseEvent,
+      coarseEvent,
+      event("next", 3000, 1000),
+    ]);
+    expect(flatEvents[2].text).toBe("six");
+    expect(flatEvents[1].end).toBeLessThanOrEqual(flatEvents[3].start);
+  });
+
   test("leaves word-level offsets unchanged", () => {
     const rawEvents = [
       {

--- a/src/subtitle/youtubeAiSegmentation.test.js
+++ b/src/subtitle/youtubeAiSegmentation.test.js
@@ -174,6 +174,32 @@ describe("coarse timedtext normalization", () => {
     expect(flatEvents[1].end).toBeLessThanOrEqual(flatEvents[3].start);
   });
 
+  test.each([
+    ["non-speech", { tStartMs: 3000, segs: [{ utf8: "[Music]" }] }],
+    ["line break", { tStartMs: 3000, aAppend: 1, segs: [{ utf8: "\n" }] }],
+  ])("caps coarse ASR words at a retained %s boundary", (_name, boundary) => {
+    const { flatEvents } = prepareTimedTextEvents([
+      {
+        tStartMs: 0,
+        dDurationMs: 6000,
+        segs: [{ utf8: "one two six", acAsrConf: 0 }],
+      },
+      boundary,
+      {
+        tStartMs: 5000,
+        dDurationMs: 1000,
+        segs: [{ utf8: "next", acAsrConf: 0 }],
+      },
+    ]);
+
+    expect(flatEvents).toEqual([
+      { text: "one", start: 0, end: 1000 },
+      { text: "two", start: 1000, end: 2000 },
+      { text: "six", start: 2000, end: 3000 },
+      { text: "next", start: 5000, end: 6000 },
+    ]);
+  });
+
   test("leaves word-level offsets unchanged", () => {
     const rawEvents = [
       {

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -51,7 +51,7 @@ export function cleanTimedText(utf8 = "") {
 }
 
 /**
- * 按词长比例将粗粒度空格文本展开为连续的时间片段。
+ * 按词长比例将自动字幕的粗粒度空格文本展开为连续的时间片段。
  * 无安全分词边界或无有效时长时保持原片段。
  */
 function expandCoarseTimedText(text, start, end) {
@@ -80,6 +80,7 @@ function expandCoarseTimedText(text, start, end) {
  * @returns {{events:Array<object>, flatEvents:Array<object>, filteredNonSpeechCount:number}}
  */
 export function prepareTimedTextEvents(rawEvents = []) {
+  const sourceEvents = Array.isArray(rawEvents) ? rawEvents : [];
   const events = [];
   const flatEvents = [];
   let filteredNonSpeechCount = 0;
@@ -97,7 +98,8 @@ export function prepareTimedTextEvents(rawEvents = []) {
     buffer = null;
   };
 
-  for (const rawEvent of Array.isArray(rawEvents) ? rawEvents : []) {
+  for (let eventIndex = 0; eventIndex < sourceEvents.length; eventIndex += 1) {
+    const rawEvent = sourceEvents[eventIndex];
     const event = rawEvent || {};
     const rawSegs = Array.isArray(event.segs) ? event.segs : [];
     const tStartMs = Number(event.tStartMs) || 0;
@@ -150,9 +152,22 @@ export function prepareTimedTextEvents(rawEvents = []) {
         index === normalizedSegs.length - 1
           ? dDurationMs
           : Number(normalizedSegs[index + 1]?.tOffsetMs) || 0;
-      const expanded = text.includes(" ")
-        ? expandCoarseTimedText(text, start, tStartMs + nextOffset)
-        : null;
+      const declaredEnd = tStartMs + nextOffset;
+      const nextEventStart = Number(sourceEvents[eventIndex + 1]?.tStartMs);
+      const effectiveEnd =
+        index === normalizedSegs.length - 1 &&
+        Number.isFinite(nextEventStart) &&
+        nextEventStart > start
+          ? Math.min(declaredEnd, nextEventStart)
+          : declaredEnd;
+      const isAsrSegment = Object.prototype.hasOwnProperty.call(
+        normalizedSegs[index],
+        "acAsrConf"
+      );
+      const expanded =
+        isAsrSegment && text.includes(" ")
+          ? expandCoarseTimedText(text, start, effectiveEnd)
+          : null;
       if (expanded) {
         flatEvents.push(...expanded.slice(0, -1));
         buffer = expanded[expanded.length - 1];

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -51,6 +51,28 @@ export function cleanTimedText(utf8 = "") {
 }
 
 /**
+ * 按词长比例将粗粒度空格文本展开为连续的时间片段。
+ * 无安全分词边界或无有效时长时保持原片段。
+ */
+function expandCoarseTimedText(text, start, end) {
+  const words = text.split(" ").filter(Boolean);
+  if (words.length < 2 || !Number.isFinite(end) || end <= start) return null;
+
+  const totalWeight = words.reduce((total, word) => total + word.length, 0);
+  let elapsedWeight = 0;
+
+  return words.map((word, index) => {
+    const wordStart = start + ((end - start) * elapsedWeight) / totalWeight;
+    elapsedWeight += word.length;
+    const wordEnd =
+      index === words.length - 1
+        ? end
+        : start + ((end - start) * elapsedWeight) / totalWeight;
+    return { text: word, start: wordStart, end: wordEnd };
+  });
+}
+
+/**
  * 一次完成 YouTube json3 events 的文本清洗、相邻重复事件去除和时间轴展平。
  * 原始输入不会被修改；统计断句读取 events，规则和 AI 断句读取已过滤非语音片段的 flatEvents。
  *
@@ -124,6 +146,19 @@ export function prepareTimedTextEvents(rawEvents = []) {
       }
 
       flushBuffer(start);
+      const nextOffset =
+        index === normalizedSegs.length - 1
+          ? dDurationMs
+          : Number(normalizedSegs[index + 1]?.tOffsetMs) || 0;
+      const expanded = text.includes(" ")
+        ? expandCoarseTimedText(text, start, tStartMs + nextOffset)
+        : null;
+      if (expanded) {
+        flatEvents.push(...expanded.slice(0, -1));
+        buffer = expanded[expanded.length - 1];
+        continue;
+      }
+
       buffer = { text, start };
       if (index === normalizedSegs.length - 1) {
         buffer.end = tStartMs + dDurationMs;

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -90,10 +90,7 @@ function findNextEffectiveEventStart(sourceEvents, eventIndex, lastEventKey) {
     const event = sourceEvents[index] || {};
     const eventKey = getTimedTextEventKey(event);
     if (!shouldRetainTimedTextEvent(eventKey, lastEventKey)) continue;
-    lastEventKey = eventKey;
-    const visibleText = getTimedTextEventText(event);
-    const hasSpeech = visibleText && !isNonSpeechSegment(visibleText);
-    if (hasSpeech) return Number(event.tStartMs);
+    return Number(event.tStartMs);
   }
   return NaN;
 }

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -72,6 +72,32 @@ function expandCoarseTimedText(text, start, end) {
   });
 }
 
+function getTimedTextEventText(event = {}) {
+  const segs = Array.isArray(event.segs) ? event.segs : [];
+  return cleanTimedText(segs.map((seg) => seg?.utf8).join(" "));
+}
+function getTimedTextEventKey(event = {}) {
+  const visibleText = getTimedTextEventText(event);
+  if (!visibleText) return "";
+  return `${Number(event.tStartMs) || 0}|${Number(event.dDurationMs) || 0}|${visibleText}`;
+}
+
+const shouldRetainTimedTextEvent = (eventKey, lastVisibleEventKey) =>
+  !eventKey || eventKey !== lastVisibleEventKey;
+
+function findNextEffectiveEventStart(sourceEvents, eventIndex, lastEventKey) {
+  for (let index = eventIndex + 1; index < sourceEvents.length; index += 1) {
+    const event = sourceEvents[index] || {};
+    const eventKey = getTimedTextEventKey(event);
+    if (!shouldRetainTimedTextEvent(eventKey, lastEventKey)) continue;
+    lastEventKey = eventKey;
+    const visibleText = getTimedTextEventText(event);
+    const hasSpeech = visibleText && !isNonSpeechSegment(visibleText);
+    if (hasSpeech) return Number(event.tStartMs);
+  }
+  return NaN;
+}
+
 /**
  * 一次完成 YouTube json3 events 的文本清洗、相邻重复事件去除和时间轴展平。
  * 原始输入不会被修改；统计断句读取 events，规则和 AI 断句读取已过滤非语音片段的 flatEvents。
@@ -112,18 +138,10 @@ export function prepareTimedTextEvents(rawEvents = []) {
       // 统计断句仍需识别 YouTube 的物理换行控制信号。
       utf8: isLineBreak ? "\n" : cleanTimedText(seg?.utf8),
     }));
-    const visibleText = normalizedSegs
-      .map((seg) => cleanTimedText(seg.utf8))
-      .filter(Boolean)
-      .join(" ")
-      .replace(/\s+/g, " ")
-      .trim();
-    const eventKey = visibleText
-      ? `${tStartMs}|${dDurationMs}|${visibleText}`
-      : "";
+    const eventKey = getTimedTextEventKey(event);
 
     // 只删除相邻且时间、时长、可见文本完全相同的重复事件。
-    if (eventKey && eventKey === lastVisibleEventKey) continue;
+    if (!shouldRetainTimedTextEvent(eventKey, lastVisibleEventKey)) continue;
 
     const canonicalEvent = { ...event, segs: normalizedSegs };
     events.push(canonicalEvent);
@@ -153,7 +171,11 @@ export function prepareTimedTextEvents(rawEvents = []) {
           ? dDurationMs
           : Number(normalizedSegs[index + 1]?.tOffsetMs) || 0;
       const declaredEnd = tStartMs + nextOffset;
-      const nextEventStart = Number(sourceEvents[eventIndex + 1]?.tStartMs);
+      const nextEventStart = findNextEffectiveEventStart(
+        sourceEvents,
+        eventIndex,
+        lastVisibleEventKey
+      );
       const effectiveEnd =
         index === normalizedSegs.length - 1 &&
         Number.isFinite(nextEventStart) &&

--- a/src/subtitle/youtubeSubtitleProcessing.js
+++ b/src/subtitle/youtubeSubtitleProcessing.js
@@ -7,6 +7,8 @@ import { logger } from "../libs/log.js";
 import { intelligentSentenceBreak } from "./sentenceBreaker.js";
 import { isNonSpeechSegment } from "./subtitleTextClassification.js";
 
+const NO_SPACE_LANGUAGES = ["zh", "ja", "ko", "th", "lo", "km", "my"];
+
 /**
  * YouTube 字幕文本处理层。
  * 只负责语言映射、timedtext 事件清洗、展平、切块和内置断句，不发起 AI 请求，也不触碰页面 DOM。
@@ -85,12 +87,21 @@ function getTimedTextEventKey(event = {}) {
 const shouldRetainTimedTextEvent = (eventKey, lastVisibleEventKey) =>
   !eventKey || eventKey !== lastVisibleEventKey;
 
-function findNextEffectiveEventStart(sourceEvents, eventIndex, lastEventKey) {
+function findNextEffectiveEventStart(
+  sourceEvents,
+  eventIndex,
+  lastEventKey,
+  currentStart
+) {
   for (let index = eventIndex + 1; index < sourceEvents.length; index += 1) {
     const event = sourceEvents[index] || {};
     const eventKey = getTimedTextEventKey(event);
     if (!shouldRetainTimedTextEvent(eventKey, lastEventKey)) continue;
-    return Number(event.tStartMs);
+    lastEventKey = eventKey;
+    const eventStart = Number(event.tStartMs);
+    if (Number.isFinite(eventStart) && eventStart > currentStart) {
+      return eventStart;
+    }
   }
   return NaN;
 }
@@ -100,10 +111,14 @@ function findNextEffectiveEventStart(sourceEvents, eventIndex, lastEventKey) {
  * 原始输入不会被修改；统计断句读取 events，规则和 AI 断句读取已过滤非语音片段的 flatEvents。
  *
  * @param {Array<object>} [rawEvents=[]] YouTube 原始 json3 events。
+ * @param {string} [fromLang="auto"] 字幕源语言代码。
  * @returns {{events:Array<object>, flatEvents:Array<object>, filteredNonSpeechCount:number}}
  */
-export function prepareTimedTextEvents(rawEvents = []) {
+export function prepareTimedTextEvents(rawEvents = [], fromLang = "auto") {
   const sourceEvents = Array.isArray(rawEvents) ? rawEvents : [];
+  const canExpandCoarseText = !NO_SPACE_LANGUAGES.some((lang) =>
+    String(fromLang).startsWith(lang)
+  );
   const events = [];
   const flatEvents = [];
   let filteredNonSpeechCount = 0;
@@ -171,7 +186,8 @@ export function prepareTimedTextEvents(rawEvents = []) {
       const nextEventStart = findNextEffectiveEventStart(
         sourceEvents,
         eventIndex,
-        lastVisibleEventKey
+        lastVisibleEventKey,
+        start
       );
       const effectiveEnd =
         index === normalizedSegs.length - 1 &&
@@ -184,7 +200,7 @@ export function prepareTimedTextEvents(rawEvents = []) {
         "acAsrConf"
       );
       const expanded =
-        isAsrSegment && text.includes(" ")
+        isAsrSegment && canExpandCoarseText && text.includes(" ")
           ? expandCoarseTimedText(text, start, effectiveEnd)
           : null;
       if (expanded) {
@@ -387,9 +403,7 @@ export function formatSubtitles(
 ) {
   if (!flatEvents?.length) return [];
 
-  const noSpaceLanguages = ["zh", "ja", "ko", "th", "lo", "km", "my"];
-
-  if (noSpaceLanguages.some((l) => lang?.startsWith(l))) {
+  if (NO_SPACE_LANGUAGES.some((l) => lang?.startsWith(l))) {
     const subtitles = [];
 
     if (isQualityPoor(flatEvents, 5, 0.5)) {

--- a/src/views/Options/SubtitleSegmentationPlayground.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.js
@@ -204,11 +204,14 @@ export default function SubtitleSegmentationPlayground({
   const prepared = useMemo(() => {
     if (!sourceValue) return null;
     try {
-      return prepareTimedTextEvents(parseSubtitleSource(sourceValue).events);
+      return prepareTimedTextEvents(
+        parseSubtitleSource(sourceValue).events,
+        fromLang
+      );
     } catch {
       return null;
     }
-  }, [sourceValue]);
+  }, [sourceValue, fromLang]);
   const estimatedChunkCount = segApi
     ? splitEventsIntoChunks(
         prepared?.flatEvents || [],

--- a/src/views/Options/SubtitleSegmentationPlayground.test.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.test.js
@@ -218,6 +218,77 @@ describe("SubtitleSegmentationPlayground", () => {
     act(() => root.unmount());
   });
 
+  test.each(["rule", "ai"])(
+    "%s preserves Korean ASR spaces after changing the source language",
+    async (mode) => {
+      const text = "오늘 날씨 정말 좋다";
+      const koreanSource = JSON.stringify({
+        events: [
+          {
+            tStartMs: 1000,
+            dDurationMs: 3000,
+            segs: [{ utf8: text, acAsrConf: 0 }],
+          },
+        ],
+      });
+      handleSubtitle.mockImplementation(async ({ events }) => [
+        {
+          start: events[0].start,
+          end: events[events.length - 1].end,
+          text: events.map((event) => event.text).join(" "),
+          translation: "天气真好",
+          _si: 0,
+          _ei: events.length - 1,
+        },
+      ]);
+      const { container, root } = renderPlayground({
+        subtitleSetting: {
+          segSlug: mode === "ai" ? "test-ai" : "-",
+          useAlgorithmBreaker: "rule",
+          chunkLength: 2000,
+          longSentenceThreshold: 120,
+          toLang: "zh-CN",
+        },
+        transApis: [{ apiSlug: "test-ai", apiType: "openai" }],
+      });
+      await flushEffects();
+      const input = container.querySelector('input[type="file"]');
+      const file = new File([koreanSource], "korean.json", {
+        type: "application/json",
+      });
+      Object.defineProperty(file, "text", { value: async () => koreanSource });
+      Object.defineProperty(input, "files", { value: [file] });
+      await act(async () => {
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      for (const language of ["ko", "en", "ko"]) {
+        await selectSourceLanguage(container, language);
+        const runButton = [...container.querySelectorAll("button")].find(
+          (button) => button.textContent.includes("运行测试")
+        );
+        await act(async () => {
+          runButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(
+          container.querySelector('textarea[aria-label="断句结果"]').value
+        ).toContain(text);
+        if (mode === "ai") {
+          const { events, from } = handleSubtitle.mock.calls.slice(-1)[0][0];
+          expect(from).toBe(language);
+          expect(events).toHaveLength(language === "ko" ? 1 : 4);
+          if (language === "ko") {
+            expect(events[0]).toMatchObject({ text, start: 1000, end: 4000 });
+          }
+        }
+      }
+      act(() => root.unmount());
+    }
+  );
+
   test("uses useConfirm and previews completed AI cues while streaming", async () => {
     let resolveResponse;
     const streamedCue = {


### PR DESCRIPTION
Extend timed-text preparation to recognize a space-separated segment that contains multiple lexical units but no usable per-word offsets, then expand only that coarse segment into word-sized `flatEvents` entries whose contiguous timestamps proportionally cover the original event duration. YouTube's automatic-caption A/B response can collapse a phrase into one `segs` entry with one start time and duration instead of returning word-level segments.

A coarse English A/B event containing one multi-word `segs` item expands into ordered word events that collectively preserve the event's exact start, end, text order, and punctuation; A mocked AI boundary response that ends at two different expanded word IDs produces two readable cues with increasing, non-overlapping timestamps rather than two cues sharing the original multi-second block.

Fixes #877
