### PR TITLE
Fix equal-timestamp initial remote sync data

### DIFF
--- a/src/libs/sync.js
+++ b/src/libs/sync.js
@@ -334,7 +334,8 @@ export const syncData = async (
   }
 
   let { updateAt = 0, syncAt = 0 } = syncMeta[key] || {};
-  if (syncAt === 0) {
+  const isFirstSync = syncAt === 0;
+  if (isFirstSync) {
     updateAt = 0; // 若从未同步过，将更新时间置 0 以触发首次拉取云端
   }
 
@@ -364,10 +365,10 @@ export const syncData = async (
     syncEncryptKey
   );
   const newVal = JSON.parse(res.value);
-  // 时间戳相等时同步端优先返回远端；内容不同时也需要应用远端数据。
+  // 首次同步时本地与远端时间戳可能同为 0；此时内容不同仍需应用远端数据。
   const isNew =
     res.updateAt > updateAt ||
-    (res.updateAt === updateAt && res.value !== data.value);
+    (isFirstSync && res.updateAt === updateAt && res.value !== data.value);
 
   // 新版客户端首次遇到旧版明文远端数据时，读取后立即迁移为密文。
   if (!encrypted && !forceRemoteRead) {

--- a/src/libs/sync.js
+++ b/src/libs/sync.js
@@ -364,8 +364,10 @@ export const syncData = async (
     syncEncryptKey
   );
   const newVal = JSON.parse(res.value);
-  // 若返回的云端数据更新时间戳晚于本地，则说明云端有新更改需要覆盖本地
-  const isNew = res.updateAt > updateAt;
+  // 时间戳相等时同步端优先返回远端；内容不同时也需要应用远端数据。
+  const isNew =
+    res.updateAt > updateAt ||
+    (res.updateAt === updateAt && res.value !== data.value);
 
   // 新版客户端首次遇到旧版明文远端数据时，读取后立即迁移为密文。
   if (!encrypted && !forceRemoteRead) {

--- a/src/libs/sync.test.js
+++ b/src/libs/sync.test.js
@@ -139,6 +139,50 @@ describe("WebDAV sync", () => {
     expect(client.putFileContents).not.toHaveBeenCalled();
     expect(result).toEqual({ value: { remote: true }, isNew: true });
   });
+
+  test("does not mark equal-timestamp legacy remote data as new after a prior sync", async () => {
+    const remoteLegacySetting = {
+      version: 1,
+      transApis: [{ systemPrompt: "legacy inline prompt" }],
+    };
+    const localMigratedSetting = {
+      version: 3,
+      prompts: [{ slug: "migrated-prompt" }],
+      transApis: [{ batchPromptSlug: "migrated-prompt" }],
+    };
+    getSyncWithDefault.mockResolvedValue({
+      syncType: "WebDAV",
+      syncUrl: "https://dav.example.com",
+      syncUser: "user",
+      syncKey: "password",
+      syncEncryptKey: SYNC_ENCRYPT_KEY,
+      syncMeta: {
+        [SETTING_KEY]: {
+          updateAt: 100,
+          syncAt: 1,
+        },
+      },
+    });
+    const client = {
+      exists: jest.fn().mockResolvedValue(true),
+      getFileContents: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          key: SETTING_KEY,
+          value: `cipher:${Buffer.from(
+            JSON.stringify(remoteLegacySetting)
+          ).toString("base64")}`,
+          updateAt: 100,
+        })
+      ),
+      putFileContents: jest.fn(),
+    };
+    createClient.mockReturnValue(client);
+
+    const result = await syncData(SETTING_KEY, localMigratedSetting);
+
+    expect(client.putFileContents).not.toHaveBeenCalled();
+    expect(result.isNew).toBe(false);
+  });
 });
 
 describe("GitHub Gist sync", () => {

--- a/src/libs/sync.test.js
+++ b/src/libs/sync.test.js
@@ -70,6 +70,7 @@ import {
   setSetting,
 } from "./storage";
 import { decryptSyncValue, encryptSyncValue } from "./syncCrypto";
+import { createClient, getPatcher } from "webdav";
 
 const SYNC_DESCRIPTION = "kiss translator sync files";
 const SYNC_KEY = "github-token";
@@ -93,6 +94,52 @@ const encryptedGistFileContent = (value, updateAt) =>
     value: `cipher:${Buffer.from(JSON.stringify(value)).toString("base64")}`,
     updateAt,
   });
+
+describe("WebDAV sync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getPatcher.mockReturnValue({ patch: jest.fn() });
+    encryptSyncValue.mockImplementation((value) =>
+      Promise.resolve(`cipher:${Buffer.from(value).toString("base64")}`)
+    );
+    decryptSyncValue.mockImplementation((value) =>
+      Promise.resolve({
+        value: Buffer.from(value.slice("cipher:".length), "base64").toString(),
+        encrypted: true,
+      })
+    );
+  });
+
+  test("applies different remote data with an equal initial timestamp", async () => {
+    getSyncWithDefault.mockResolvedValue({
+      syncType: "WebDAV",
+      syncUrl: "https://dav.example.com",
+      syncUser: "user",
+      syncKey: "password",
+      syncEncryptKey: SYNC_ENCRYPT_KEY,
+      syncMeta: {},
+    });
+    const client = {
+      exists: jest.fn().mockResolvedValue(true),
+      getFileContents: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          key: SETTING_KEY,
+          value: `cipher:${Buffer.from(
+            JSON.stringify({ remote: true })
+          ).toString("base64")}`,
+          updateAt: 0,
+        })
+      ),
+      putFileContents: jest.fn(),
+    };
+    createClient.mockReturnValue(client);
+
+    const result = await syncData(SETTING_KEY, { local: true });
+
+    expect(client.putFileContents).not.toHaveBeenCalled();
+    expect(result).toEqual({ value: { remote: true }, isNew: true });
+  });
+});
 
 describe("GitHub Gist sync", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Apply different remote data with an equal timestamp only when the local data has never been synced (`syncAt === 0`).
- Preserve existing local data when an equal-timestamp conflict occurs after a previous sync, including migrated local settings versus legacy remote settings.
- Add WebDAV regression coverage for both the initial-sync case and the post-migration conflict case.

This fixes remote settings being downloaded but not applied during an initial sync, without allowing equal-timestamp legacy remote data to overwrite migrated local settings.

Fixes #680
Fixes #305

## Testing

- `react-app-rewired test src/libs/sync.test.js --runInBand --watchAll=false`
- Related sync, storage, migration, and Options tests: 56 passed
- `pnpm build:chrome`