### PR TITLE
✨ feat(ui): 输入框统一 ResizeHandle 拖拽调高并重设计右上操作 rail

### DIFF
--- a/src/components/ResizeHandle.js
+++ b/src/components/ResizeHandle.js
@@ -1,0 +1,689 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import Box from "@mui/material/Box";
+import DragIndicator from "@mui/icons-material/DragIndicator";
+import { isMobile } from "../libs/mobile";
+import {
+  MIN_RESIZE_HEIGHT,
+  KEYBOARD_RESIZE_STEP,
+  VIEWPORT_SAFE_GUTTER,
+  normalizeResizeHeight,
+  resolveResizeMaxHeight,
+  toFiniteNumber,
+} from "./resizeBounds";
+
+// 再导出保持既有 import 兼容，常量值单一真源
+export {
+  MIN_RESIZE_HEIGHT,
+  MIN_RESIZE_HEIGHT_MEDIUM,
+  KEYBOARD_RESIZE_STEP,
+  VIEWPORT_SAFE_GUTTER,
+} from "./resizeBounds";
+
+// 控件嵌入边框的共享定位常量
+export const CONTROL_HEIGHT = 28; // 小 IconButton ≈ 28px
+export const CONTROL_CENTER_FROM_RIGHT = 12; // 共享中心轴距离右边缘的距离（px）
+export const NOTCH_STRIP_HEIGHT = 4; // 默认 notch 遮罩条高度（遮盖 2px 聚焦边框 + 各 1px anti-aliasing）
+export const NOTCH_HORIZONTAL_PAD = 4; // 遮罩条水平方向超出控件两侧的宽度
+
+const START_THRESHOLD = 6; // 6px 启动阈值
+const CLIPPING_OVERFLOW = new Set(["hidden", "auto", "scroll", "clip"]);
+
+/**
+ * 检测用户系统是否启用了"减少动态效果"偏好设置，
+ * 并在偏好变化时自动更新，确保在运行时层面完全禁用非必要动画。
+ */
+export function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(() => {
+    try {
+      return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+      const handler = (e) => setReduced(e.matches);
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
+    } catch {
+      return undefined;
+    }
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * 自定义纵向缩放手柄（右下角六点手柄，渲染 `DragIndicator` 图标）。
+ *
+ * 视觉手柄保持小巧，实际命中热区向文本框内部扩展；只调整高度、不调整宽度。
+ *
+ * 事件模型：
+ * - Pointer 主路径：元素级回调（onPointerMove/Up/Cancel/LostPointerCapture）+
+ *   setPointerCapture；匹配 lostpointercapture 终止会话（不续拖）；
+ * - Pointer capture 失败/缺失降级：同步激活 window 临时监听，move/up/cancel 均按
+ *   活动 pointerId 匹配；gotpointercapture 成功后撤除降级监听并置 element 接管；
+ * - Touch 路径（已声明的 iOS Safari Userscripts 兼容路径，README.md:89）：
+ *   handleTouchStart 按 changedTouches[0] → targetTouches[0] → touches[0]
+ *   绑定发起触点，move 全程按 Touch.identifier 跟踪，不受多指顺序干扰；
+ * - 模式隔离：同一时刻仅一个活动会话，双向闭合，第二指针/第二手指既不接管
+ *   也不提前终止会话。
+ *
+ * 键盘可达性（W3C Window Splitter 模式，WCAG 2.1.1）：
+ * - role="separator" + tabIndex=0 参与 Tab 序；
+ * - aria-orientation="horizontal"（底边横向分隔条）；
+ * - ArrowDown 增加高度、ArrowUp 减少高度（步进 12px）；
+ * - aria-valuemin、aria-valuemax、aria-valuenow：
+ *   受控态输出 clamped 值；未受控态输出实测自动高度（ARIA 1.2 focusable
+ *   separator 对作者为 MUST；缺失时 user agent 才按规范回退值近似处理，
+ *   因此必须显式提供真实值）。
+ *   offsetHeight 为 0 或非有限时省略（硬红线，宁缺勿造）；
+ * - 增加明确 :focus-visible 焦点环。
+ *
+ * 集中测量与动态上界：
+ * - 单一 useLayoutEffect 订阅 root 与视口变化，计算最近裁剪祖先与 visualViewport
+ *   双重候选上界；受控高度超界时一次性重 clamp（记录 lastNormalized 引用防重复提交）；
+ * - 视口恢复后不自动复活被截断的旧高度。
+ */
+export function ResizeHandle({
+  visible,
+  closing,
+  height,
+  containerRef,
+  onHeightChange,
+  title,
+  ariaLabel,
+  testId,
+  notchTestId,
+  notchStripHeight = NOTCH_STRIP_HEIGHT,
+  prefersReducedMotion = false,
+  controlsId,
+  minHeight = MIN_RESIZE_HEIGHT,
+}) {
+  // 活动会话记录：{ mode, pointerId, identifier, startY, startHeight, moved, eventOwner }
+  const sessionRef = useRef(null);
+  const [dragging, setDragging] = useState(false);
+
+  // 未受控态（height == null）的实测自动高度（像素）：供 aria-valuenow 播报
+  // 真实值（ARIA 1.2 focusable separator MUST）。写入点钉死在测量 effect 的
+  // applyMeasured 内，resize/RO 回调经 schedule() 汇聚后在同一处重测。
+  const [autoHeightPx, setAutoHeightPx] = useState(null);
+
+  // 动态上界（像素）：由集中测量 layoutEffect 维护
+  const [maxHeight, setMaxHeight] = useState(null);
+  const maxHeightRef = useRef(null);
+  maxHeightRef.current = maxHeight;
+  const lastNormalizedRef = useRef(null);
+
+  // 当前会话的 window 监听清理函数（pointer fallback 或 touch 二选一：beginSession
+  // 保证同一时刻仅一个活动会话，两类清理互斥共存于同一引用）
+  const sessionCleanupRef = useRef(null);
+
+  // 最新 props 的 ref 视图，供异步/DOM 回调读取最新值
+  const propsRef = useRef({ onHeightChange, height, visible });
+  propsRef.current.onHeightChange = onHeightChange;
+  propsRef.current.height = height;
+  propsRef.current.visible = visible;
+
+  const endSession = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+    if (sessionCleanupRef.current) {
+      sessionCleanupRef.current();
+    }
+    setDragging(false);
+  }, []);
+
+  // 挂载期间只装一次 window blur 监听器，失焦时无条件结束拖动会话
+  useLayoutEffect(() => {
+    const onBlur = () => {
+      if (sessionRef.current) {
+        endSession();
+      }
+    };
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [endSession]);
+
+  // 组件卸载时确保清理全部会话与监听器
+  useEffect(() => {
+    return () => {
+      sessionRef.current = null;
+      if (sessionCleanupRef.current) {
+        sessionCleanupRef.current();
+      }
+    };
+  }, []);
+
+  // 集中测量与视口订阅：维护动态上界并在视口收缩时一次性重 clamp。
+  // 容器 ref 挂载时序：React 提交阶段先执行子组件 layout effect、后挂祖先
+  // host 元素的 ref——常显手柄（如 Playground）挂载即 visible=true 且本效应
+  // 只跑一次，若此刻容器 ref 尚未就绪，测量订阅会永久失效；故经微任务重试
+  // （提交完成后祖先 ref 已挂载）。Selection 的手柄挂载时 visible=false，
+  // 靠焦点门控翻转重跑本效应，不经此路径。
+  useLayoutEffect(() => {
+    if (!visible) return;
+
+    let cancelled = false;
+    let cleanup = null;
+
+    const activate = () => {
+      if (cancelled) return;
+      const root = containerRef.current;
+      if (!root) {
+        Promise.resolve().then(activate);
+        return;
+      }
+
+      const measure = () => {
+        const rootRect = root.getBoundingClientRect?.() ?? { top: 0, height: 0 };
+        const rootTop = toFiniteNumber(rootRect.top, 0);
+
+        // 上界候选 1: 最近裁剪祖先 bottom（相对 root 顶部）。
+        // jsdom 的 getBoundingClientRect 一律返回 0 矩形，height/bottom 为 0；
+        // 若裁剪祖先的布局未真实生效（0 矩形），跳过该候选，避免把上界压成
+        // 负数导致拖动无法增长。
+        let ancestorMax = null;
+        for (let el = root.parentElement; el; el = el.parentElement) {
+          let overflowY = null;
+          try {
+            overflowY = window.getComputedStyle?.(el)?.overflowY;
+          } catch {
+            overflowY = null;
+          }
+          if (overflowY && CLIPPING_OVERFLOW.has(overflowY)) {
+            const r = el.getBoundingClientRect?.() ?? { bottom: 0, height: 0 };
+            if (
+              !Number.isFinite(r.bottom) ||
+              (r.bottom === 0 && r.height === 0)
+            ) {
+              break;
+            }
+            const candidate = r.bottom - rootTop - VIEWPORT_SAFE_GUTTER;
+            ancestorMax = Number.isFinite(candidate) ? candidate : null;
+            break;
+          }
+        }
+
+        // 上界候选 2: 布局视口 bottom（visualViewport 优先，否则 innerHeight）
+        const vv = typeof window !== "undefined" ? window.visualViewport : null;
+        const viewportBottom =
+          vv && Number.isFinite(vv.offsetTop) && Number.isFinite(vv.height)
+            ? vv.offsetTop + vv.height
+            : toFiniteNumber(window?.innerHeight, null);
+        const viewportMax =
+          viewportBottom != null
+            ? viewportBottom - rootTop - VIEWPORT_SAFE_GUTTER
+            : null;
+
+        // 取最小有限候选
+        const candidates = [ancestorMax, viewportMax].filter(
+          (c) => c != null && Number.isFinite(c)
+        );
+        let upper;
+        if (candidates.length > 0) {
+          upper = Math.min(...candidates);
+        } else {
+          upper = toFiniteNumber(rootRect.height, MIN_RESIZE_HEIGHT);
+        }
+        return resolveResizeMaxHeight(upper, MIN_RESIZE_HEIGHT, minHeight);
+      };
+
+      const applyMeasured = () => {
+        const upper = measure();
+        setMaxHeight((prev) => (prev === upper ? prev : upper));
+        // 受控高度超界时一次性重 clamp（记录 lastNormalized 引用，防 observer 回调重复提交）
+        const current = propsRef.current.height;
+        if (current != null) {
+          const normalized = normalizeResizeHeight(current, upper, upper, minHeight);
+          if (
+            normalized !== current &&
+            lastNormalizedRef.current !== normalized
+          ) {
+            lastNormalizedRef.current = normalized;
+            propsRef.current.onHeightChange(normalized);
+          }
+          if (current === normalized) {
+            lastNormalizedRef.current = null;
+          }
+        } else {
+          // 未受控态：实测 .MuiInputBase-root 自动高度，供 aria-valuenow 播报。
+          // 浏览器中若挂载时 offsetHeight 为 0（面板尚未完成布局），真实
+          // ResizeObserver 会在布局后回调 schedule() 补测；jsdom 无 RO 且本套件
+          // 未 mock，只能靠显式 window resize 触发——两条是不同的覆盖路径，
+          // 测试触发不等于生产保障。
+          const inputBase = root.querySelector(".MuiInputBase-root");
+          const autoHeight = inputBase?.offsetHeight;
+          if (Number.isFinite(autoHeight) && autoHeight > 0) {
+            setAutoHeightPx((prev) => (prev === autoHeight ? prev : autoHeight));
+          }
+        }
+      };
+
+      // 布局阶段同步执行一次测量
+      applyMeasured();
+
+      // ResizeObserver / window resize / visualViewport resize 订阅，经单一可取消
+      // 微任务合并：把一帧内的高频回调折叠为一次测量。用微任务（而非
+      // requestAnimationFrame）避免与 Jest fake timers 的 native-timer 冲突，
+      // cleanup 时通过 cancelled 标志取消未决回调。
+      let scheduled = false;
+      const schedule = () => {
+        if (cancelled || scheduled) return;
+        scheduled = true;
+        Promise.resolve().then(() => {
+          scheduled = false;
+          if (!cancelled) {
+            applyMeasured();
+          }
+        });
+      };
+
+      let ro = null;
+      if (typeof ResizeObserver === "function") {
+        ro = new ResizeObserver(schedule);
+        ro.observe(root);
+        const visibleArea = root.querySelector(
+          'textarea:not([aria-hidden="true"])'
+        );
+        if (visibleArea) {
+          ro.observe(visibleArea);
+        }
+      }
+
+      window.addEventListener("resize", schedule);
+      const vv = typeof window !== "undefined" ? window.visualViewport : null;
+      vv?.addEventListener?.("resize", schedule);
+
+      cleanup = () => {
+        cancelled = true;
+        ro?.disconnect();
+        window.removeEventListener("resize", schedule);
+        vv?.removeEventListener?.("resize", schedule);
+      };
+    };
+
+    activate();
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [visible, containerRef, minHeight]);
+
+  const getCurrentMax = () => {
+    if (Number.isFinite(maxHeightRef.current)) {
+      return maxHeightRef.current;
+    }
+    const inner = typeof window !== "undefined" ? window.innerHeight : null;
+    return Number.isFinite(inner) ? inner : null;
+  };
+
+  const applyMove = (clientY, mode) => {
+    const session = sessionRef.current;
+    if (!session || session.mode !== mode) return;
+    const dy = clientY - session.startY;
+    if (!session.moved && Math.abs(dy) <= START_THRESHOLD) {
+      return;
+    }
+    session.moved = true;
+    const next = normalizeResizeHeight(
+      session.startHeight + dy,
+      getCurrentMax(),
+      session.startHeight,
+      minHeight
+    );
+    if (next !== propsRef.current.height) {
+      propsRef.current.onHeightChange(next);
+    }
+  };
+
+  const beginSession = (clientY, mode, identifier, pointerId) => {
+    if (sessionRef.current) {
+      return false;
+    }
+    const inputBase = containerRef.current?.querySelector(".MuiInputBase-root");
+    const measuredHeight =
+      height ??
+      inputBase?.offsetHeight ??
+      containerRef.current?.offsetHeight ??
+      minHeight;
+    sessionRef.current = {
+      startY: clientY,
+      startHeight: measuredHeight,
+      mode,
+      moved: false,
+      identifier,
+      pointerId,
+      eventOwner: null,
+    };
+    setDragging(true);
+    return true;
+  };
+
+  // 激活 capture 失败时的 window fallback 监听
+  const activateWindowPointerFallback = (pointerId) => {
+    const session = sessionRef.current;
+    if (!session) return;
+    session.eventOwner = "window";
+
+    const onWinPointerMove = (e) => {
+      const current = sessionRef.current;
+      if (current?.mode !== "pointer" || current.eventOwner !== "window")
+        return;
+      if (e.pointerId !== current.pointerId) return;
+      applyMove(e.clientY, "pointer");
+    };
+
+    const onWinPointerEnd = (e) => {
+      const current = sessionRef.current;
+      if (current?.mode !== "pointer" || current.eventOwner !== "window")
+        return;
+      if (e.pointerId !== current.pointerId) return;
+      endSession();
+    };
+
+    sessionCleanupRef.current = () => {
+      window.removeEventListener("pointermove", onWinPointerMove);
+      window.removeEventListener("pointerup", onWinPointerEnd);
+      window.removeEventListener("pointercancel", onWinPointerEnd);
+      sessionCleanupRef.current = null;
+    };
+
+    window.addEventListener("pointermove", onWinPointerMove);
+    window.addEventListener("pointerup", onWinPointerEnd);
+    window.addEventListener("pointercancel", onWinPointerEnd);
+  };
+
+  const handlePointerDown = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const pointerId = e.pointerId;
+    const created = beginSession(e.clientY, "pointer", undefined, pointerId);
+    if (!created) return;
+
+    const el = e.currentTarget;
+    let captureSuccess = false;
+
+    if (typeof el?.setPointerCapture === "function") {
+      try {
+        el.setPointerCapture(pointerId);
+        if (typeof el.hasPointerCapture === "function") {
+          captureSuccess = Boolean(el.hasPointerCapture(pointerId));
+        } else {
+          captureSuccess = true;
+        }
+      } catch {
+        captureSuccess = false;
+      }
+    }
+
+    if (captureSuccess) {
+      const session = sessionRef.current;
+      if (session) {
+        session.eventOwner = "element";
+      }
+    } else {
+      activateWindowPointerFallback(pointerId);
+    }
+  };
+
+  const handleGotPointerCapture = (e) => {
+    const session = sessionRef.current;
+    if (!session || session.mode !== "pointer") return;
+    if (e.pointerId !== session.pointerId) return;
+    // gotpointercapture 成功确认：撤除 window fallback，确认由元素自身处理
+    if (sessionCleanupRef.current) {
+      sessionCleanupRef.current();
+    }
+    session.eventOwner = "element";
+  };
+
+  const handlePointerMove = (e) => {
+    const session = sessionRef.current;
+    if (!session || session.mode !== "pointer") return;
+    if (session.eventOwner === "window") return;
+    if (e.pointerId !== session.pointerId) return;
+    applyMove(e.clientY, "pointer");
+  };
+
+  const handlePointerEnd = (e) => {
+    const session = sessionRef.current;
+    if (!session || session.mode !== "pointer") return;
+    if (session.eventOwner === "window") return;
+    if (e.pointerId !== session.pointerId) return;
+    endSession();
+  };
+
+  const handleLostPointerCapture = (e) => {
+    const session = sessionRef.current;
+    if (!session || session.mode !== "pointer") return;
+    if (session.eventOwner === "window") return;
+    if (e.pointerId !== session.pointerId) return;
+    // 元素会话中的匹配 lostpointercapture 终止会话（不续拖）
+    endSession();
+  };
+
+  const handleTouchStart = (e) => {
+    // React 18 根容器委托的 touchstart 为 passive 注册（本仓库
+    // node_modules/react-dom/cjs/react-dom.development.js:9165-9174），
+    // 合成 preventDefault 在真实浏览器为 no-op 且触发 intervention 告警；
+    // 防滚由下方 window 非 passive touchmove 监听（onWinTouchMove）承载。
+    e.stopPropagation();
+    const native = e.nativeEvent || e;
+    const touch =
+      native.changedTouches?.[0] ||
+      native.targetTouches?.[0] ||
+      native.touches?.[0];
+    if (!touch) return;
+
+    const created = beginSession(touch.clientY, "touch", touch.identifier);
+    if (!created) return;
+
+    const onWinTouchMove = (evt) => {
+      const current = sessionRef.current;
+      if (current?.mode !== "touch") return;
+      const n = evt.nativeEvent || evt;
+      const touches = n.touches || n.targetTouches;
+      if (!touches) return;
+      const t = Array.from(touches).find(
+        (item) => item.identifier === current.identifier
+      );
+      if (t) {
+        // 本监听以 { passive: false } 挂载，preventDefault 真实生效：命中
+        // 发起触点的拖动必须阻止页面滚动；非发起触点的 touchmove 不
+        // preventDefault、不改高度（保留其余手指滚动页面的能力）。
+        evt.preventDefault?.();
+        applyMove(t.clientY, "touch");
+      }
+    };
+
+    const onWinTouchEnd = (evt) => {
+      const current = sessionRef.current;
+      if (current?.mode !== "touch") return;
+      const n = evt.nativeEvent || evt;
+      const id = current.identifier;
+      const includes = (list) =>
+        list && Array.from(list).some((item) => item.identifier === id);
+      if (includes(n.changedTouches)) {
+        endSession();
+        return;
+      }
+      const stillActive = includes(n.touches) || includes(n.targetTouches);
+      if (!stillActive) {
+        endSession();
+      }
+    };
+
+    sessionCleanupRef.current = () => {
+      window.removeEventListener("touchmove", onWinTouchMove);
+      window.removeEventListener("touchend", onWinTouchEnd);
+      window.removeEventListener("touchcancel", onWinTouchEnd);
+      sessionCleanupRef.current = null;
+    };
+
+    window.addEventListener("touchmove", onWinTouchMove, { passive: false });
+    window.addEventListener("touchend", onWinTouchEnd);
+    window.addEventListener("touchcancel", onWinTouchEnd);
+  };
+
+  const handleMouseDown = (e) => {
+    // 阻止兼容 mousedown 的焦点转移，避免点击手柄导致所属文本框失焦
+    e.preventDefault();
+  };
+
+  // 键盘可达性（W3C Splitter）：ArrowDown 增高、ArrowUp 减高（步进 12px）
+  const handleKeyDown = (e) => {
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
+      return;
+    }
+    e.preventDefault();
+    const inputBase = containerRef.current?.querySelector(".MuiInputBase-root");
+    // baseHeight 末位兜底为防御性死路径：仅 containerRef.current === null 时可触达，
+    // 而手柄 DOM 嵌于 ref 容器内，容器脱挂后键盘事件不可投递；jsdom offsetHeight=0
+    // 会被 ?? 保留（走 normalize(±12, …, minHeight) 钳制），与 beginSession 的
+    // ?? minHeight 兜底无可观察差异。min 下界已经由本函数 normalize 第 4 参真实穿入。
+    const baseHeight =
+      height ??
+      inputBase?.offsetHeight ??
+      containerRef.current?.offsetHeight ??
+      MIN_RESIZE_HEIGHT;
+    const delta =
+      e.key === "ArrowDown" ? KEYBOARD_RESIZE_STEP : -KEYBOARD_RESIZE_STEP;
+    const next = normalizeResizeHeight(
+      baseHeight + delta,
+      getCurrentMax(),
+      baseHeight,
+      minHeight
+    );
+    if (next !== propsRef.current.height) {
+      propsRef.current.onHeightChange(next);
+    }
+  };
+
+  // 渲染门控：无活动会话时跟随 visible 显隐；拖动中即使失焦也保持挂载
+  if (!visible && !sessionRef.current) {
+    return null;
+  }
+
+  const hitSize = isMobile ? 28 : 16;
+  const resolvedMax =
+    maxHeight != null
+      ? maxHeight
+      : Math.max(
+          minHeight,
+          toFiniteNumber(window?.innerHeight, minHeight)
+        );
+
+  return (
+    <>
+      <Box
+        data-testid={testId}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label={ariaLabel}
+        title={title}
+        tabIndex={0}
+        aria-controls={controlsId}
+        aria-valuemin={minHeight}
+        aria-valuemax={resolvedMax}
+        aria-valuenow={
+          height != null
+            ? normalizeResizeHeight(
+                height,
+                resolvedMax,
+                MIN_RESIZE_HEIGHT,
+                minHeight
+              )
+            : Number.isFinite(autoHeightPx) && autoHeightPx > 0
+              ? autoHeightPx
+              : undefined
+        }
+        onKeyDown={handleKeyDown}
+        onPointerDown={handlePointerDown}
+        onGotPointerCapture={handleGotPointerCapture}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onLostPointerCapture={handleLostPointerCapture}
+        onTouchStart={handleTouchStart}
+        onMouseDown={handleMouseDown}
+        style={{
+          position: "absolute",
+          right: CONTROL_CENTER_FROM_RIGHT - hitSize / 2,
+          bottom: -Math.round(hitSize / 2),
+          width: hitSize,
+          height: hitSize,
+          pointerEvents: closing && !dragging ? "none" : "auto",
+          cursor: "row-resize",
+        }}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          touchAction: "none",
+          userSelect: "none",
+          zIndex: 2,
+          color: "action.active",
+          opacity: closing ? 0 : 1,
+          visibility: closing ? "hidden" : "visible",
+          transition: prefersReducedMotion
+            ? "none"
+            : "color 120ms ease, opacity 120ms ease, visibility 120ms ease",
+          "&:hover": { color: "primary.main" },
+          "&:focus-visible": {
+            outline: (theme) => `2px solid ${theme.palette.primary.main}`,
+            outlineOffset: "2px",
+            borderRadius: "2px",
+          },
+          ...(dragging && { color: "primary.main" }),
+        }}
+      >
+        <DragIndicator
+          fontSize="small"
+          sx={{
+            opacity: 0.6,
+            ...(!prefersReducedMotion && {
+              transition: "opacity 120ms ease",
+            }),
+            "&:hover": { opacity: 1 },
+            ...(dragging && { opacity: 1 }),
+          }}
+        />
+      </Box>
+      <Box
+        data-testid={notchTestId}
+        style={{
+          position: "absolute",
+          right:
+            CONTROL_CENTER_FROM_RIGHT -
+            CONTROL_HEIGHT / 2 -
+            NOTCH_HORIZONTAL_PAD,
+          bottom: -Math.round(notchStripHeight / 2),
+          width: CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2,
+          height: notchStripHeight,
+        }}
+        sx={{
+          backgroundColor: "background.paper",
+          zIndex: 1,
+          opacity: closing ? 0 : 1,
+          visibility: closing ? "hidden" : "visible",
+          transition: prefersReducedMotion
+            ? "none"
+            : "opacity 120ms ease, visibility 120ms ease",
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/resizeBounds.js
+++ b/src/components/resizeBounds.js
@@ -1,0 +1,77 @@
+// 缩放手柄高度归一化：纯函数单一真源模块。
+//
+// 所有高度计算（拖动、键盘、测量初值、视口变化、ARIA 数值）都必须经由本模块，
+// 保证任何路径都不会把 NaN / Infinity / 负数 / 超界值传给 CSS 或 ARIA。
+// 本模块不依赖 DOM / 浏览器 API，可被组件与单测直接导入；以下常量与全部 6 个导出
+// 仅在本文件定义。ResizeHandle.js 从本模块导入并再导出（维持既有 import 路径兼容）；
+// useTextareaResize.js 不从本模块导入任何符号，保留自己的 DEFAULT_MAX_ROWS
+// （行数上限语义，与像素高度归一化常量不同域，分开定义）。
+
+// 自定义缩放手柄允许的最小文本框高度（像素），派生式：单行 23px（MUI
+// InputBase lineHeight 1.4375em）+ small 根节点纵向 padding 17px（8.5×2）。
+// 保持与 MUI 几何解耦：若主题 shape/尺寸变化，此处算式须同步复核。
+export const MIN_RESIZE_HEIGHT = 40;
+
+// medium 规格（TextField 未传 size）根节点纵向 padding 33px（16.5×2）下的
+// 最小文本框高度：23 + 33 = 56。
+export const MIN_RESIZE_HEIGHT_MEDIUM = 56;
+
+// 键盘方向键（ArrowUp/ArrowDown）每次调整的高度步进（像素）
+export const KEYBOARD_RESIZE_STEP = 12;
+
+// 高度上界相对视口/裁剪祖先底部的安全留白（像素），防止拖高后底部控件被裁切
+export const VIEWPORT_SAFE_GUTTER = 8;
+
+/**
+ * 把任意输入转换为有限数字，非有限值（NaN / Infinity / null / undefined /
+ * 非数字类型）回退到 fallback。
+ *
+ * @param {*} value 待归一化的输入。
+ * @param {number} fallback 非有限值时的回退值。
+ * @returns {number} 始终为有限数字。
+ */
+export function toFiniteNumber(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * 解析可拖高度的上界：先把 maxHeight 转为有限值（不可测/非有限时用
+ * fallbackHeight 兜底），再 clamp 到不小于下界。
+ *
+ * 上界永远 >= 下界：即使视口比最小高度还小（如虚拟键盘占屏、极小视口），
+ * 上界也收敛到最小高度而非反转成负数。
+ *
+ * @param {*} maxHeight 候选上界（可为 NaN / Infinity / undefined）。
+ * @param {number} fallbackHeight 不可测边界时的回退高度。
+ * @param {number} [min=MIN_RESIZE_HEIGHT] 显式下界（如 medium 口径 56）。
+ * @returns {number} 始终 >= 下界的有限上界。
+ */
+export function resolveResizeMaxHeight(maxHeight, fallbackHeight, min = MIN_RESIZE_HEIGHT) {
+  const floor = toFiniteNumber(min, MIN_RESIZE_HEIGHT);
+  if (Number.isFinite(maxHeight)) {
+    return Math.max(floor, maxHeight);
+  }
+  const fallback = toFiniteNumber(fallbackHeight, floor);
+  return Math.max(floor, fallback);
+}
+
+/**
+ * 把任意高度输入归一化到合法区间：
+ *   [下界, resolveResizeMaxHeight(maxHeight, fallbackHeight, min)]
+ *
+ * 对拖动、键盘、测量初值与视口变化统一执行；任何路径都不会把非有限值传给
+ * CSS 或 ARIA。结果仅在真实变化时由调用方写回 state。
+ *
+ * @param {*} value 待归一化的高度（可为 NaN / Infinity / undefined / null）。
+ * @param {*} maxHeight 当前解析出的上界（动态视口/容器上界）。
+ * @param {number} fallbackHeight 不可测边界时的回退高度。
+ * @param {number} [min=MIN_RESIZE_HEIGHT] 显式下界（如 medium 口径 56）。
+ * @returns {number} 始终为区间内有限值。
+ */
+export function normalizeResizeHeight(value, maxHeight, fallbackHeight, min = MIN_RESIZE_HEIGHT) {
+  const floor = toFiniteNumber(min, MIN_RESIZE_HEIGHT);
+  const upper = resolveResizeMaxHeight(maxHeight, fallbackHeight, min);
+  const fallback = toFiniteNumber(fallbackHeight, floor);
+  const finite = toFiniteNumber(value, fallback);
+  return Math.min(Math.max(floor, finite), upper);
+}

--- a/src/components/resizeBounds.test.js
+++ b/src/components/resizeBounds.test.js
@@ -1,0 +1,111 @@
+import {
+  MIN_RESIZE_HEIGHT,
+  MIN_RESIZE_HEIGHT_MEDIUM,
+  KEYBOARD_RESIZE_STEP,
+  VIEWPORT_SAFE_GUTTER,
+  toFiniteNumber,
+  resolveResizeMaxHeight,
+  normalizeResizeHeight,
+} from "./resizeBounds";
+
+describe("resizeBounds pure functions", () => {
+  test("constants are defined as expected", () => {
+    expect(MIN_RESIZE_HEIGHT).toBe(40);
+    expect(KEYBOARD_RESIZE_STEP).toBe(12);
+    expect(typeof VIEWPORT_SAFE_GUTTER).toBe("number");
+    expect(VIEWPORT_SAFE_GUTTER).toBeGreaterThan(0);
+  });
+
+  test("min heights are derived from one text line plus root padding", () => {
+    expect(MIN_RESIZE_HEIGHT).toBe(23 + 17);
+    expect(MIN_RESIZE_HEIGHT_MEDIUM).toBe(23 + 33);
+    expect(MIN_RESIZE_HEIGHT_MEDIUM).toBe(56);
+  });
+
+  describe("toFiniteNumber", () => {
+    test("returns finite numbers", () => {
+      expect(toFiniteNumber(100, 40)).toBe(100);
+      expect(toFiniteNumber(0, 40)).toBe(0);
+      expect(toFiniteNumber(-50, 40)).toBe(-50);
+      expect(toFiniteNumber(3.14, 40)).toBe(3.14);
+    });
+
+    test("falls back on non-finite values", () => {
+      expect(toFiniteNumber(undefined, 40)).toBe(40);
+      expect(toFiniteNumber(null, 40)).toBe(40);
+      expect(toFiniteNumber(NaN, 40)).toBe(40);
+      expect(toFiniteNumber(Infinity, 40)).toBe(40);
+      expect(toFiniteNumber(-Infinity, 40)).toBe(40);
+      expect(toFiniteNumber("100", 40)).toBe(40);
+    });
+  });
+
+  describe("resolveResizeMaxHeight", () => {
+    test("returns finite values clamped to MIN_RESIZE_HEIGHT", () => {
+      expect(resolveResizeMaxHeight(500, 100)).toBe(500);
+      expect(resolveResizeMaxHeight(20, 100)).toBe(40);
+      expect(resolveResizeMaxHeight(-20, 100)).toBe(40);
+      expect(resolveResizeMaxHeight(0, 100)).toBe(40);
+    });
+
+    test("falls back on non-finite maxHeight", () => {
+      expect(resolveResizeMaxHeight(undefined, 100)).toBe(100);
+      expect(resolveResizeMaxHeight(NaN, 100)).toBe(100);
+      expect(resolveResizeMaxHeight(Infinity, 100)).toBe(100);
+      expect(resolveResizeMaxHeight(-Infinity, 100)).toBe(100);
+      expect(resolveResizeMaxHeight(null, 100)).toBe(100);
+    });
+
+    test("clamps fallback if fallback is below MIN_RESIZE_HEIGHT", () => {
+      expect(resolveResizeMaxHeight(undefined, 20)).toBe(40);
+      expect(resolveResizeMaxHeight(undefined, -10)).toBe(40);
+      expect(resolveResizeMaxHeight(undefined, undefined)).toBe(40);
+      expect(resolveResizeMaxHeight(NaN, NaN)).toBe(40);
+    });
+
+    test("honors an explicit min floor without changing the default behavior", () => {
+      expect(resolveResizeMaxHeight(20, 100, 56)).toBe(56);
+      expect(resolveResizeMaxHeight(undefined, 30, 56)).toBe(56);
+      expect(resolveResizeMaxHeight(undefined, undefined, 56)).toBe(56);
+      expect(resolveResizeMaxHeight(20, 100)).toBe(40);
+    });
+  });
+
+  describe("normalizeResizeHeight", () => {
+    test("clamps finite values within [MIN_RESIZE_HEIGHT, resolvedMax]", () => {
+      expect(normalizeResizeHeight(200, 500, 100)).toBe(200);
+      expect(normalizeResizeHeight(20, 500, 100)).toBe(40);
+      expect(normalizeResizeHeight(600, 500, 100)).toBe(500);
+      expect(normalizeResizeHeight(-100, 500, 100)).toBe(40);
+    });
+
+    test("handles non-finite value by falling back to the measured height", () => {
+      expect(normalizeResizeHeight(undefined, 500, 150)).toBe(150);
+      expect(normalizeResizeHeight(NaN, 500, 150)).toBe(150);
+      expect(normalizeResizeHeight(Infinity, 500, 150)).toBe(150);
+      expect(normalizeResizeHeight(-Infinity, 500, 150)).toBe(150);
+      expect(normalizeResizeHeight(null, 500, 20)).toBe(40);
+    });
+
+    test("handles extreme small max height where max <= min", () => {
+      expect(normalizeResizeHeight(300, 20, 100)).toBe(40);
+      expect(normalizeResizeHeight(20, 20, 100)).toBe(40);
+    });
+
+    test("returns MIN_RESIZE_HEIGHT when all parameters are invalid/undefined", () => {
+      expect(normalizeResizeHeight(undefined, undefined, undefined)).toBe(40);
+      expect(normalizeResizeHeight(NaN, NaN, NaN)).toBe(40);
+    });
+
+    test("normalizeResizeHeight honors an explicit min floor (medium variant)", () => {
+      expect(normalizeResizeHeight(20, 500, 100, 56)).toBe(56);
+      expect(normalizeResizeHeight(40, 500, 100, 56)).toBe(56);
+      expect(normalizeResizeHeight(80, 500, 100, 56)).toBe(80);
+      // upper < floor 反转防线：normalize 内部 resolve 必须同步穿参
+      expect(normalizeResizeHeight(80, 20, 100, 56)).toBe(56);
+      // 不传 min 时回退默认下界 40
+      expect(normalizeResizeHeight(20, 500, 100)).toBe(40);
+      expect(normalizeResizeHeight(undefined, undefined, undefined)).toBe(40);
+    });
+  });
+});

--- a/src/components/useFocusClosingGate.js
+++ b/src/components/useFocusClosingGate.js
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// 真离场后的退出动画时长（ms）：关闭过渡结束后卸载相关控件
+export const FOCUS_CLOSE_DELAY_MS = 120;
+
+/**
+ * 唯一焦点退出 gate：TranForm / TranCont 共享的「聚焦 + 退出动画」状态机。
+ *
+ * 从两个组件中抽取的共同逻辑，保证焦点保活与退出动画行为单一真源：
+ * - 容器内焦点迁移（Tab/Shift+Tab 在 textarea、复制按钮、提交按钮、缩放手柄
+ *   之间移动）不放行关闭；
+ * - 真正离开容器时立即执行 onTrueBlur（TranForm 在此提交 editText.trim()，
+ *   TranCont 无提交回调），并进入 120ms closing 过渡；
+ * - prefers-reduced-motion 时跳过过渡、同步关闭并同步完成关闭生命周期（onClosingEnd）；
+ * - closing 期间重新聚焦任意子元素会取消未到期定时器并恢复 focused；
+ * - 组件卸载时取消未决定时器，不产生卸载后的状态回写。
+ *
+ * 输入：
+ * @param {Object} options
+ * @param {boolean} options.prefersReducedMotion 系统是否启用"减少动态效果"。
+ * @param {Function} [options.onTrueBlur] 焦点真正离开容器时的提交回调。
+ * @param {Function} [options.onClosingEnd] closing 过渡结束时的回调（常规路径 120ms 到期触发；reduced-motion 下随同步关闭立即触发）。
+ *
+ * 输出：
+ * @returns {{focused: boolean, closing: boolean, handleFocus: Function, handleBlur: Function}}
+ *   - focused：容器内是否存在焦点（驱动 rail / 手柄显隐）。
+ *   - closing：是否处于退出过渡中。
+ *   - handleFocus：容器内任意可聚焦元素聚焦时调用（只恢复 gate，不修改业务 editMode）。
+ *   - handleBlur：容器包装层 onBlur（focusout 冒泡）处理器。
+ *
+ * 注意：textarea 自身的 onFocus/onChange 与粘贴命令继续负责恢复业务 editMode；
+ * 活动 Pointer/Touch 拖动会话由 ResizeHandle 自己保活，不并入本 Hook。
+ */
+export function useFocusClosingGate({
+  prefersReducedMotion = false,
+  onTrueBlur,
+  onClosingEnd,
+}) {
+  const [focused, setFocused] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const closeTimerRef = useRef(null);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current != null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  // 卸载时取消未决定时器，避免卸载后仍触发状态更新
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current != null) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    // 重新聚焦：取消未到期的退出动画定时器，rail 重新进入
+    clearCloseTimer();
+    setFocused(true);
+    setClosing(false);
+  }, [clearCloseTimer]);
+
+  const handleBlur = useCallback(
+    (e) => {
+      // 焦点保活：relatedTarget 判定必须先于 reduced-motion 的同步卸载分支。
+      // textarea ↔ rail ↔ 手柄之间的内部焦点迁移（Tab）不关闭、不卸载——否则
+      // 键盘用户 Tab 进手柄/按钮的瞬间字段即卸载；relatedTarget 为 null 或
+      // 在包装层外才恢复正常关闭。
+      if (e.currentTarget.contains(e.relatedTarget)) {
+        return;
+      }
+      // 提交语义立即生效：真正离开字段时提交当前编辑内容（TranCont 无提交回调）
+      onTrueBlur?.();
+      // focus-gating 立即翻转：手柄与 rail 中的焦点相关控件随失焦卸载
+      setFocused(false);
+      if (prefersReducedMotion) {
+        // 减少动态效果：跳过退出动画延迟，立即关闭并同步完成关闭生命周期
+        clearCloseTimer();
+        setClosing(false);
+        onClosingEnd?.();
+        return;
+      }
+      // 退出动画：rail 滞留 120ms 播放淡出。先清理未到期定时器，
+      // 防止双 blur 边界旧定时器提前截断本次退出动画。
+      setClosing(true);
+      clearCloseTimer();
+      closeTimerRef.current = setTimeout(() => {
+        closeTimerRef.current = null;
+        setClosing(false);
+        onClosingEnd?.();
+      }, FOCUS_CLOSE_DELAY_MS);
+    },
+    [clearCloseTimer, onTrueBlur, onClosingEnd, prefersReducedMotion]
+  );
+
+  return { focused, closing, handleFocus, handleBlur };
+}

--- a/src/components/useFocusClosingGate.test.js
+++ b/src/components/useFocusClosingGate.test.js
@@ -1,0 +1,229 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useRef, useState } from "react";
+import {
+  useFocusClosingGate,
+  FOCUS_CLOSE_DELAY_MS,
+} from "./useFocusClosingGate";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * B 类 Hook 测试宿主：收集 hook 返回值并通过事件驱动 state 变化，
+ * 覆盖初始加载、更新、焦点迁移、reduced-motion 与卸载清理。
+ */
+function FocusGateHost({ prefersReducedMotion, onTrueBlur, onClosingEnd }) {
+  const { focused, closing, handleFocus, handleBlur } = useFocusClosingGate({
+    prefersReducedMotion,
+    onTrueBlur,
+    onClosingEnd,
+  });
+  const [text, setText] = useState("");
+  const ref = useRef(null);
+
+  return (
+    <div ref={ref} onBlur={handleBlur} data-testid="gate">
+      <input
+        data-testid="input"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onFocus={handleFocus}
+      />
+      <button type="button" data-testid="button" onFocus={handleFocus}>
+        copy
+      </button>
+      <output data-testid="state">
+        {String(focused)}:{String(closing)}
+      </output>
+    </div>
+  );
+}
+
+function renderHost(props = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onTrueBlur = jest.fn();
+  const onClosingEnd = jest.fn();
+
+  act(() => {
+    root.render(
+      <FocusGateHost
+        prefersReducedMotion={false}
+        onTrueBlur={onTrueBlur}
+        onClosingEnd={onClosingEnd}
+        {...props}
+      />
+    );
+  });
+
+  return { container, root, onTrueBlur, onClosingEnd };
+}
+
+// React 的 onFocus/onBlur 由 focusin/focusout 冒泡事件驱动（non-native focus/blur
+// 不会命中 React 合成事件分发），测试必须派发 focusin/focusout 并携带 relatedTarget。
+function blurWith(container, targetTestId, relatedTarget) {
+  const target = container.querySelector(`[data-testid="${targetTestId}"]`);
+  act(() => {
+    target.dispatchEvent(
+      new FocusEvent("focusout", {
+        bubbles: true,
+        relatedTarget: relatedTarget || null,
+      })
+    );
+  });
+}
+
+function focusWith(container, testId) {
+  act(() => {
+    container
+      .querySelector(`[data-testid="${testId}"]`)
+      .dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+  });
+}
+
+function stateOf(container) {
+  return container.querySelector('[data-testid="state"]').textContent;
+}
+
+describe("useFocusClosingGate", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.clearAllTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test("keeps the gate open on internal focus moves (Tab inside the container)", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+
+    focusWith(container, "input");
+    const gate = container.querySelector('[data-testid="gate"]');
+    const button = container.querySelector('[data-testid="button"]');
+    // Tab 从 input 到内部按钮：relatedTarget 在容器内，不得触发提交或关闭
+    blurWith(container, "input", button);
+    expect(onTrueBlur).not.toHaveBeenCalled();
+    expect(stateOf(container)).toBe("true:false");
+    expect(onClosingEnd).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("true blur commits once and runs the closing transition then ends", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+
+    focusWith(container, "input");
+    blurWith(container, "input", document.body);
+    // 真离场：立即提交一次并进入 closing
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+    expect(stateOf(container)).toBe("false:true");
+
+    // 120ms 后退出动画结束
+    act(() => {
+      jest.advanceTimersByTime(FOCUS_CLOSE_DELAY_MS);
+    });
+    expect(onClosingEnd).toHaveBeenCalledTimes(1);
+    expect(stateOf(container)).toBe("false:false");
+
+    act(() => root.unmount());
+  });
+
+  test("refocus during closing cancels the timer and restores focused", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+
+    focusWith(container, "input");
+    blurWith(container, "input", document.body);
+    expect(stateOf(container)).toBe("false:true");
+
+    // closing 期间重新进入任意子元素：取消未到期定时器，恢复 focused
+    focusWith(container, "input");
+    expect(stateOf(container)).toBe("true:false");
+    expect(onClosingEnd).not.toHaveBeenCalled();
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+
+    // 推进超过 120ms：旧定时器已被取消，不得触发 closing end
+    act(() => {
+      jest.advanceTimersByTime(FOCUS_CLOSE_DELAY_MS * 3);
+    });
+    expect(onClosingEnd).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("true blur is not re-submitted on a second internal blur while closing", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+
+    focusWith(container, "input");
+    const gate = container.querySelector('[data-testid="gate"]');
+    const button = container.querySelector('[data-testid="button"]');
+    blurWith(container, "input", document.body);
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+
+    // 仍然在 closing 期间 Tab 回内部按钮：relatedTarget 在容器内，不得二次提交
+    blurWith(container, "input", button);
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+
+  test("reduced-motion true blur closes synchronously with no leftover timer", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost({
+      prefersReducedMotion: true,
+    });
+
+    focusWith(container, "input");
+    expect(jest.getTimerCount()).toBe(0);
+    blurWith(container, "input", document.body);
+    // 同步关闭，无 closing 过渡
+    expect(stateOf(container)).toBe("false:false");
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+    // 订正：同步关闭也必须触发一次 onClosingEnd，完成生命周期清理
+    // （TranForm 依赖它把 editMode 归位，否则 reduced-motion 下外部 text 永久失同步）
+    expect(onClosingEnd).toHaveBeenCalledTimes(1);
+    // 无遗留 timer
+    expect(jest.getTimerCount()).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("unmount during closing cancels the timer without warnings", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    focusWith(container, "input");
+    blurWith(container, "input", document.body);
+    expect(stateOf(container)).toBe("false:true");
+    expect(jest.getTimerCount()).toBe(1);
+
+    // closing 期间父组件卸载：清理定时器，无幽灵更新
+    act(() => root.unmount());
+    expect(jest.getTimerCount()).toBe(0);
+    act(() => {
+      jest.advanceTimersByTime(FOCUS_CLOSE_DELAY_MS * 2);
+    });
+    expect(onClosingEnd).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  test("true blur on an unmonitored focus still commits and runs closing transition safely", () => {
+    const { container, root, onTrueBlur, onClosingEnd } = renderHost();
+
+    blurWith(container, "input", document.body);
+    expect(onTrueBlur).toHaveBeenCalledTimes(1);
+    expect(stateOf(container)).toBe("false:true");
+
+    act(() => {
+      jest.advanceTimersByTime(FOCUS_CLOSE_DELAY_MS);
+    });
+    expect(onClosingEnd).toHaveBeenCalledTimes(1);
+    expect(stateOf(container)).toBe("false:false");
+
+    act(() => root.unmount());
+  });
+});

--- a/src/components/useTextareaResize.js
+++ b/src/components/useTextareaResize.js
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+
+// 未拖动时限制 textarea 自动增长上限（内容超高时 textarea 内部滚动）
+export const DEFAULT_MAX_ROWS = 10;
+
+/**
+ * 把缩放手柄的拖动高度换算为 TextField 的 minRows / maxRows / 根节点高度样式。
+ *
+ * 未拖动（resizeHeight == null）：
+ * - minRows = defaultRows，maxRows = DEFAULT_MAX_ROWS（限制自动增长上限），
+ *   高度仍由 MUI TextareaAutosize 自动测量，根节点不持有受控高度。
+ *
+ * 已拖动（resizeHeight 为像素值）：
+ * - 受控像素高度落在 TextField 的 InputBase 根节点（rootStyle），
+ *   与 TranForm/TranCont 采用的根节点高度模型对齐：helperText/标签不随
+ *   拖动位移，TextareaAutosize 的自动测量不受影响。
+ * - minRows 与 maxRows 全部释放为 undefined：不再把像素高度量化为整数行，
+ *   高度由像素 state 直接驱动，避免量化整数行导致的「真源与 DOM 分离」。
+ *   maxRows 必须保持 undefined，否则 TextareaAutosize 会无条件执行
+ *   min(maxRows*singleRowHeight, outerHeight)，在拖动超过 DEFAULT_MAX_ROWS
+ *   行后把 textarea 压回 maxRows 高度造成拖动死区。
+ * - 可见 textarea 的内部滚动与几何契约由调用方的 scoped sx 规则承载
+ *   （`& textarea:not([aria-hidden="true"])`：`box-sizing: border-box` +
+ *   `max-height: 100%` + 拖高时 `overflow: auto !important`），既不会命中 MUI
+ *   测量 shadow textarea（aria-hidden="true"），也不会把 `!important` 写入
+ *   React inline style。
+ * - 根节点不持有受控 overflowY（MUI TextareaAutosize 每帧会重写
+ *   textarea.style.overflow，root 级滚动会与内部滚动形成双滚动条）。
+ *
+ * 仅约束 InputBase 根节点；内部 textarea 的样式统一交给调用方 scoped 规则。
+ */
+export function useTextareaResize(resizeHeight, defaultRows) {
+  const minRows = resizeHeight == null ? defaultRows : undefined;
+  const maxRows = resizeHeight == null ? DEFAULT_MAX_ROWS : undefined;
+  const rootStyle = useMemo(
+    () =>
+      resizeHeight == null
+        ? undefined
+        : {
+            height: resizeHeight,
+            alignItems: "flex-start",
+          },
+    [resizeHeight]
+  );
+  return { minRows, maxRows, rootStyle };
+}

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -4043,6 +4043,15 @@ export const I18N = {
     tr: `Çeviri Kutusu Uyarlanabilir Yükseklik`,
     vi: "Hộp dịch tự động chiều cao",
   },
+  field_resize_height: {
+    zh: `拖动调整高度`,
+    en: `Drag to adjust height`,
+    zh_TW: `拖曳調整高度`,
+    ja: `ドラッグで高さを調整`,
+    ko: `드래그하여 높이 조절`,
+    tr: `Yüksekliği ayarlamak için sürükleyin`,
+    vi: "Kéo để điều chỉnh chiều cao",
+  },
   tranbox_interact_mode: {
     zh: `翻译框内交互模式`,
     en: `Transbox Interact Mode`,

--- a/src/config/i18n.ru.js
+++ b/src/config/i18n.ru.js
@@ -420,6 +420,7 @@ export const RU_I18N = {
   open_setting: `Открыть настройки`,
   follow_selection: `Окно перевода следует за выделением`,
   tranbox_auto_height: `Автоматическая высота окна перевода`,
+  field_resize_height: `Перетащите, чтобы изменить высоту`,
   tranbox_interact_mode: `Способ взаимодействия с окном перевода`,
   tranbox_interact_click: `Перевод по клику на выделенный текст`,
   tranbox_interact_dblclick: `Перевод по двойному клику на выделенный текст`,

--- a/src/config/i18n.test.js
+++ b/src/config/i18n.test.js
@@ -1,0 +1,47 @@
+import { I18N } from "./i18n";
+import { RU_I18N } from "./i18n.ru";
+
+// 主字典作者态 7 语；ru 由 i18n.js 初始化时从 i18n.ru.js 合并（合并语句见 i18n.js 末尾
+// `Object.keys(I18N).forEach` 块：`I18N[key].ru = RU_I18N[key] ?? I18N[key].en`），
+// 因此 entry.ru 非空不能证明俄语真实存在——必须直读 RU_I18N 断言。
+const MAIN_LANGUAGES = ["zh", "en", "zh_TW", "ja", "ko", "tr", "vi"];
+
+// 分支触及键 + 组件引用的操作键（copy/paste/submit 为基线键，此处作字典回归保护）
+const AFFECTED_KEYS = [
+  "tranbox_auto_height",
+  "field_resize_height",
+  "subtitle_playground_result",
+  "subtitle_playground_source_json",
+  "copy",
+  "paste",
+  "submit",
+];
+
+describe("i18n dictionary completeness for resize & playground keys", () => {
+  test.each(AFFECTED_KEYS)(
+    "key '%s' has non-empty translations across main languages and a real Russian entry",
+    (key) => {
+      const entry = I18N[key];
+      expect(entry).toBeDefined();
+
+      for (const lang of MAIN_LANGUAGES) {
+        expect(typeof entry[lang]).toBe("string");
+        expect(entry[lang].trim().length).toBeGreaterThan(0);
+      }
+
+      // 直读俄语专用字典，防止 en 回退造成假绿
+      expect(typeof RU_I18N[key]).toBe("string");
+      expect(RU_I18N[key].trim().length).toBeGreaterThan(0);
+    }
+  );
+
+  test("field_resize_height stays distinct from the tranbox_auto_height setting label across all main languages", () => {
+    expect(I18N.field_resize_height).toBeDefined();
+
+    for (const lang of MAIN_LANGUAGES) {
+      expect(I18N.field_resize_height[lang]).not.toBe(
+        I18N.tranbox_auto_height[lang]
+      );
+    }
+  });
+});

--- a/src/views/Options/SubtitleSegmentationPlayground.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -40,17 +40,16 @@ import {
 } from "../../subtitle/subtitleSegmentationMetrics";
 import { DEFAULT_PARAMS } from "../../subtitle/sentenceBreaker";
 import { buildBilingualVtt } from "../../subtitle/vtt";
+import {
+  ResizeHandle,
+  usePrefersReducedMotion,
+  MIN_RESIZE_HEIGHT_MEDIUM,
+} from "../../components/ResizeHandle";
+import { useTextareaResize } from "../../components/useTextareaResize";
 
 const SAMPLE_BASE_URL = `${process.env.REACT_APP_SITEURL}/subtitle-samples`;
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const MAX_UPLOAD_EVENTS = 100000;
-// 原始数据和结果框默认显示五行，并允许用户从右下角按需拉高查看区域。
-const RESIZABLE_TEXT_FIELD_SX = {
-  "& textarea": {
-    resize: "vertical !important",
-    overflow: "auto !important",
-  },
-};
 
 /** 用命名占位符组装包含运行时数据的多语言文案。 */
 function formatI18n(i18n, key, fallback, values = {}) {
@@ -150,6 +149,105 @@ function hasCompleteIndexedCoverage(cues, eventCount) {
   return nextIndex === eventCount;
 }
 
+/**
+ * 字幕页可拖高输入框包装组件（最简形态）：把「受控高度 state +
+ * useTextareaResize + 只读 TextField + 常显 ResizeHandle」收敛进这一层，
+ * 使拖动期间的每次 pointermove 只重渲染本组件，不再触发整页
+ * SubtitleSegmentationPlayground 的 reconciliation —— 重渲染范围隔离，
+ * 修复整页重渲染导致的拖动掉帧。
+ *
+ * 重渲染范围隔离生效的关键：onHeightChange 直接传 useState setter（引用稳定）。
+ * ResizeHandle 的拖动会话监听在 pointerdown/touchstart 内同步安装、由 endSession
+ * 卸载，不随重渲染重建；拖动期间每次 pointermove 只重渲染本组件，父级不参与
+ * reconciliation，value/ariaLabel 等 props 引用不变、不参与拖动路径。
+ *
+ * 字幕页没有 focus-gating：两手柄静态 visible、closing=false，
+ * 不引入任何焦点状态；notch 遮罩条用默认高度（无局部聚焦边框策略）。
+ *
+ * 本文件内定义专用包装组件，不与 Selection 的 focus-gating 形态共享：
+ * 字幕页是只读静态常显手柄 + 默认 notch；Selection（TranForm/TranCont）则是
+ * focus-gating 显隐 + 自定义遮罩条高度——差异足以支撑分开定义，贸然合并会
+ * 回归焦点/notch 行为。
+ */
+function ResizableSubtitleField({
+  value,
+  textareaLabel,
+  handleLabel,
+  testId,
+  notchTestId,
+  // 额外绝对定位浮层（如结果框右上角 JSON/VTT 工具栏），渲染在手柄覆盖层之下。
+  toolbar = null,
+}) {
+  const boxRef = useRef(null);
+  const fieldId = useId();
+  // 受控高度：null 表示仍由 MUI TextareaAutosize 自动测量，
+  // 用户首次拖动后切换为受控高度（与 Selection 语义一致）。
+  const [height, setHeight] = useState(null);
+  // reduced-motion 偏好由本组件订阅一次并经 prop 下发（单一状态真源，
+  // ResizeHandle 自身不再重复订阅）。
+  const prefersReducedMotion = usePrefersReducedMotion();
+  // 拖动高度 → TextField 的 minRows/maxRows/根节点高度样式（共享 hook）。
+  // 未拖动时保持原语义：minRows=5、maxRows=10 限制自动增长上限；
+  // 拖动后受控像素高度落在 InputBase 根节点（与 Selection 的根节点高度模型
+  // 对齐），min/maxRows 量化全部释放。
+  const { minRows, maxRows, rootStyle } = useTextareaResize(height, 5);
+
+  return (
+    <Box ref={boxRef} sx={{ position: "relative" }}>
+      <TextField
+        id={fieldId}
+        fullWidth
+        multiline
+        minRows={minRows}
+        maxRows={maxRows}
+        value={value}
+        InputProps={{
+          readOnly: true,
+          // 根节点保留右侧内边距；拖动后受控像素高度直接约束 InputBase
+          // （输入框本体），与 helperText/标签互不干扰，rootStyle 与
+          // TranForm/TranCont 的 InputBase 根节点高度模型一致。不写入内部
+          // textarea 的 inline height，TextareaAutosize 的自动测量不受影响；
+          // 滚动与几何契约由下方 scoped sx 规则承载（不命中测量 shadow）。
+          style: {
+            paddingRight: 14,
+            ...(rootStyle || {}),
+          },
+        }}
+        inputProps={{
+          "aria-label": textareaLabel,
+        }}
+        sx={{
+          "& textarea:not([aria-hidden='true'])": {
+            boxSizing: "border-box",
+            maxHeight: "100%",
+            resize: "none",
+            ...(height != null ? { overflow: "auto !important" } : {}),
+          },
+        }}
+      />
+      {toolbar}
+      {/* 覆盖层：手柄/notch 相对本包装层定位，不被滚动裁切 */}
+      <Box sx={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+        <ResizeHandle
+          visible
+          closing={false}
+          height={height}
+          containerRef={boxRef}
+          minHeight={MIN_RESIZE_HEIGHT_MEDIUM}
+          // 直接传 state setter（引用稳定）：拖动全程监听器集不重挂，隔离生效关键。
+          onHeightChange={setHeight}
+          prefersReducedMotion={prefersReducedMotion}
+          controlsId={fieldId}
+          title={handleLabel}
+          ariaLabel={handleLabel}
+          testId={testId}
+          notchTestId={notchTestId}
+        />
+      </Box>
+    </Box>
+  );
+}
+
 /** 字幕断句工作台，所有配置只读取当前字幕设置，不单独持久化。 */
 export default function SubtitleSegmentationPlayground({
   subtitleSetting = {},
@@ -173,6 +271,8 @@ export default function SubtitleSegmentationPlayground({
   const [showLanguageRequired, setShowLanguageRequired] = useState(false);
   const abortRef = useRef(null);
   const languageSelectRef = useRef(null);
+  // 原始字幕 JSON / 断句结果输入框的高度 state、useTextareaResize 与手柄
+  // 已整体收敛进下方 ResizableSubtitleField 包装组件（重渲染范围隔离）。
   // 索引只应拉取一次，通过 ref 读取当前语言，避免翻译函数变化导致重复请求。
   const i18nRef = useRef(i18n);
   i18nRef.current = i18n;
@@ -778,71 +878,61 @@ export default function SubtitleSegmentationPlayground({
           <Typography variant="subtitle2" gutterBottom>
             {i18n("subtitle_playground_source_json", "原始字幕 JSON")}
           </Typography>
-          <TextField
-            fullWidth
-            multiline
-            rows={5}
+          <ResizableSubtitleField
             value={sourceText}
-            InputProps={{ readOnly: true }}
-            inputProps={{
-              "aria-label": i18n(
-                "subtitle_playground_source_json",
-                "原始字幕 JSON"
-              ),
-            }}
-            sx={RESIZABLE_TEXT_FIELD_SX}
+            textareaLabel={i18n("subtitle_playground_source_json")}
+            handleLabel={i18n("field_resize_height")}
+            testId="segmentation-source-resize-handle"
+            notchTestId="segmentation-source-resize-notch"
           />
         </Box>
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="subtitle2" gutterBottom>
             {i18n("subtitle_playground_result", "断句结果")}
           </Typography>
-          <Box sx={{ position: "relative" }}>
-            <TextField
-              fullWidth
-              multiline
-              rows={5}
-              value={resultText}
-              InputProps={{ readOnly: true }}
-              inputProps={{
-                "aria-label": i18n("subtitle_playground_result", "断句结果"),
-              }}
-              sx={RESIZABLE_TEXT_FIELD_SX}
-            />
-            <Stack
-              direction="row"
-              spacing={0.5}
-              alignItems="center"
-              sx={{
-                position: "absolute",
-                zIndex: 1,
-                top: 8,
-                right: 8,
-                p: 0.25,
-                borderRadius: 1,
-                bgcolor: "background.paper",
-                boxShadow: 1,
-              }}
-            >
-              <ToggleButtonGroup
-                exclusive
-                size="small"
-                value={resultFormat}
-                onChange={(_, value) => value && setResultFormat(value)}
+          <ResizableSubtitleField
+            value={resultText}
+            textareaLabel={i18n("subtitle_playground_result")}
+            handleLabel={i18n("field_resize_height")}
+            testId="segmentation-result-resize-handle"
+            notchTestId="segmentation-result-resize-notch"
+            toolbar={
+              <Stack
+                direction="row"
+                spacing={0.5}
+                alignItems="center"
+                sx={{
+                  position: "absolute",
+                  zIndex: 1,
+                  top: 8,
+                  right: 8,
+                  p: 0.25,
+                  borderRadius: 1,
+                  bgcolor: "background.paper",
+                  boxShadow: 1,
+                }}
               >
-                <ToggleButton value="json">JSON</ToggleButton>
-                <ToggleButton value="vtt">VTT</ToggleButton>
-              </ToggleButtonGroup>
-              <Button
-                size="small"
-                startIcon={<DownloadIcon />}
-                disabled={!result}
-                onClick={downloadResult}
-              >
-                {i18n("subtitle_playground_download", "下载")}
-              </Button>
-            </Stack>
-          </Box>
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={resultFormat}
+                  onChange={(_, value) => value && setResultFormat(value)}
+                >
+                  <ToggleButton value="json">JSON</ToggleButton>
+                  <ToggleButton value="vtt">VTT</ToggleButton>
+                </ToggleButtonGroup>
+                <Button
+                  size="small"
+                  startIcon={<DownloadIcon />}
+                  disabled={!result}
+                  onClick={downloadResult}
+                >
+                  {i18n("subtitle_playground_download", "下载")}
+                </Button>
+              </Stack>
+            }
+          />
+          {/* 右上按钮 Stack zIndex=1，手柄在下右下，几何上不重叠。 */}
         </Box>
       </Box>
 

--- a/src/views/Options/SubtitleSegmentationPlayground.test.js
+++ b/src/views/Options/SubtitleSegmentationPlayground.test.js
@@ -5,6 +5,7 @@ import path from "path";
 import SubtitleSegmentationPlayground from "./SubtitleSegmentationPlayground";
 import { handleSubtitle } from "../../apis/trans";
 import { I18N, UI_LANGS } from "../../config/i18n";
+import { MIN_RESIZE_HEIGHT_MEDIUM } from "../../components/resizeBounds";
 import { downloadBlobFile } from "../../libs/utils";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -19,13 +20,12 @@ jest.mock("../../hooks/Confirm", () => ({
   useConfirm: () => mockConfirm,
 }));
 
-jest.mock("../../hooks/I18n", () => ({
-  // 组件测试固定使用中文备用文案，避免依赖完整的设置上下文。
-  useI18n:
-    () =>
-    (_, fallback = "") =>
-      fallback,
-}));
+jest.mock("../../hooks/I18n", () => {
+  const i18nModule = jest.requireActual("../../config/i18n");
+  return {
+    useI18n: () => (key) => i18nModule.I18N[key]?.["zh"] || "",
+  };
+});
 
 jest.mock("../../libs/utils", () => {
   const actual = jest.requireActual("../../libs/utils");
@@ -38,6 +38,19 @@ async function flushEffects() {
     await Promise.resolve();
     await Promise.resolve();
   });
+}
+
+/**
+ * 构造一个带 clientY/pointerId 的通用指针事件。
+ * @param {string} type 事件类型（如 pointerdown/pointermove）。
+ * @param {Object} opts 可选的 clientY 与 pointerId。
+ * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+ */
+function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clientY", { value: clientY });
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  return event;
 }
 
 /** 通过 MUI 下拉菜单选择本地字幕的明确源语言。 */
@@ -184,8 +197,11 @@ describe("SubtitleSegmentationPlayground", () => {
     const resultArea = container.querySelector(
       'textarea[aria-label="断句结果"]'
     );
-    expect(sourceArea.getAttribute("rows")).toBe("5");
-    expect(resultArea.getAttribute("rows")).toBe("5");
+    // 输入框使用 minRows={5}（可自动增长到 maxRows=10）。MUI InputBase 显式传
+    // rows:undefined 覆盖了 TextareaAutosize 内部的 rows={minRows}，DOM 上不再有
+    // rows 属性（高度由 TextareaAutosize 的 style.height 决定），只断言元素存在。
+    expect(sourceArea).not.toBeNull();
+    expect(resultArea).not.toBeNull();
     expect(container.textContent.indexOf("当前生效的断句配置")).toBeLessThan(
       container.textContent.indexOf("内置字幕样本")
     );
@@ -304,6 +320,232 @@ describe("SubtitleSegmentationPlayground", () => {
     });
     expect(container.textContent).toContain("断句统计信息");
     expect(container.textContent).not.toContain("当前结果已过期");
+
+    act(() => root.unmount());
+  });
+
+  test("resize handles drag to control textarea height on both fields", async () => {
+    // 冒烟回归锁：两个输入框的手柄拖动 → 高度跟随。此前本文件没有任何
+    // resize 用例，抽 ResizableSubtitleField 包装组件后若引入回归将无测试可拦。
+    const { container, root } = renderPlayground();
+    await flushEffects();
+
+    // 手柄静态常显（无 focus-gating）：无需聚焦即可命中。
+    const sourceHandle = container.querySelector(
+      '[data-testid="segmentation-source-resize-handle"]'
+    );
+    const resultHandle = container.querySelector(
+      '[data-testid="segmentation-result-resize-handle"]'
+    );
+    const sourceNotch = container.querySelector(
+      '[data-testid="segmentation-source-resize-notch"]'
+    );
+    expect(sourceHandle).not.toBeNull();
+    expect(resultHandle).not.toBeNull();
+    expect(sourceNotch).not.toBeNull();
+
+    const sourceArea = container.querySelector(
+      'textarea[aria-label="原始字幕 JSON"]'
+    );
+    const sourceField = sourceArea.closest(".MuiInputBase-root");
+    Object.defineProperty(sourceField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+
+    // 未拖动：根节点不持有受控高度，textarea 不持有受控 maxHeight。
+    expect(sourceField.style.height).toBe("");
+    expect(sourceArea.style.maxHeight).toBe("");
+
+    // 6px 内轻触不进入高度调整；超过阈值后受控像素高度落到 InputBase 根节点
+    // （与 Selection 根节点高度模型对齐）。
+    await act(async () => {
+      sourceHandle.dispatchEvent(
+        makePointerEvent("pointerdown", { clientY: 0 })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 4 }));
+    });
+    expect(sourceField.style.height).toBe("");
+    expect(sourceArea.style.maxHeight).toBe("");
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    expect(sourceField.style.height).toBe("120px");
+    // 根节点不持有受控 overflowY（可见 textarea 的强制滚动经 scoped sx 规则）
+    expect(sourceField.style.overflowY).toBe("");
+    expect(sourceArea.style.maxHeight).toBe("");
+
+    // 松手结束会话，后续移动不再改变高度。
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 20 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 80 }));
+    });
+    expect(sourceField.style.height).toBe("120px");
+    expect(sourceArea.style.maxHeight).toBe("");
+
+    // 结果框手柄同样可拖（同一包装组件的第二个调用点）。
+    const resultArea = container.querySelector(
+      'textarea[aria-label="断句结果"]'
+    );
+    const resultField = resultArea.closest(".MuiInputBase-root");
+    Object.defineProperty(resultField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    await act(async () => {
+      resultHandle.dispatchEvent(
+        makePointerEvent("pointerdown", { clientY: 0 })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: -60 }));
+    });
+    // 向上拖出初始高度：不低于 medium 最小高度（100 - 60 = 40 → 56）。
+    expect(resultField.style.height).toBe(`${MIN_RESIZE_HEIGHT_MEDIUM}px`);
+    expect(resultArea.style.maxHeight).toBe("");
+    expect(resultField.style.overflowY).toBe("");
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: -60 }));
+    });
+
+    act(() => root.unmount());
+  });
+
+  test("pixel-precise drag height lands on the InputBase root and carries into the next drag", async () => {
+    // 锁定 Task 3 的精确像素契约：拖动高度不再量化成整数 minRows 行，
+    // 连续值逐像素生效，且第二轮以第一次结束值为基线（jsdom 仅验证状态值与
+    // 样式归属，不证明 TextareaAutosize 的真实浏览器逐像素视觉连续）。
+    const { container, root } = renderPlayground();
+    await flushEffects();
+
+    const sourceArea = container.querySelector(
+      'textarea[aria-label="原始字幕 JSON"]'
+    );
+    const sourceField = sourceArea.closest(".MuiInputBase-root");
+    Object.defineProperty(sourceField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="segmentation-source-resize-handle"]'
+    );
+
+    // 未拖动：根节点不持有受控像素高度。
+    expect(sourceField.style.height).toBe("");
+
+    // 突破 6px 阈值后，高度连续值 107 → 101 → 102 逐像素生效（不再量化整行）。
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 7 }));
+    });
+    expect(sourceField.style.height).toBe("107px");
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 1 }));
+    });
+    expect(sourceField.style.height).toBe("101px");
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 2 }));
+    });
+    expect(sourceField.style.height).toBe("102px");
+
+    // 受控像素高度落在 .MuiInputBase-root（可见根节点），根节点不持有受控
+    // overflowY（可见 textarea 的强制滚动经 scoped sx 规则承载）。
+    expect(sourceField.style.alignItems).toBe("flex-start");
+    expect(sourceField.style.overflowY).toBe("");
+    expect(sourceArea.style.maxHeight).toBe("");
+
+    // 情感样式表存在 scoped 强制滚动规则（`& textarea:not([aria-hidden=...])`
+    // 匹配 overflow: auto !important）
+    const emotionCss = Array.from(
+      document.querySelectorAll("style[data-emotion]")
+    )
+      .flatMap((tag) => {
+        const rules = tag.sheet && tag.sheet.cssRules;
+        if (rules && rules.length) {
+          return Array.from(rules).map((r) => r.cssText || "");
+        }
+        return [tag.textContent || ""];
+      })
+      .join("\n");
+    expect(emotionCss).toMatch(
+      /textarea:not\(\[aria-hidden=['"]true['"]\]\)\s*\{[^}]*overflow:\s*auto\s*!important/
+    );
+
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 2 }));
+    });
+
+    // 第二轮拖动以第一次结束值 102px 为基线；下拖穿越到 medium 最小高度。
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: -62 }));
+    });
+    expect(sourceField.style.height).toBe(`${MIN_RESIZE_HEIGHT_MEDIUM}px`);
+    expect(sourceArea.style.maxHeight).toBe("");
+
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: -62 }));
+    });
+    act(() => root.unmount());
+  });
+
+  test("playground handles floor at the medium minimum height (aria-valuemin)", async () => {
+    const { container, root } = renderPlayground();
+    await flushEffects();
+
+    const sourceHandle = container.querySelector(
+      '[data-testid="segmentation-source-resize-handle"]'
+    );
+    const resultHandle = container.querySelector(
+      '[data-testid="segmentation-result-resize-handle"]'
+    );
+    expect(sourceHandle).not.toBeNull();
+    expect(resultHandle).not.toBeNull();
+    expect(sourceHandle.getAttribute("aria-valuemin")).toBe(
+      String(MIN_RESIZE_HEIGHT_MEDIUM)
+    );
+    expect(resultHandle.getAttribute("aria-valuemin")).toBe(
+      String(MIN_RESIZE_HEIGHT_MEDIUM)
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("uncontrolled aria-valuenow publishes the raw measured height below the medium floor", async () => {
+    const { container, root } = renderPlayground();
+    await flushEffects();
+
+    const sourceArea = container.querySelector(
+      'textarea[aria-label="原始字幕 JSON"]'
+    );
+    const sourceField = sourceArea.closest(".MuiInputBase-root");
+    Object.defineProperty(sourceField, "offsetHeight", {
+      configurable: true,
+      value: 40,
+    });
+    const handle = container.querySelector(
+      '[data-testid="segmentation-source-resize-handle"]'
+    );
+    // stub 发生在测量 layout effect 之后：jsdom 无 ResizeObserver，须显式派发
+    // resize 强制重测（schedule → 微任务 → applyMeasured 重读 offsetHeight）。
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // 实测值低于 medium 下界 56 时仍播报原始实测值，不得被抬成 56（Z1）
+    expect(handle.getAttribute("aria-valuenow")).toBe("40");
+    expect(handle.getAttribute("aria-valuemin")).toBe(
+      String(MIN_RESIZE_HEIGHT_MEDIUM)
+    );
 
     act(() => root.unmount());
   });

--- a/src/views/Selection/CopyBtn.js
+++ b/src/views/Selection/CopyBtn.js
@@ -1,36 +1,79 @@
 import IconButton from "@mui/material/IconButton";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import LibraryAddCheckIcon from "@mui/icons-material/LibraryAddCheck";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * 复制文本内容按钮组件
  *
  * @param {Object} props
  * @param {string} props.text - 需要复制的纯文本内容
- * @param {string} [props.title="copy"] - 悬浮提示文案
+ * @param {string} props.title - 悬浮提示文案（本地化），所有调用方必须显式传入
  */
-export default function CopyBtn({ text, title = "copy" }) {
+export default function CopyBtn({ text, title }) {
   // copied 状态标识是否刚刚成功执行了复制操作
   const [copied, setCopied] = useState(false);
+  // 复制成功状态的定时器引用，覆盖与卸载时统一清理，避免卸载后仍触发 setState
+  const timerRef = useRef(null);
+  // 卸载守卫：卸载可能发生在 writeText 的 await 期间——此时既有 cleanup 先跑
+  // （定时器尚不存在），await 返回后必须先判定再 setState，否则会把
+  // setCopied 打在已卸载 fiber 上并新建 500ms 幽灵定时器（无人清理）。
+  const mountedRef = useRef(true);
+  // 代际 token：每次点击复制递增。慢的旧复制 Promise 晚于新复制完成返回时，
+  // 不得覆盖较新的 copied 视觉状态、不得残留旧 timer。
+  const generationRef = useRef(0);
+
+  const clearTimer = () => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  // StrictMode 开发环境会双调 effect：setup → cleanup → setup。cleanup 会把
+  // mountedRef 翻为 false；必须在每次 setup 恢复 true，否则挂载后点击永远被
+  // mountedRef.current === false 拦截，复制完成图标永不出现。
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearTimer();
+    };
+  }, []);
 
   const handleClick = async (e) => {
     e.stopPropagation();
-    // 写入系统剪贴板
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-
-    // REVIEW: 1. setTimeout 内部执行 clearTimeout(timer) 逻辑属于冗余操作。
-    // REVIEW: 2. 如果组件在 500ms 内卸载，此时定时器未被注销依然会触发异步 setState 导致潜在的 React warning，建议在组件卸载时进行定时器的清理。
-    const timer = setTimeout(() => {
-      clearTimeout(timer);
-      setCopied(false);
-    }, 500);
+    // 剪贴板能力守卫：非安全上下文或未实现该 API 的环境直接降级为无操作
+    if (typeof navigator.clipboard?.writeText !== "function") {
+      return;
+    }
+    // 每次点击进入新一代，旧代返回不得覆盖新代状态
+    const generation = ++generationRef.current;
+    try {
+      await navigator.clipboard.writeText(text);
+      // await 期间可能已卸载，或已被更新的复制取代：先判定再 setState
+      if (!mountedRef.current || generation !== generationRef.current) {
+        return;
+      }
+      setCopied(true);
+      // 新复制发生时替换上一个定时器
+      clearTimer();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setCopied(false);
+      }, 500);
+    } catch {
+      // 剪贴板不可用或权限被拒绝：静默降级，不翻转 copied 状态
+    }
   };
 
   return (
     <IconButton
       size="small"
+      aria-label={title}
+      // 鼠标按下时阻止默认行为，避免所在 TextField 因 mousedown 先失焦而卸载按钮，
+      // 与提交按钮同一套 blur/click 竞态修复模式，保证 onClick 正常触发。
+      onMouseDown={(e) => e.preventDefault()}
       sx={{
         opacity: 0.5,
         "&:hover": {

--- a/src/views/Selection/CopyBtn.test.js
+++ b/src/views/Selection/CopyBtn.test.js
@@ -1,0 +1,300 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import CopyBtn from "./CopyBtn";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 渲染复制按钮组件。
+ *
+ * @param {Object} props 覆盖默认组件参数。
+ * @returns {{container: HTMLElement, root: Object}} React 根节点与容器。
+ */
+function renderCopyBtn(props = {}, options = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    const element = <CopyBtn text="hello" title="Copy" {...props} />;
+    root.render(
+      options.strict ? <React.StrictMode>{element}</React.StrictMode> : element
+    );
+  });
+
+  return { container, root };
+}
+
+describe("CopyBtn", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("copies the full text and recovers the copy state after the timeout", async () => {
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+    // 复制成功后显示成功图标
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // 临时状态按时恢复为普通复制按钮
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("a new copy replaces the previous timer", async () => {
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // 第一个定时器只运行 400ms，尚未到期
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // 第二个定时器运行 200ms；若旧定时器未被替换，此时（首个定时器 600ms）早已恢复
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+
+    // 第二个定时器到期后才恢复
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("keeps the copy state when the clipboard write is denied", async () => {
+    // 切真实定时器：unhandledRejection 需要真实微任务/宏任务时序才能暴露
+    jest.useRealTimers();
+    navigator.clipboard.writeText.mockRejectedValue(new Error("denied"));
+    const unhandled = [];
+    const onUnhandled = (reason) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    try {
+      await act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandled);
+    }
+
+    // 拒绝必须被组件自身捕获：不得产生 unhandled rejection，也不翻转 copied
+    expect(unhandled.length).toBe(0);
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("is inert when the clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 无剪贴板能力：不抛错、不翻转 copied、不创建状态定时器
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).toBeNull();
+    expect(jest.getTimerCount()).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("does not flip the state or leak timers when unmounted mid-copy", async () => {
+    // 卸载竞态（AGENTS §7.4 幽灵定时器模式）：卸载发生在 writeText 的
+    // await 期间时，既有 cleanup 先跑（此刻定时器尚不存在），随后 await
+    // 返回仍不得 setState 或新建 500ms 定时器。
+    let resolveWrite;
+    navigator.clipboard.writeText.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveWrite = resolve;
+        })
+    );
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // handleClick 挂起在 writeText 上，此刻尚无状态定时器
+    expect(jest.getTimerCount()).toBe(0);
+
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+    act(() => root.unmount());
+    await act(async () => {
+      resolveWrite();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 卸载后不得新建幽灵定时器
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    setTimeoutSpy.mockRestore();
+  });
+
+  test("clears the timer on unmount so no state update happens afterwards", async () => {
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+
+    clearTimeoutSpy.mockClear();
+    act(() => root.unmount());
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+
+    // 卸载后推进定时器，不应抛错或更新状态
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    }).not.toThrow();
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test("works correctly when mounted under React.StrictMode (double effect setup/cleanup)", async () => {
+    const { container, root } = renderCopyBtn({}, { strict: true });
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // StrictMode 挂载下复制完成图标仍必须出现（mountedRef 已正确恢复 true）
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("out-of-order copy promises do not overwrite a newer copied state or leak timers", async () => {
+    let slowResolve;
+    let fastResolve;
+    let callCount = 0;
+
+    navigator.clipboard.writeText.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return new Promise((r) => {
+          slowResolve = r;
+        });
+      }
+      return new Promise((r) => {
+        fastResolve = r;
+      });
+    });
+
+    const { container, root } = renderCopyBtn();
+    const button = container.querySelector("button");
+
+    // 第一次慢复制
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    // 第二次快复制
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // 快复制先 resolve
+    await act(async () => {
+      fastResolve();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+
+    // 慢复制后 resolve：不得覆盖第二代的状态，也不得新建旧代 timer
+    await act(async () => {
+      slowResolve();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="LibraryAddCheckIcon"]')
+    ).not.toBeNull();
+
+    // 快复制的 500ms 到期后恢复普通图标
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(
+      container.querySelector('[data-testid="ContentCopyIcon"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+});

--- a/src/views/Selection/DraggableResizable.test.js
+++ b/src/views/Selection/DraggableResizable.test.js
@@ -1,6 +1,7 @@
-import { act } from "react";
+import { act, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import DraggableResizable from "./DraggableResizable";
+import { ResizeHandle } from "../../components/ResizeHandle";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -114,5 +115,213 @@ describe("DraggableResizable auto height bounds", () => {
 
     const updater = panel.setPosition.mock.calls.at(-1)[0];
     expect(updater({ x: 0, y: 400 })).toEqual({ x: 0, y: 200 });
+  });
+});
+
+describe("DraggableResizable inner/outer drag isolation", () => {
+  let container;
+  let root;
+  let getBoundingClientRect;
+  let originalResizeObserver;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    originalResizeObserver = window.ResizeObserver;
+    window.ResizeObserver = class {
+      observe() {}
+
+      disconnect() {}
+    };
+    // 默认：setPointerCapture 成功（hasPointerCapture 存在且返回 true）→ 元素主路径
+    HTMLElement.prototype.setPointerCapture = jest.fn(function () {
+      return true;
+    });
+    HTMLElement.prototype.hasPointerCapture = jest.fn(function () {
+      return true;
+    });
+    HTMLElement.prototype.releasePointerCapture = jest.fn(function () {
+      return undefined;
+    });
+    getBoundingClientRect = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function () {
+        if (this.classList?.contains("KT-draggable")) {
+          return { ...emptyRect, height: 400, bottom: 400 };
+        }
+        return emptyRect;
+      });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    getBoundingClientRect.mockRestore();
+    window.ResizeObserver = originalResizeObserver;
+    delete HTMLElement.prototype.releasePointerCapture;
+    delete HTMLElement.prototype.hasPointerCapture;
+  });
+
+  /** 构造一个可与主事件流配合的指针事件（pointerdown 需要在句柄元素上派发）。 */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 真实 ResizeHandle 宿主：内部 state 就是 handle 的拖动高度，
+   * 拖动发生变化时其调用的 onHeightChange 与外部 position/size setter 无关。
+   */
+  function InnerResizableField({ onHeightChange, onDragStart }) {
+    const boxRef = useRef(null);
+    const [height, setHeight] = useState(null);
+    return (
+      <div ref={boxRef} style={{ position: "relative" }}>
+        <textarea readOnly value="inner" data-testid="inner-field" />
+        <ResizeHandle
+          visible
+          closing={false}
+          height={height}
+          containerRef={boxRef}
+          onHeightChange={(value) => {
+            setHeight(value);
+            onHeightChange(value);
+            onDragStart();
+          }}
+          title="Resize"
+          ariaLabel="Resize"
+          testId="inner-resize-handle"
+          notchTestId="inner-resize-notch"
+        />
+      </div>
+    );
+  }
+
+  // 冲刷 ResizeHandle 挂载后的微任务测量：常显手柄（visible=true 挂载）的测量
+  // effect 会经 activate() 的微任务重试补测容器 ref，setState 必须落在 act 边界内，
+  // 否则 React 抛 "not wrapped in act" 警告（与 SubtitleSegmentationPlayground 的
+  // flushEffects 同款配方：双 Promise.resolve 冲刷微任务队列）。
+  async function flushEffects() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  async function renderIsolationScenario() {
+    const setSize = jest.fn();
+    const setPosition = jest.fn();
+    let innerLatestHeight = null;
+
+    act(() => {
+      root.render(
+        <DraggableResizable
+          position={{ x: 0, y: 0 }}
+          size={{ w: 320, h: 400 }}
+          minSize={{ w: 100, h: 100 }}
+          maxSize={{ w: 800, h: 800 }}
+          setSize={setSize}
+          setPosition={setPosition}
+          autoHeight
+          header={<span>header</span>}
+          onClick={() => {}}
+        >
+          <InnerResizableField
+            onHeightChange={(h) => {
+              innerLatestHeight = h;
+            }}
+            onDragStart={() => {}}
+          />
+        </DraggableResizable>
+      );
+    });
+
+    // 等 ResizeHandle 挂载期测量（activate 微任务重试）完成，避免其 setState 落在 act 外
+    await flushEffects();
+
+    const boxDiv = container.querySelector(
+      '[data-testid="inner-field"]'
+    ).parentElement;
+    Object.defineProperty(boxDiv, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="inner-resize-handle"]'
+    );
+
+    // 清理初次挂载时 autoHeight clampPosition 对 setPosition 的初始调用
+    setSize.mockClear();
+    setPosition.mockClear();
+
+    return {
+      setSize,
+      setPosition,
+      boxDiv,
+      handle,
+      getLatest: () => innerLatestHeight,
+    };
+  }
+
+  test("element capture main path: inner resize does not move or resize the outer panel", async () => {
+    const { setSize, setPosition, handle, getLatest } =
+      await renderIsolationScenario();
+    expect(handle).not.toBeNull();
+
+    // 元素 capture 主路径：pointerdown 在句柄元素上建立会话并 setPointerCapture 成功，
+    // 后续 move/up 直接派发在句柄元素上（window 降级监听不参与）。
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+    });
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointerup", { clientY: 50 }));
+    });
+
+    // 内层高度确实跟随拖动了（100 + 50 = 150）
+    expect(getLatest()).toBe(150);
+
+    // 外层面板的 size/position setter 一律未被调用（事件被 stopPropagation 隔离）
+    expect(setSize).not.toHaveBeenCalled();
+    expect(setPosition).not.toHaveBeenCalled();
+  });
+
+  test("window fallback path: capture failure still resizes and stays isolated", async () => {
+    // 模拟 Pointer capture 失败（缺失）：setPointerCapture 不可用 →
+    // pointerdown 激活完整 window fallback，window 承接的 move 仍可调高。
+    HTMLElement.prototype.setPointerCapture = undefined;
+    HTMLElement.prototype.hasPointerCapture = undefined;
+
+    const { setSize, setPosition, handle, getLatest } =
+      await renderIsolationScenario();
+    expect(handle).not.toBeNull();
+
+    // capture 失败：pointerdown 建立会话并同步激活 window 降级监听
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    // 拖出元素（window 承接 move 仍有效）
+    act(() => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    act(() => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+    });
+    act(() => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 50 }));
+    });
+
+    // window 降级路径下内层高度仍跟随拖动（100 + 50 = 150）
+    expect(getLatest()).toBe(150);
+    expect(setSize).not.toHaveBeenCalled();
+    expect(setPosition).not.toHaveBeenCalled();
   });
 });

--- a/src/views/Selection/TranCont.js
+++ b/src/views/Selection/TranCont.js
@@ -1,10 +1,11 @@
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
+import FormHelperText from "@mui/material/FormHelperText";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { apiTranslate } from "../../apis";
 import {
   API_SPE_TYPES,
@@ -13,6 +14,24 @@ import {
 } from "../../config";
 import { useI18n } from "../../hooks/I18n";
 import CopyBtn from "./CopyBtn";
+import {
+  ResizeHandle,
+  usePrefersReducedMotion,
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "../../components/ResizeHandle";
+import { useTextareaResize } from "../../components/useTextareaResize";
+import { useFocusClosingGate } from "../../components/useFocusClosingGate";
+
+// 控件嵌入边框的共享定位常量（转发导出，供测试与其他调用点从本组件导入）
+export {
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "../../components/ResizeHandle";
 
 /**
  * 判断划词翻译结果是否允许进行可见的流式渲染。
@@ -147,9 +166,41 @@ export default function TranCont({
   simpleStyle = false,
 }) {
   const i18n = useI18n();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  // 实例级稳定 ID：同一页面多个 TranCont（多引擎并行）同时出错时，每个错误
+  // 提示都必须有唯一、稳定的 DOM id 与对应 textarea 的 aria-describedby 一一
+  // 关联；不得共享硬编码 id，避免重复 id 造成错误的可访问性关联。
+  const helperId = useId();
+  const fieldId = useId();
   const [trText, setTrText] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  // 唯一焦点退出 gate：与 TranForm 共享的状态机，负责 focus-gating（focused）
+  // 与 120ms 退出过渡（closing）。
+  const {
+    focused,
+    closing,
+    handleFocus: handleFieldFocus,
+    handleBlur: handleFieldBlur,
+  } = useFocusClosingGate({ prefersReducedMotion });
+  // focus-gating + 内容门控：译文框是只读的，空译文时右上角没有任何可执行操作
+  // （不能复制、不能输入、不能提交），故 rail / 复制按钮 / 右上 rail-notch 只在
+  // "有译文"时显示，空译文聚焦不挖右上角缺口；流式加载中即使已有部分译文，
+  // rail 系列也整体隐藏（加载期间不可复制、不可 resize，避免只剩 rail/notch
+  // 而可操作按钮全部消失的视觉缺口）；有译文失焦时 closing 期间照常淡出。
+  const hasTranslation = Boolean(trText && trText.trim());
+  const showControls = hasTranslation && (focused || closing) && !loading;
+  // 译文文本框自定义高度：null 表示仍由 MUI TextareaAutosize 自动测量，
+  // 用户首次拖动后切换为受控高度，后续内容变化不会覆盖用户调整的尺寸。
+  const [resizeHeight, setResizeHeight] = useState(null);
+  // 拖动高度 → TextField 的 minRows/maxRows/根节点高度样式（共享 hook）：
+  // 未拖动时保持自动测量（maxRows=10 限制上限），拖动后全部释放量化，
+  // 由像素高度驱动。
+  const { minRows, maxRows, rootStyle } = useTextareaResize(resizeHeight, 1);
+  // loading 期间译文框内已有 startAdornment spinner 占位，label 必须随之一并
+  // 浮动到边框，避免与 spinner 在框内视觉重叠；空译文非 loading 仍不浮动。
+  const labelShrink = Boolean(loading || (trText && trText.trim()));
+  const translatedBoxRef = useRef(null);
 
   // 根据 slug 找到当前组件实例负责调用的翻译接口配置。
   const apiSetting = useMemo(
@@ -297,37 +348,144 @@ export default function TranCont({
   }
 
   return (
-    <Box>
-      <TextField
-        size="small"
-        label={`${i18n("translated_text")} - ${apiSetting.apiName}`}
-        fullWidth
-        multiline
-        maxRows={10}
-        sx={{
-          "& textarea": {
-            resize: "vertical",
-          },
-        }}
-        value={trText}
-        helperText={error}
-        InputProps={{
-          startAdornment: loading ? <CircularProgress size={16} /> : null,
-          endAdornment: (
-            <Stack
-              direction="row"
-              sx={{
-                position: "absolute",
-                right: 0,
-                top: 0,
-              }}
-            >
-              {/* 复制当前译文；流式渲染期间复制到的是已经到达的部分文本。 */}
-              <CopyBtn text={trText} title={i18n("copy")} />
-            </Stack>
-          ),
-        }}
-      />
-    </Box>
+    <>
+      {/* 定位包装层：外框与输入根节点完全重合（helperText 在包装层之外渲染，
+          不参与覆盖层几何），rail / 手柄 / notch 相对本包装层定位，
+          与可能设置 overflow-y: auto 的输入根节点同级，不会被滚动裁切；
+          onBlur 挂在包装层（焦点保活见 handleFieldBlur）。 */}
+      <Box
+        ref={translatedBoxRef}
+        sx={{ position: "relative" }}
+        onBlur={handleFieldBlur}
+      >
+        <TextField
+          id={fieldId}
+          size="small"
+          label={`${i18n("translated_text")} - ${apiSetting.apiName}`}
+          fullWidth
+          multiline
+          minRows={minRows}
+          maxRows={maxRows}
+          // 译文为受控组件且没有 onChange，显式声明只读语义，同时保留文本选择与复制能力
+          inputProps={{
+            readOnly: true,
+            // helperText 移出包装层后手动保持无障碍关联：仅在出错时引用
+            // 本实例的 helper ID，无错误时不留下悬空的 aria-describedby。
+            "aria-describedby": error ? helperId : undefined,
+          }}
+          // 空译文时 label 不浮动：强制 label 只在有译文内容时浮动（shrink）
+          InputLabelProps={{ shrink: labelShrink }}
+          error={Boolean(error)}
+          sx={{
+            "& textarea:not([aria-hidden='true'])": {
+              boxSizing: "border-box",
+              maxHeight: "100%",
+              resize: "none",
+              ...(resizeHeight != null ? { overflow: "auto !important" } : {}),
+            },
+          }}
+          value={trText}
+          onFocus={handleFieldFocus}
+          InputProps={{
+            style: {
+              paddingRight: 14,
+              ...(rootStyle || {}),
+            },
+            startAdornment: loading ? <CircularProgress size={16} /> : null,
+          }}
+        />
+        {/* 覆盖层：与可能设置 overflow-y: auto 的输入根节点同级，避免滚动裁切
+            控件（rail / 六点手柄 / 两处 notch 不再位于滚动根节点内部），
+            也避免滚动时覆盖层随内容滚走。 */}
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            pointerEvents: "none",
+          }}
+        >
+          {/* 右上角复制操作区：聚焦显示；失焦播放退出动画后卸载 */}
+          {showControls && (
+            <>
+              {/* Notch 遮罩条：覆盖顶边框线段，形成 notch 效果 */}
+              <Box
+                data-testid="trancont-rail-notch"
+                style={{
+                  position: "absolute",
+                  right:
+                    CONTROL_CENTER_FROM_RIGHT -
+                    CONTROL_HEIGHT / 2 -
+                    NOTCH_HORIZONTAL_PAD,
+                  top: -Math.round(NOTCH_STRIP_HEIGHT / 2),
+                  width: CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2,
+                  height: NOTCH_STRIP_HEIGHT,
+                }}
+                sx={{
+                  backgroundColor: "background.paper",
+                  zIndex: 1,
+                  // 与 rail 统一为同一套 opacity + visibility 过渡（120ms）
+                  opacity: closing ? 0 : 1,
+                  visibility: closing ? "hidden" : "visible",
+                  transition: prefersReducedMotion
+                    ? "none"
+                    : "opacity 120ms ease, visibility 120ms ease",
+                }}
+              />
+              <Stack
+                direction="row"
+                data-testid="trancont-rail"
+                style={{
+                  position: "absolute",
+                  right: CONTROL_CENTER_FROM_RIGHT - CONTROL_HEIGHT / 2,
+                  top: -Math.round(CONTROL_HEIGHT / 2),
+                  // 进入态保持 auto 以便命中；closing 期间屏蔽点击，防止残留按钮被触发
+                  pointerEvents: closing ? "none" : "auto",
+                }}
+                sx={{
+                  zIndex: 2,
+                  // 与边框变色 / 缩放手柄统一为同一套 opacity + visibility 过渡（120ms）
+                  opacity: closing ? 0 : 1,
+                  visibility: closing ? "hidden" : "visible",
+                  transition: prefersReducedMotion
+                    ? "none"
+                    : "opacity 120ms ease, visibility 120ms ease",
+                }}
+              >
+                {/* 复制当前译文；流式渲染期间复制到的是已经到达的部分文本。 */}
+                {Boolean(trText.trim() && !loading) && (
+                  <CopyBtn text={trText} title={i18n("copy")} />
+                )}
+              </Stack>
+            </>
+          )}
+          {/* 右下缩放手柄：聚焦且有有效译文时显示（错误前部分译文仍有效）；
+              已有手动高度（resizeHeight）本身也构成显示手柄的理由——
+              每次重译 setTrText("") 清空译文后手柄常驻，可拖回最小完成复位。 */}
+          <ResizeHandle
+            visible={Boolean(
+              (focused || closing) &&
+                (trText.trim() || resizeHeight != null) &&
+                !loading
+            )}
+            closing={closing}
+            height={resizeHeight}
+            containerRef={translatedBoxRef}
+            onHeightChange={setResizeHeight}
+            prefersReducedMotion={prefersReducedMotion}
+            controlsId={fieldId}
+            title={i18n("field_resize_height")}
+            ariaLabel={i18n("field_resize_height")}
+            testId="trancont-resize-handle"
+            notchTestId="trancont-resize-notch"
+          />
+        </Box>
+      </Box>
+      {/* 错误提示：位于定位包装层之外，不参与覆盖层几何（与 Preview 的 .helper 一致） */}
+      {error && (
+        <FormHelperText error id={helperId} sx={{ margin: "3px 14px 0" }}>
+          {error}
+        </FormHelperText>
+      )}
+    </>
   );
 }

--- a/src/views/Selection/TranCont.test.js
+++ b/src/views/Selection/TranCont.test.js
@@ -1,6 +1,11 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import TranCont from "./TranCont";
+import TranCont, {
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "./TranCont";
 import { apiTranslate } from "../../apis";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -20,7 +25,7 @@ jest.mock("../../config", () => ({
 }));
 
 jest.mock("../../hooks/I18n", () => ({
-  useI18n: () => (key) => key,
+  useI18n: () => jest.requireActual("../../config/i18n").newI18n("en"),
 }));
 
 jest.mock("./CopyBtn", () => {
@@ -59,6 +64,59 @@ async function flushEffects() {
   await act(async () => {
     await Promise.resolve();
   });
+}
+
+/**
+ * 构造 prefers-reduced-motion 的 matchMedia stub。
+ *
+ * @param {boolean} matches 是否开启"减少动态效果"。
+ * @returns {Function} 可赋给 window.matchMedia 的 jest mock。
+ */
+function matchMediaStub(matches) {
+  return jest.fn().mockReturnValue({
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  });
+}
+
+/**
+ * 收集当前 document.styleSheets 中所有 CSS 规则。
+ *
+ * @returns {Array<CSSRule>} 全部规则（跨源样式表读取失败时跳过）。
+ */
+function collectRules() {
+  return Array.from(document.styleSheets).flatMap((sheet) => {
+    try {
+      return Array.from(sheet.cssRules);
+    } catch {
+      return [];
+    }
+  });
+}
+
+/**
+ * 读取所有 Emotion 样式表规则文本（speedy 模式下规则通过 insertRule 写入
+ * sheet.cssRules，textContent 为空；两者优先读取）。
+ *
+ * @returns {string} 合并后的 CSS 文本。
+ */
+function emotionCssText() {
+  const tags = Array.from(document.querySelectorAll("style[data-emotion]"));
+  return tags
+    .flatMap((tag) => {
+      const rules = tag.sheet && tag.sheet.cssRules;
+      if (rules && rules.length) {
+        return Array.from(rules).map((r) => r.cssText || "");
+      }
+      return [tag.textContent || ""];
+    })
+    .join("\n");
 }
 
 const baseApiSetting = {
@@ -211,6 +269,10 @@ describe("TranCont", () => {
     const expectedText =
       'First isn\'t "plain" & simple\n\nSecond\nThird\nFourth';
     expect(container.querySelector("textarea").value).toBe(expectedText);
+    // 聚焦后复制按钮才显示
+    act(() => {
+      container.querySelector("textarea").focus();
+    });
     expect(container.querySelector("[data-copy-text]").dataset.copyText).toBe(
       expectedText
     );
@@ -564,6 +626,20 @@ describe("TranCont", () => {
     });
   });
 
+  test("划词翻译不携带 glossary（规则级 AI 术语不作用于划词）", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+
+    const { root } = renderTranCont();
+    await flushEffects();
+
+    // 划词走 apiTranslate，不注入规则级 glossary
+    expect(apiTranslate.mock.calls[0][0].glossary).toBeUndefined();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
   test("passes stream callback when batch fetch is disabled", async () => {
     const nonBatchStream = {
       ...baseApiSetting,
@@ -643,5 +719,1482 @@ describe("TranCont", () => {
       deferred.resolve({ trText: "卸载后的译文" });
       await deferred.promise;
     });
+  });
+});
+
+describe("TranCont translation controls and resize handle", () => {
+  beforeEach(() => {
+    apiTranslate.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 构造一个带 touches 数组的触摸事件。
+   *
+   * @param {Array<{clientY: number}>} touches 触点数组。
+   * @returns {Event} 可被 React 与 jsdom 识别的触摸事件。
+   */
+  function makeTouchEvent(type, touches) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "touches", { value: touches });
+    Object.defineProperty(event, "targetTouches", { value: touches });
+    return event;
+  }
+
+  /**
+   * 渲染译文框并使其 textarea 聚焦：focus-gating 下复制按钮与缩放手柄只在聚焦时显示。
+   *
+   * @param {Object} props 覆盖默认组件参数。
+   * @returns {{container: HTMLElement, root: Object, textarea: HTMLTextAreaElement}} 渲染结果。
+   */
+  async function renderFocusedTranCont(props = {}) {
+    const rendered = renderTranCont(props);
+    await flushEffects();
+    const textarea = rendered.container.querySelector("textarea");
+    act(() => {
+      textarea.focus();
+    });
+    return { ...rendered, textarea };
+  }
+
+  test("marks the translated textarea as read only", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = renderTranCont();
+    await flushEffects();
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea.readOnly).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  test("hides copy and resize controls while loading or empty", async () => {
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+
+    const { container, root } = await renderFocusedTranCont();
+
+    // 加载中（即使聚焦）：无有效译文，复制与缩放手柄均隐藏
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+
+    await act(async () => {
+      deferred.resolve({ trText: "" });
+      await deferred.promise;
+    });
+
+    // 空译文（聚焦中）：仍隐藏
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("streaming loading with partial text hides rail, notch, copy and resize consistently", async () => {
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+
+    const { container, root } = await renderFocusedTranCont();
+
+    // 流式加载中，已有部分译文（聚焦中）：此时不可复制、不可 resize，
+    // rail 系列控件必须整体隐藏，不得出现「rail/notch 还在、可操作按钮却
+    // 全部消失」的视觉缺口。
+    await act(async () => {
+      apiTranslate.mock.calls[0][0].onStreamChunk({
+        text: "部分译文",
+        isComplete: false,
+      });
+    });
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="trancont-rail"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-rail-notch"]')
+    ).toBeNull();
+
+    // 流式完成（loading=false）：rail / 复制 / 手柄恢复可见，部分译文可复制
+    await act(async () => {
+      deferred.resolve({ trText: "完整译文" });
+      await deferred.promise;
+    });
+    expect(container.querySelector("[data-copy-text]").dataset.copyText).toBe(
+      "完整译文"
+    );
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-rail"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-rail-notch"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("multiple concurrent error TranCont instances receive unique, instance-stable helper IDs", async () => {
+    apiTranslate.mockImplementation(async ({ apiSetting }) => {
+      throw new Error(`${apiSetting.apiName} error`);
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <>
+          <TranCont
+            text="hello"
+            fromLang="auto"
+            toLang="zh-CN"
+            apiSlug="openai"
+            transApis={[baseApiSetting, googleApiSetting]}
+          />
+          <TranCont
+            text="hello"
+            fromLang="auto"
+            toLang="zh-CN"
+            apiSlug="google"
+            transApis={[baseApiSetting, googleApiSetting]}
+          />
+        </>
+      );
+    });
+    await flushEffects();
+
+    const helperElements = container.querySelectorAll(
+      ".MuiFormHelperText-root"
+    );
+    expect(helperElements.length).toBe(2);
+    const helperIds = Array.from(helperElements).map((el) => el.id);
+    // 每个 helper 节点必须持有非空的唯一 ID（不能共享硬编码的 trancont-helper-text）
+    expect(helperIds[0]).toBeTruthy();
+    expect(helperIds[1]).toBeTruthy();
+    expect(helperIds[0]).not.toBe(helperIds[1]);
+
+    // 过滤出用户可见的 textarea（排除 TextareaAutosize 用于测量的 shadow textarea）
+    const textareas = Array.from(container.querySelectorAll("textarea")).filter(
+      (ta) => ta.tabIndex !== -1
+    );
+    expect(textareas.length).toBe(2);
+    const describedBys = textareas.map((ta) =>
+      ta.getAttribute("aria-describedby")
+    );
+    // 两个输入框必须分别与其对应的错误文本关联
+    expect(describedBys[0]).toBe(helperIds[0]);
+    expect(describedBys[1]).toBe(helperIds[1]);
+
+    act(() => root.unmount());
+  });
+
+  test("does not leave a dangling aria-describedby when there is no error", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "正常译文" });
+    const { container, root } = renderTranCont();
+    await flushEffects();
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea.getAttribute("aria-describedby")).toBeNull();
+    expect(container.querySelector(".MuiFormHelperText-root")).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("empty read-only translation does not float the label (no notched gap on focus)", async () => {
+    // 空译文：即使聚焦，label 也不应浮动到边框（不挖 notchedOutline 缺口），
+    // 因为没有内容可复制、不能输入、不能提交，浮动 label 无意义。
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+    const { container, root } = await renderFocusedTranCont();
+
+    await act(async () => {
+      deferred.resolve({ trText: "" });
+      await deferred.promise;
+    });
+
+    const label = container.querySelector(".MuiInputLabel-outlined");
+    expect(label).not.toBeNull();
+    // shrink=false：label 停留在输入框内作为占位，不浮动、不挖缺口
+    expect(label.classList.contains("MuiInputLabel-shrink")).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("translation text floats the label (notched gap only when there is content)", async () => {
+    // 有译文：label 浮动到边框（正常挖缺口标识字段），这是有内容的合理表现。
+    apiTranslate.mockResolvedValueOnce({ trText: "有内容的译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const label = container.querySelector(".MuiInputLabel-outlined");
+    expect(label).not.toBeNull();
+    expect(label.classList.contains("MuiInputLabel-shrink")).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  test("empty translation on focus renders no rail, rail-notch, or copy button", async () => {
+    // 空译文 + 聚焦：只读空框右上角无可执行操作，不得挖出空的装饰缺口。
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+    const { container, root } = await renderFocusedTranCont();
+
+    await act(async () => {
+      deferred.resolve({ trText: "" });
+      await deferred.promise;
+    });
+
+    expect(
+      container.querySelector('[data-testid="trancont-rail-notch"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="trancont-rail"]')).toBeNull();
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("translation on focus renders the rail and rail-notch", async () => {
+    // 有译文 + 聚焦：rail 嵌入顶边框的装饰缺口正常出现（有内容可复制）。
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    expect(
+      container.querySelector('[data-testid="trancont-rail-notch"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-rail"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("shows copy and resize controls for a valid translation", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "完整的译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    expect(container.querySelector("[data-copy-text]").dataset.copyText).toBe(
+      "完整的译文"
+    );
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("keeps copy and resize controls when an error occurs after partial text", async () => {
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+
+    const { container, root } = await renderFocusedTranCont();
+
+    await act(async () => {
+      apiTranslate.mock.calls[0][0].onStreamChunk({
+        text: "部分译文",
+        isComplete: false,
+      });
+    });
+    await act(async () => {
+      deferred.reject(new Error("网络错误"));
+      await deferred.promise.catch(() => {});
+    });
+
+    // 错误发生前已有的部分译文仍可复制
+    expect(container.querySelector("[data-copy-text]").dataset.copyText).toBe(
+      "部分译文"
+    );
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("hides copy and resize controls when an error leaves no translation or on blur", async () => {
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+
+    const { container, root } = await renderFocusedTranCont();
+
+    await act(async () => {
+      deferred.reject(new Error("请求失败"));
+      await deferred.promise.catch(() => {});
+    });
+
+    expect(container.textContent).toContain("请求失败");
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+
+    // 失焦也不残留可命中控件（空译文失焦后仍隐藏）
+    act(() => {
+      container.querySelector("textarea").blur();
+    });
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("simpleStyle keeps rendering Typography without textarea, copy or resize controls", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = renderTranCont({ simpleStyle: true });
+    await flushEffects();
+
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector("[data-copy-text]")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+    expect(container.textContent).toContain("译文");
+
+    act(() => root.unmount());
+  });
+
+  test("does not propagate pointer or touch start events from the resize handle", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    const pointerSpy = jest.fn();
+    const touchSpy = jest.fn();
+    document.body.addEventListener("pointerdown", pointerSpy);
+    document.body.addEventListener("touchstart", touchSpy);
+
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      handle.dispatchEvent(makeTouchEvent("touchstart", [{ clientY: 0 }]));
+    });
+
+    // 起始事件已隔离，不会冒泡到外层拖动/缩放容器
+    expect(pointerSpy).not.toHaveBeenCalled();
+    expect(touchSpy).not.toHaveBeenCalled();
+
+    document.body.removeEventListener("pointerdown", pointerSpy);
+    document.body.removeEventListener("touchstart", touchSpy);
+    act(() => root.unmount());
+  });
+
+  test("keeps the height unchanged below the 6px threshold and resizes above it", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    // 模拟输入框真实高度作为首次拖动起点
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+
+    // 纵向移动 6px 内：高度不变
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 6 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    // 超过 6px 即启动（7px 边界，100 + 7 = 107）
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 7 }));
+    });
+    expect(textField.style.height).toBe("107px");
+
+    // 继续拖动继续调整（100 + 20 = 120）
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    expect(textField.style.height).toBe("120px");
+
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 20 }));
+    });
+    act(() => root.unmount());
+  });
+
+  test("a gesture starting outside the hot area never starts resizing", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    const textarea = container.querySelector("textarea");
+
+    // 手势从热区外的正文区开始
+    await act(async () => {
+      textarea.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 100 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    act(() => root.unmount());
+  });
+
+  test("ends the touch session on touchend even when the touches array is empty", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    await act(async () => {
+      handle.dispatchEvent(makeTouchEvent("touchstart", [{ clientY: 0 }]));
+    });
+    // touchend 时触点数组为空，会话应正常结束
+    await act(async () => {
+      window.dispatchEvent(new Event("touchend"));
+    });
+    // 会话结束后再移动不再改变高度
+    await act(async () => {
+      window.dispatchEvent(makeTouchEvent("touchmove", [{ clientY: 50 }]));
+    });
+    expect(textField.style.height).toBe("");
+
+    act(() => root.unmount());
+  });
+
+  test("removes all window listeners on unmount while dragging a pointer session", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    // 进入拖动会话。jsdom 无 Pointer capture，pointerdown 激活完整 window fallback，
+    // 会话期间 window 上存在 pointermove/pointerup/pointercancel 降级监听。
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    act(() => root.unmount());
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type);
+    for (const type of ["pointermove", "pointerup", "pointercancel", "blur"]) {
+      expect(removedTypes).toContain(type);
+    }
+    removeSpy.mockRestore();
+  });
+
+  test("removes all window listeners on unmount while dragging a touch session", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    // 进入 Touch 会话：touchmove/touchend/touchcancel 监听仅随活动会话安装
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    act(() => root.unmount());
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type);
+    for (const type of ["touchmove", "touchend", "touchcancel", "blur"]) {
+      expect(removedTypes).toContain(type);
+    }
+    removeSpy.mockRestore();
+  });
+
+  test("hides copy and resize controls once the textarea loses focus", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      apiTranslate.mockResolvedValueOnce({ trText: "完整的译文" });
+      const { container, root } = await renderFocusedTranCont();
+
+      // 聚焦且有效译文：复制与缩放手柄显示
+      expect(container.querySelector("[data-copy-text]")).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).not.toBeNull();
+
+      // 失焦：缩放手柄与 copy rail 同构，均播放退出动画后卸载（不再瞬时卸载）
+      act(() => {
+        container.querySelector("textarea").blur();
+      });
+      // 退出动画期间复制与缩放手柄仍在 DOM（淡出中）
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).not.toBeNull();
+      expect(container.querySelector("[data-copy-text]")).not.toBeNull();
+
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(container.querySelector("[data-copy-text]")).toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("gives the resize handle a non-empty accessible name via the real i18n dictionary", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+    // 使用真实 I18N 字典获取本地化文案，不依赖硬编码 fallback
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+    expect(handle.getAttribute("title")).toBeTruthy();
+    expect(handle.getAttribute("aria-label")).toBe(
+      jest.requireActual("../../config/i18n").newI18n("en")(
+        "field_resize_height"
+      )
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("a manually resized box keeps the resize handle visible after the translation is cleared", async () => {
+    apiTranslate
+      .mockResolvedValueOnce({ trText: "译文" })
+      .mockResolvedValueOnce({ trText: "" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+
+    // 拖动放大产生手动高度
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 200 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 200 }));
+    });
+    expect(textField.style.height).toBe("300px");
+
+    // 重新划词翻译（文本变化清空 trText）：已有手动高度仍是显示手柄的理由
+    await act(async () => {
+      root.render(
+        <TranCont
+          text="hello again"
+          fromLang="auto"
+          toLang="zh-CN"
+          apiSlug="openai"
+          transApis={[baseApiSetting]}
+        />
+      );
+      await Promise.resolve();
+    });
+    await flushEffects();
+    expect(container.querySelector("textarea").value).toBe("");
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("exposes a keyboard-operable separator with arrow-key resizing", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // keyboard-operable separator：保留可读名称，且可聚焦、支持方向键调整
+    expect(handle.getAttribute("role")).toBe("separator");
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+    expect(handle.getAttribute("title")).toBeTruthy();
+    expect(handle.getAttribute("tabindex")).toBe("0");
+    // 手柄物理上是贴在字段底边框上的横向分隔条：横向语义与 ArrowUp/Down 对应
+    expect(handle.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(handle.getAttribute("aria-valuemin")).toBe("40");
+    // 未受控态：实测自动高度作为 aria-valuenow（ARIA 1.2 focusable separator
+    // MUST set aria-valuenow）。jsdom 无 ResizeObserver，测量 effect 只在挂载
+    // 与 window resize 时重跑，故 stub offsetHeight 后须显式派发 resize 重测。
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(handle.getAttribute("aria-valuenow")).toBe("100");
+
+    // W3C Window Splitter 语义（上方文本框为主区域）：
+    // ArrowDown：增加高度（从测量基线 100 增加一个步进 12px → 112px）
+    await act(async () => {
+      handle.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await Promise.resolve();
+    });
+    expect(textField.style.height).toBe("112px");
+    // 持有受控高度后 valuenow 输出真实值
+    expect(handle.getAttribute("aria-valuenow")).toBe("112");
+
+    // ArrowUp：以受控高度为基线递减一个步进（112 - 12 = 100px）
+    await act(async () => {
+      handle.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowUp",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await Promise.resolve();
+    });
+    expect(textField.style.height).toBe("100px");
+
+    // 连续 ArrowUp 触底：不得低于 MIN_RESIZE_HEIGHT (40)
+    for (let i = 0; i < 6; i += 1) {
+      await act(async () => {
+        handle.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "ArrowUp",
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        await Promise.resolve();
+      });
+    }
+    expect(textField.style.height).toBe("40px");
+
+    act(() => root.unmount());
+  });
+
+  test("tabbing focus to the handle keeps the field open (relatedTarget keep-alive)", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // 焦点从 textarea 迁移到手柄（Tab 等价场景）：focusout 冒泡到字段包装层，
+    // relatedTarget 在包装层内 → 不关闭、不卸载
+    await act(async () => {
+      handle.focus();
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(handle);
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+    // rail 同样保持挂载（字段未关闭）
+    expect(
+      container.querySelector('[data-testid="trancont-rail"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("keeps dragging when the textarea blurs mid-drag until pointerup", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // 进入拖动会话并移动超过阈值
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 缩放中途失焦：进入退出动画，但活动会话期间手柄保持挂载与监听
+    act(() => {
+      container.querySelector("textarea").blur();
+    });
+    // 退出动画期间（closing=true）拖动不受 pointer-events 阻断
+    expect(handle.style.pointerEvents).toBe("auto");
+
+    // 等待超过 120ms 退出动画：失焦不再终止会话（新契约）
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 130));
+    });
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).not.toBeNull();
+
+    // 失焦后 height 仍在跟随鼠标
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 40 }));
+    });
+    expect(textField.style.height).toBe("140px");
+
+    // 松手结束会话：重渲染后按新门控自然卸载
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 40 }));
+    });
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+
+    // 后续 pointermove 不再改变高度
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 60 }));
+    });
+    expect(textField.style.height).toBe("140px");
+
+    act(() => root.unmount());
+  });
+
+  test("drag height lands on the InputBase root and the visible textarea scrolls internally", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // 拖动 200px：受控像素高度 300px 直接落在 InputBase 根节点（已超过
+    // maxRows=10 的高度，钳制必须释放，不得把内框压回固定行高形成死区）
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 200 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 200 }));
+    });
+    expect(textField.style.height).toBe("300px");
+    // 受控高度落在 InputBase 根节点；根节点不持有受控 overflowY
+    // （避免 MUI TextareaAutosize 每帧重写 textarea.style.overflow 与 root 级
+    // 滚动形成双滚动条）
+    expect(textField.style.overflowY).toBe("");
+
+    // 可见 textarea（过滤测量用 shadow 副本）的强制滚动规则来自 scoped sx
+    // （`& textarea:not([aria-hidden="true"])`），不写入 React inline style。
+    const visibleTextareas = Array.from(
+      container.querySelectorAll("textarea")
+    ).filter((ta) => ta.tabIndex !== -1);
+    expect(visibleTextareas.length).toBe(1);
+    expect(visibleTextareas[0].style.maxHeight).toBe("");
+
+    // 情感样式表存在同时匹配 textarea:not([aria-hidden=...]) 与
+    // overflow: auto !important 的 scoped 强制滚动规则
+    expect(emotionCssText()).toMatch(
+      /textarea:not\(\[aria-hidden=['"]true['"]\]\)\s*\{[^}]*overflow:\s*auto\s*!important/
+    );
+    // 测量用 shadow textarea 不命中强制滚动规则（aria-hidden="true" 排除），
+    // 其测量关键基准 height:0 必须原样保留
+    const shadowTextareas = Array.from(
+      container.querySelectorAll("textarea")
+    ).filter((ta) => ta.tabIndex === -1);
+    for (const shadow of shadowTextareas) {
+      expect(shadow.style.height).toBe("0px");
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("floats the label while loading so it does not overlap the spinner", async () => {
+    // loading 期间（译文挂起）：label 必须随 spinner 一并浮动到边框，
+    // 避免与 startAdornment 的 spinner 在框内视觉重叠。
+    const deferred = createDeferred();
+    apiTranslate.mockReturnValueOnce(deferred.promise);
+    const { container, root } = await renderFocusedTranCont();
+
+    const label = container.querySelector(".MuiInputLabel-outlined");
+    expect(label).not.toBeNull();
+    expect(label.classList.contains("MuiInputLabel-shrink")).toBe(true);
+
+    // resolve 空译文后（非 loading 且无内容）：label 回到非浮动占位
+    await act(async () => {
+      deferred.resolve({ trText: "" });
+      await deferred.promise;
+    });
+    expect(label.classList.contains("MuiInputLabel-shrink")).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("unmounts the handle and ignores pointer moves when blur happens without a drag session", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+
+    // 从未进入拖动会话：失焦后按旧契约卸载，且后续指针移动无效
+    // （无监听器响应，等价于"监听器已移除"的功能性断言）。
+    act(() => {
+      container.querySelector("textarea").blur();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 130));
+    });
+    expect(
+      container.querySelector('[data-testid="trancont-resize-handle"]')
+    ).toBeNull();
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    act(() => root.unmount());
+  });
+
+  test("prevents default on compatible mousedown to guard textarea focus", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const { container, root } = await renderFocusedTranCont();
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // 兼容 mousedown 必须被 preventDefault 抑制（防失焦兜底，与 TranForm
+    // 提交按钮/CopyBtn 同一套先例），且 mousedown 本身不是拖动会话入口。
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      handle.dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  test("keeps resizing after instant blur when prefers-reduced-motion is enabled", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const originalMatchMedia = window.matchMedia;
+    try {
+      window.matchMedia = matchMediaStub(true);
+      const { container, root } = await renderFocusedTranCont();
+      const textField = container.querySelector(".MuiInputBase-root");
+      Object.defineProperty(textField, "offsetHeight", {
+        configurable: true,
+        value: 100,
+      });
+      const handle = container.querySelector(
+        '[data-testid="trancont-resize-handle"]'
+      );
+
+      // 进入拖动会话并移动超过阈值
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      });
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+      });
+      expect(textField.style.height).toBe("120px");
+
+      // 减少动态效果：失焦跳过退出动画立即翻转 visible，活动会话必须存活
+      act(() => {
+        container.querySelector("textarea").blur();
+      });
+      // 拖动继续：高度仍在跟随，且不被 pointer-events 阻断
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+      });
+      expect(textField.style.height).toBe("150px");
+      expect(handle.style.pointerEvents).not.toBe("none");
+
+      // 松手结束会话：按新门控卸载；后续移动不再改变高度
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointerup", { clientY: 50 }));
+      });
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).toBeNull();
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 80 }));
+      });
+      expect(textField.style.height).toBe("150px");
+
+      act(() => root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test("reads prefers-reduced-motion and subscribes/unsubscribes to runtime changes", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const originalMatchMedia = window.matchMedia;
+    const changeHandlers = [];
+    const removeFn = jest.fn();
+    const mql = {
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+      addEventListener: (type, handler) => {
+        if (type === "change") changeHandlers.push(handler);
+      },
+      removeEventListener: removeFn,
+    };
+    window.matchMedia = jest.fn().mockReturnValue(mql);
+
+    try {
+      const { container, root } = await renderFocusedTranCont();
+
+      // 组件确以"减少动态效果"媒体查询读取系统偏好
+      expect(window.matchMedia).toHaveBeenCalledWith(
+        "(prefers-reduced-motion: reduce)"
+      );
+      // TranCont 唯一注册运行时订阅：ResizeHandle 改由 prop 接收偏好值，
+      // 不再内部重复订阅（单一状态真源）。
+      expect(changeHandlers.length).toBe(1);
+
+      act(() => {
+        changeHandlers[0]({ matches: false });
+      });
+      expect(container.querySelector("[data-copy-text]").dataset.copyText).toBe(
+        "译文"
+      );
+
+      act(() => root.unmount());
+      expect(removeFn).toHaveBeenCalledWith("change", expect.any(Function));
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test("does not inject the enter animation when prefers-reduced-motion is enabled", async () => {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const originalMatchMedia = window.matchMedia;
+
+    try {
+      const matchMediaStub = (matches) =>
+        jest.fn().mockReturnValue({
+          matches,
+          media: "(prefers-reduced-motion: reduce)",
+          onchange: null,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        });
+
+      // 未开启减少动态效果：进入动画关键帧应注入
+      window.matchMedia = matchMediaStub(false);
+      apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+      const normal = await renderFocusedTranCont();
+      const normalCopy = normal.container.querySelector("[data-copy-text]");
+      const normalStack = normalCopy.parentElement;
+      const normalClasses = (normalStack.className || "")
+        .split(" ")
+        .filter(Boolean);
+      const normalRules = Array.from(document.styleSheets).flatMap((sheet) => {
+        try {
+          return Array.from(sheet.cssRules);
+        } catch {
+          return [];
+        }
+      });
+      const normalOwnAnimations = normalRules.filter(
+        (rule) =>
+          rule.selectorText &&
+          normalClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(normalOwnAnimations.length).toBeGreaterThan(0);
+      act(() => normal.root.unmount());
+
+      // 开启减少动态效果：该实例的控制组不得注入进入动画关键帧
+      window.matchMedia = matchMediaStub(true);
+      apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+      const reduced = await renderFocusedTranCont();
+      const reducedCopy = reduced.container.querySelector("[data-copy-text]");
+      const reducedStack = reducedCopy.parentElement;
+      const reducedClasses = (reducedStack.className || "")
+        .split(" ")
+        .filter(Boolean);
+      const reducedOwnAnimations = Array.from(document.styleSheets)
+        .flatMap((sheet) => {
+          try {
+            return Array.from(sheet.cssRules);
+          } catch {
+            return [];
+          }
+        })
+        .filter(
+          (rule) =>
+            rule.selectorText &&
+            reducedClasses.some((c) =>
+              rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+            ) &&
+            /transition[^;]*opacity/.test(rule.cssText)
+        );
+      expect(reducedOwnAnimations.length).toBe(0);
+
+      act(() => reduced.root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+});
+
+describe("TranCont embedded border controls", () => {
+  beforeEach(() => {
+    apiTranslate.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 渲染译文框并使其 textarea 聚焦：focus-gating 下复制 rail 与缩放手柄只在聚焦时显示。
+   *
+   * @param {Object} props 覆盖默认组件参数。
+   * @returns {{container: HTMLElement, root: Object, textarea: HTMLTextAreaElement}} 渲染结果。
+   */
+  async function renderFocusedTranCont(props = {}) {
+    apiTranslate.mockResolvedValueOnce({ trText: "译文" });
+    const rendered = renderTranCont(props);
+    await flushEffects();
+    const textarea = rendered.container.querySelector("textarea");
+    act(() => {
+      textarea.focus();
+    });
+    return { ...rendered, textarea };
+  }
+
+  test("resize handle and rail are not shielded by the overlay pointer-events none", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    const rail = container.querySelector('[data-testid="trancont-rail"]');
+    expect(handle).not.toBeNull();
+    expect(rail).not.toBeNull();
+
+    // 覆盖层父级显式 pointer-events: none，控件自身必须内联覆盖为 auto
+    expect(getComputedStyle(handle).pointerEvents).toBe("auto");
+    expect(getComputedStyle(rail).pointerEvents).toBe("auto");
+    expect(getComputedStyle(handle).cursor).toBe("row-resize");
+
+    act(() => root.unmount());
+  });
+
+  test("anchors the resize handle centered on the bottom border", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+
+    // 跨底边框居中：共享中心轴距右边缘 12px，热区宽 16，中心偏移 8
+    expect(parseFloat(handle.style.right)).toBe(CONTROL_CENTER_FROM_RIGHT - 8);
+    expect(parseFloat(handle.style.bottom)).toBe(-8);
+    // jsdom 下桌面命中热区 = 16
+    expect(parseFloat(handle.style.width)).toBe(16);
+    expect(parseFloat(handle.style.height)).toBe(16);
+
+    act(() => root.unmount());
+  });
+
+  test("rail and handle share the same right center axis", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    const rail = container.querySelector('[data-testid="trancont-rail"]');
+
+    // 右上 rail 与缩放手柄均以共享中心轴定位：中心 = right + 自身宽度/2 = CONTROL_CENTER_FROM_RIGHT
+    const railCenter = parseFloat(rail.style.right) + CONTROL_HEIGHT / 2;
+    expect(railCenter).toBe(CONTROL_CENTER_FROM_RIGHT);
+
+    // rail 以顶边为中心垂直居中：top = -CONTROL_HEIGHT/2，中心落在边框线 y=0
+    expect(parseFloat(rail.style.top)).toBe(-Math.round(CONTROL_HEIGHT / 2));
+    expect(parseFloat(rail.style.top) + CONTROL_HEIGHT / 2).toBe(0);
+
+    // 手柄同样以共享中心轴定位（跨底边框居中）
+    const handleCenter =
+      parseFloat(handle.style.right) + parseFloat(handle.style.width) / 2;
+    expect(handleCenter).toBe(CONTROL_CENTER_FROM_RIGHT);
+
+    act(() => root.unmount());
+  });
+
+  test("rail and handle both have notch strips", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const railNotch = container.querySelector(
+      '[data-testid="trancont-rail-notch"]'
+    );
+    expect(railNotch).not.toBeNull();
+    const resizeNotch = container.querySelector(
+      '[data-testid="trancont-resize-notch"]'
+    );
+    expect(resizeNotch).not.toBeNull();
+
+    // rail 遮罩 top 在顶边框线，宽度 = 控件宽度 + 两侧水平 padding
+    expect(parseFloat(railNotch.style.top)).toBe(
+      -Math.round(NOTCH_STRIP_HEIGHT / 2)
+    );
+    expect(parseFloat(railNotch.style.width)).toBe(
+      CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2
+    );
+
+    // 缩放手柄遮罩 bottom 在底边框线，宽度 = 控件宽度 + 两侧水平 padding
+    expect(parseFloat(resizeNotch.style.bottom)).toBe(
+      -Math.round(NOTCH_STRIP_HEIGHT / 2)
+    );
+    expect(parseFloat(resizeNotch.style.width)).toBe(
+      CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2
+    );
+
+    // 两个遮罩条均以 background.paper 主题色遮盖边框
+    const rules = collectRules();
+    const notchPairs = [
+      (railNotch.className || "").split(" ").filter(Boolean),
+      (resizeNotch.className || "").split(" ").filter(Boolean),
+    ];
+    notchPairs.forEach((classes) => {
+      const ownRules = rules.filter(
+        (rule) =>
+          rule.selectorText &&
+          classes.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          rule.cssText.includes("background-color")
+      );
+      expect(ownRules.length).toBeGreaterThan(0);
+      expect(
+        ownRules.every((rule) => !rule.cssText.includes("background.paper"))
+      ).toBe(true);
+    });
+
+    act(() => root.unmount());
+  });
+
+  test("renders the DragIndicatorIcon inside the resize handle", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+    // 六点 DragIndicator 图标渲染在手柄热区内
+    expect(
+      handle.querySelector('[data-testid="DragIndicatorIcon"]')
+    ).not.toBeNull();
+
+    // 不再使用 ::before 折角画线：styleSheets 中不应存在该伪元素的规则
+    const handleClasses = (handle.className || "").split(" ").filter(Boolean);
+    const ownBeforeRules = collectRules().filter(
+      (rule) =>
+        rule.selectorText &&
+        handleClasses.some((c) =>
+          rule.selectorText
+            .split(",")
+            .some((sel) => sel.trim() === `.${c}::before`)
+        )
+    );
+    expect(ownBeforeRules.length).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("hidden state leaves no rail, handle or notch in the DOM", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root, textarea } = await renderFocusedTranCont();
+
+      // 失焦：缩放手柄与 rail-notch 同构，均播放退出动画后卸载（不再瞬时卸载）
+      act(() => {
+        textarea.blur();
+      });
+      // 退出动画期间缩放手柄与 rail-notch 仍在 DOM（淡出中）
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-resize-notch"]')
+      ).not.toBeNull();
+
+      // 退出动画期间 rail 与 notch 仍在 DOM
+      expect(
+        container.querySelector('[data-testid="trancont-rail"]')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-rail-notch"]')
+      ).not.toBeNull();
+
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        container.querySelector('[data-testid="trancont-rail"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-rail-notch"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("plays the rail exit animation on blur and unmounts after 120ms", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root, textarea } = await renderFocusedTranCont();
+
+      act(() => {
+        textarea.blur();
+      });
+
+      // 退出动画期间 rail 仍在 DOM，且注入 opacity/visibility 过渡规则。
+      // 注意：closing 翻转会使 rail 的 emotion 类名变化，须在 blur 后重新取类名过滤。
+      const rail = container.querySelector('[data-testid="trancont-rail"]');
+      expect(rail).not.toBeNull();
+      const railClasses = (rail.className || "").split(" ").filter(Boolean);
+      const ownOutAnimations = collectRules().filter(
+        (rule) =>
+          rule.selectorText &&
+          railClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(ownOutAnimations.length).toBeGreaterThan(0);
+
+      // 缩放手柄同构：失焦后参与退出动画（淡出中仍在 DOM），退出期间禁用命中
+      const exitHandle = container.querySelector(
+        '[data-testid="trancont-resize-handle"]'
+      );
+      expect(exitHandle).not.toBeNull();
+      expect(getComputedStyle(exitHandle).pointerEvents).toBe("none");
+
+      // 退出动画期间 rail 屏蔽指针事件，防止残留按钮被点击触发复制
+      expect(
+        getComputedStyle(
+          container.querySelector('[data-testid="trancont-rail"]')
+        ).pointerEvents
+      ).toBe("none");
+
+      // 120ms 后 rail 与缩放手柄均卸载
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        container.querySelector('[data-testid="trancont-rail"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="trancont-resize-handle"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("removes the rail immediately on blur without exit animation when prefers-reduced-motion is enabled", async () => {
+    const originalMatchMedia = window.matchMedia;
+    try {
+      window.matchMedia = matchMediaStub(true);
+      const { container, root, textarea } = await renderFocusedTranCont();
+      const rail = container.querySelector('[data-testid="trancont-rail"]');
+      const railClasses = (rail.className || "").split(" ").filter(Boolean);
+
+      act(() => {
+        textarea.blur();
+      });
+
+      // reduced-motion：跳过 120ms 滞留，立即卸载
+      expect(
+        container.querySelector('[data-testid="trancont-rail"]')
+      ).toBeNull();
+
+      // 未注入 opacity/visibility 退出过渡（reduced-motion 下 transition: none）
+      const ownOutAnimations = collectRules().filter(
+        (rule) =>
+          rule.selectorText &&
+          railClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(ownOutAnimations.length).toBe(0);
+
+      act(() => root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 解析真实浏览器级联下 fieldset 的 border-width。
+   *
+   * jsdom 的级联按样式表文档顺序解析而不是按选择器特异性，而 emotion 把每条
+   * 规则注入到独立的 <style> 标签，标签顺序随挂载顺序变化（同一 DOM 在不同
+   * 测试文件里的计算值可能不同）。这里取"实际匹配该元素且类数量最多"的选择器
+   * 所声明的 border-width，模拟浏览器的特异性级联，可靠断言聚焦边框宽度。
+   *
+   * @param {HTMLElement} outline .MuiOutlinedInput-notchedOutline 元素。
+   * @returns {string} 胜者规则中声明的 border-width（如 "1px" / "2px"）。
+   */
+  function winningBorderWidth(outline) {
+    const matched = collectRules()
+      .filter((rule) => rule.selectorText && /border-width/.test(rule.cssText))
+      .map((rule) => ({
+        rule,
+        selectors: rule.selectorText.split(",").map((s) => s.trim()),
+      }))
+      .filter(({ selectors }) => selectors.some((sel) => outline.matches(sel)))
+      .map(({ rule, selectors }) => ({
+        rule,
+        classCount: Math.max(
+          ...selectors.map(
+            (sel) => (sel.match(/\.-?[_a-zA-Z][\w-]*/g) || []).length
+          )
+        ),
+      }))
+      .sort((a, b) => b.classCount - a.classCount)[0];
+    expect(matched).toBeDefined();
+    return /border-width:\s*([^;]+)/.exec(matched.rule.cssText)?.[1]?.trim();
+  }
+
+  test("keeps the focused notched outline at 2px border width", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const focusedOutline = container.querySelector(
+      ".MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline"
+    );
+    expect(focusedOutline).not.toBeNull();
+    // 保留 MUI 原生 2px 聚焦边框（键盘焦点可见性，WCAG 2.4.7）；装饰缺口由
+    // NOTCH_STRIP_HEIGHT=4 的遮罩条把两层边框一起清掉，不再用字段局部样式压制。
+    expect(winningBorderWidth(focusedOutline)).toBe("2px");
+
+    act(() => root.unmount());
+  });
+
+  test("keeps rail, handle and notches outside the scrollable input root after a drag", async () => {
+    const { container, root } = await renderFocusedTranCont();
+
+    const textField = container.querySelector(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="trancont-resize-handle"]'
+    );
+
+    // 完成一次超过 6px 阈值的高度拖动，使 resizeHeight 进入受控状态
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    // 受控高度已接管 InputBase 根节点；根节点不持有受控 overflowY
+    // （jsdom/cssstyle 不展开 overflow shorthand，且 MUI TextareaAutosize 会
+    // 每帧重写 textarea.style.overflow——root 级 overflowY 会让可见 textarea
+    // 无法成为唯一滚动容器）
+    expect(textField.style.height).toBe("120px");
+    expect(textField.style.overflowY).toBe("");
+
+    // rail、六点手柄与两处 notch 必须与滚动根节点同级（或其外层），
+    // 祖先链不得包含该滚动节点，否则会被 overflow-y: auto 裁切。
+    for (const testId of [
+      "trancont-rail",
+      "trancont-resize-handle",
+      "trancont-resize-notch",
+    ]) {
+      const node = container.querySelector(`[data-testid="${testId}"]`);
+      expect(node).not.toBeNull();
+      expect(node.closest(".MuiInputBase-root")).toBeNull();
+    }
+
+    act(() => root.unmount());
   });
 });

--- a/src/views/Selection/TranForm.js
+++ b/src/views/Selection/TranForm.js
@@ -22,7 +22,7 @@ import {
   PROMPT_MODE_FOLLOW_API,
   findPromptBySlug,
 } from "../../config";
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useId } from "react";
 import TranCont from "./TranCont";
 import DictCont from "./DictCont";
 import AiDictCont from "./AiDictCont";
@@ -33,6 +33,24 @@ import { isValidWord, isSingleChineseChar } from "../../libs/utils";
 import { kissLog } from "../../libs/log";
 import { tryDetectLang } from "../../libs/detect";
 import { isSameTranslationLanguage } from "../../libs/language";
+import {
+  ResizeHandle,
+  usePrefersReducedMotion,
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "../../components/ResizeHandle";
+import { useTextareaResize } from "../../components/useTextareaResize";
+import { useFocusClosingGate } from "../../components/useFocusClosingGate";
+
+// 控件嵌入边框的共享定位常量（转发导出，供测试与其他调用点从本组件导入）
+export {
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "../../components/ResizeHandle";
 
 /**
  * 翻译交互核心表单组件 (集成源/目标语言选择、多引擎翻译、词典展示、汉典展示、语言检测与文本输入)
@@ -60,11 +78,34 @@ export default function TranForm({
   syncExternalTextWhileEditing = false,
 }) {
   const i18n = useI18n();
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   // 当前是否处于文本框获取焦点的编辑提交模式
   const [editMode, setEditMode] = useState(false);
   // 输入框中临时编辑的文本，在失焦或点击提交时同步至外层全局 text 状态
   const [editText, setEditText] = useState(text);
+  const editTextRef = useRef(editText);
+  editTextRef.current = editText;
+
+  // 唯一焦点退出 gate：TranForm / TranCont 共享的状态机，
+  // 负责 focus-gating（focused）与 120ms 退出过渡（closing）。
+  const {
+    focused: originalFocused,
+    closing,
+    handleFocus: handleFieldFocus,
+    handleBlur: handleFieldBlur,
+  } = useFocusClosingGate({
+    prefersReducedMotion,
+    onTrueBlur: () => {
+      // 提交语义立即生效：真正离开字段时提交当前编辑内容
+      setText(editTextRef.current.trim());
+    },
+    onClosingEnd: () => {
+      // 退出动画到期后 editMode 归位
+      setEditMode(false);
+    },
+  });
+
   const [apiSlugs, setApiSlugs] = useState(initApiSlugs);
   const [hasUserChangedApiSlugs, setHasUserChangedApiSlugs] = useState(false);
   const [fromLang, setFromLang] = useState(initFromLang);
@@ -82,6 +123,19 @@ export default function TranForm({
     loading: false,
   });
   const inputRef = useRef(null);
+  const fieldId = useId();
+  // 原文文本框自定义高度：null 表示仍由 MUI TextareaAutosize 自动测量，
+  // 用户首次拖动后切换为受控高度，后续内容变化不会覆盖用户调整的尺寸。
+  const [resizeHeight, setResizeHeight] = useState(null);
+  // 拖动高度 → TextField 的 minRows/maxRows/根节点高度样式（共享 hook）：
+  // 未拖动时保持自动测量（minRows 随 Playgound 形态、maxRows=10 限制上限），
+  // 拖动后全部释放量化，由像素高度驱动。
+  const { minRows, maxRows, rootStyle } = useTextareaResize(
+    resizeHeight,
+    isPlaygound ? 2 : 1
+  );
+  const originalBoxRef = useRef(null);
+  const showOriginalControls = originalFocused || closing;
 
   const detectionKey = useMemo(
     () => `${langDetector}\u0000${text}`,
@@ -166,9 +220,18 @@ export default function TranForm({
 
   // 从剪贴板粘贴文本到翻译框
   const handlePaste = async () => {
+    // 剪贴板能力守卫：非安全上下文或未实现 readText 的环境直接降级为
+    // 无操作；不依赖异常流作为正常路径。
+    if (typeof navigator.clipboard?.readText !== "function") {
+      return;
+    }
     try {
       const text = await navigator.clipboard.readText();
       setText(text.trim());
+      // 粘贴的内容立即成为当前编辑值并恢复编辑/提交态：粘贴动作等价于
+      // 手动输入，rail 应切回 Done 提交，而非停留在空态粘贴按钮上。
+      setEditText(text.trim());
+      setEditMode(true);
     } catch (err) {
       //
     }
@@ -453,63 +516,135 @@ export default function TranForm({
             </Grid>
           </Box>
 
-          {/* 原始文本输入区域 */}
-          <Box>
+          {/* 原始文本输入区域：onBlur 挂在包装层（焦点保活见 handleFieldBlur） */}
+          <Box
+            ref={originalBoxRef}
+            sx={{ position: "relative" }}
+            onBlur={handleFieldBlur}
+          >
             <TextField
+              id={fieldId}
               size="small"
               label={i18n("original_text")}
               fullWidth
               multiline
               inputRef={inputRef}
-              minRows={isPlaygound ? 2 : 1}
-              maxRows={10}
+              minRows={minRows}
+              maxRows={maxRows}
               sx={{
-                "& textarea": {
-                  resize: "vertical",
+                "& textarea:not([aria-hidden='true'])": {
+                  boxSizing: "border-box",
+                  maxHeight: "100%",
+                  resize: "none",
+                  ...(resizeHeight != null
+                    ? { overflow: "auto !important" }
+                    : {}),
                 },
               }}
               value={editText}
               onChange={(e) => {
                 setEditText(e.target.value);
-              }}
-              onFocus={() => {
+                // 打字即进入编辑态：提交后焦点仍保留在 textarea，
+                // 继续输入必须恢复 Done 提交态
                 setEditMode(true);
               }}
-              // REVIEW: TextField 的 onBlur 会立即触发 setEditMode(false) 并提交数据，而 DoneIcon 的 onClick 也会执行相同逻辑。这会在点击提交按钮时产生多余重入。更关键的是，在某些系统或移动端环境下，onBlur 优先于 click 触发会使 EditMode 瞬间置为 false，导致 DoneIcon 被提早销毁而无法正常响应 onClick 事件。建议在图标按钮上改用 onMouseDown + preventDefault，或使用 onCommit 统一提交通道。
-              onBlur={() => {
-                setEditMode(false);
-                setText(editText.trim());
+              onFocus={() => {
+                handleFieldFocus();
+                setEditMode(true);
               }}
               InputProps={{
-                endAdornment: (
+                style: {
+                  paddingRight: 14,
+                  ...(rootStyle || {}),
+                },
+              }}
+            />
+            {/* 覆盖层：与可能设置 overflow-y: auto 的输入根节点同级，避免滚动裁切
+                控件（rail / 六点手柄 / 两处 notch 不再位于滚动根节点内部），
+                也避免滚动时覆盖层随内容滚走。几何相对本包装层，
+                其外框与输入根节点完全重合。 */}
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                pointerEvents: "none",
+              }}
+            >
+              {/* 右上角操作区：聚焦显示（编辑态提交，有内容非编辑复制，空态粘贴）；失焦播放退出动画后卸载 */}
+              {showOriginalControls && (
+                <>
+                  {/* Notch 遮罩条：覆盖顶边框线段，形成 notch 效果 */}
+                  <Box
+                    data-testid="tranform-rail-notch"
+                    style={{
+                      position: "absolute",
+                      right:
+                        CONTROL_CENTER_FROM_RIGHT -
+                        CONTROL_HEIGHT / 2 -
+                        NOTCH_HORIZONTAL_PAD,
+                      top: -Math.round(NOTCH_STRIP_HEIGHT / 2),
+                      width: CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2,
+                      height: NOTCH_STRIP_HEIGHT,
+                    }}
+                    sx={{
+                      backgroundColor: "background.paper",
+                      zIndex: 1,
+                      // 与 rail 统一为同一套 opacity + visibility 过渡（120ms）
+                      opacity: closing ? 0 : 1,
+                      visibility: closing ? "hidden" : "visible",
+                      transition: prefersReducedMotion
+                        ? "none"
+                        : "opacity 120ms ease, visibility 120ms ease",
+                    }}
+                  />
                   <Stack
                     direction="row"
-                    sx={{
+                    data-testid="tranform-rail"
+                    style={{
                       position: "absolute",
-                      right: 0,
-                      top: 0,
+                      right: CONTROL_CENTER_FROM_RIGHT - CONTROL_HEIGHT / 2,
+                      top: -Math.round(CONTROL_HEIGHT / 2),
+                      // 进入态保持 auto 以便命中；closing 期间屏蔽点击，防止残留按钮被触发
+                      pointerEvents: closing ? "none" : "auto",
+                    }}
+                    sx={{
+                      zIndex: 2,
+                      // 与边框变色 / 缩放手柄统一为同一套 opacity + visibility 过渡（120ms）
+                      opacity: closing ? 0 : 1,
+                      visibility: closing ? "hidden" : "visible",
+                      transition: prefersReducedMotion
+                        ? "none"
+                        : "opacity 120ms ease, visibility 120ms ease",
                     }}
                   >
-                    {editMode ? (
-                      /* 编辑模式：显示提交勾选图标 */
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setEditMode(false);
-                          setText(editText.trim());
-                        }}
-                        title={i18n("submit")}
-                      >
-                        <DoneIcon fontSize="inherit" />
-                      </IconButton>
-                    ) : text ? (
-                      /* 有内容时：显示一键复制按钮 */
-                      <CopyBtn text={text} title={i18n("copy")} />
+                    {editText.trim() ? (
+                      editMode ? (
+                        /* 编辑模式：显示提交勾选图标 */
+                        <IconButton
+                          size="small"
+                          aria-label={i18n("submit")}
+                          // 鼠标按下时阻止默认行为，避免 textarea 先失焦卸载按钮，保证 onClick 正常触发
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditMode(false);
+                            setText(editText.trim());
+                          }}
+                          title={i18n("submit")}
+                        >
+                          <DoneIcon fontSize="inherit" />
+                        </IconButton>
+                      ) : (
+                        /* 有内容且非编辑态：显示一键复制按钮（复制当前编辑缓冲，
+                           聚焦后未提交的改动同样被复制） */
+                        <CopyBtn text={editText} title={i18n("copy")} />
+                      )
                     ) : (
-                      /* 无内容时：显示一键粘贴按钮 */
+                      /* 空缓冲：显示一键粘贴按钮（同样阻止 mousedown 失焦） */
                       <IconButton
                         size="small"
+                        aria-label={i18n("paste")}
+                        onMouseDown={(e) => e.preventDefault()}
                         onClick={handlePaste}
                         title={i18n("paste")}
                       >
@@ -517,9 +652,29 @@ export default function TranForm({
                       </IconButton>
                     )}
                   </Stack>
-                ),
-              }}
-            />
+                </>
+              )}
+              {/* 右下角纵向缩放手柄：内容门控依据当前编辑值 editText.trim()（而非
+                  已提交的 text），空框输入立即可调、清空已有内容立即隐藏；
+                  已有手动高度（resizeHeight）本身也构成显示手柄的理由——
+                  清空内容后手柄常驻，可拖回最小完成复位。 */}
+              <ResizeHandle
+                visible={Boolean(
+                  (originalFocused || closing) &&
+                    (editText.trim() || resizeHeight != null)
+                )}
+                closing={closing}
+                height={resizeHeight}
+                containerRef={originalBoxRef}
+                onHeightChange={setResizeHeight}
+                prefersReducedMotion={prefersReducedMotion}
+                controlsId={fieldId}
+                title={i18n("field_resize_height")}
+                ariaLabel={i18n("field_resize_height")}
+                testId="tranform-resize-handle"
+                notchTestId="tranform-resize-notch"
+              />
+            </Box>
           </Box>
         </>
       )}

--- a/src/views/Selection/TranForm.test.js
+++ b/src/views/Selection/TranForm.test.js
@@ -1,6 +1,15 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import TranForm from "./TranForm";
+import TranForm, {
+  CONTROL_HEIGHT,
+  CONTROL_CENTER_FROM_RIGHT,
+  NOTCH_STRIP_HEIGHT,
+  NOTCH_HORIZONTAL_PAD,
+} from "./TranForm";
+import {
+  MIN_RESIZE_HEIGHT,
+  KEYBOARD_RESIZE_STEP,
+} from "../../components/ResizeHandle";
 import { apiDict } from "../../apis";
 import { tryDetectLang } from "../../libs/detect";
 
@@ -10,9 +19,12 @@ jest.mock("../../apis", () => ({
   apiDict: jest.fn(),
 }));
 
-jest.mock("../../hooks/I18n", () => ({
-  useI18n: () => (key, fallback) => fallback || key,
-}));
+jest.mock("../../hooks/I18n", () => {
+  const { newI18n } = jest.requireActual("../../config");
+  return {
+    useI18n: () => newI18n("en"),
+  };
+});
 
 jest.mock("../../libs/detect", () => ({
   tryDetectLang: jest.fn(async () => "en"),
@@ -67,7 +79,12 @@ jest.mock("./AudioBtn", () => {
 jest.mock("./CopyBtn", () => {
   const React = require("react");
 
-  return () => React.createElement("button", { type: "button" }, "copy");
+  return ({ text }) =>
+    React.createElement(
+      "button",
+      { type: "button", "data-copy-text": text },
+      "copy"
+    );
 });
 
 async function flushEffects() {
@@ -77,6 +94,9 @@ async function flushEffects() {
   });
 }
 
+/**
+ * 构造一个可手动 resolve / reject 的 Promise，用于测试中精确控制异步完成时机。
+ */
 function createDeferred() {
   let resolve;
   let reject;
@@ -85,6 +105,44 @@ function createDeferred() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+/**
+ * 读取所有 Emotion 样式表规则文本（speedy 模式下规则通过 insertRule 写入
+ * sheet.cssRules，textContent 为空；两者优先读取）。
+ *
+ * @returns {string} 合并后的 CSS 文本。
+ */
+function emotionCssText() {
+  const tags = Array.from(document.querySelectorAll("style[data-emotion]"));
+  return tags
+    .flatMap((tag) => {
+      const rules = tag.sheet && tag.sheet.cssRules;
+      if (rules && rules.length) {
+        return Array.from(rules).map((r) => r.cssText || "");
+      }
+      return [tag.textContent || ""];
+    })
+    .join("\n");
+}
+
+/**
+ * 构造 prefers-reduced-motion 的 matchMedia stub。
+ *
+ * @param {boolean} matches 是否开启"减少动态效果"。
+ * @returns {Function} 可赋给 window.matchMedia 的 jest mock。
+ */
+function matchMediaStub(matches) {
+  return jest.fn().mockReturnValue({
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  });
 }
 
 function renderTranForm(props = {}) {
@@ -541,6 +599,2968 @@ describe("TranForm input focus and external text synchronization", () => {
       await Promise.resolve();
     });
     expect(setText).toHaveBeenLastCalledWith("bug");
+    act(() => root.unmount());
+  });
+
+  test("reduced-motion true blur resets editMode so external text keeps syncing", async () => {
+    // N7 系统回归：开启"减少动态效果"后真离场，editMode 必须随同步关闭归位，
+    // 否则外部划词 text 永久无法刷新输入框（§1.4 用户路径）。
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = matchMediaStub(true);
+    try {
+      const setText = jest.fn();
+      const props = {
+        text: "first",
+        setText,
+        apiSlugs: [],
+        fromLang: "en",
+        toLang: "zh-CN",
+        toLang2: "-",
+        transApis: [],
+        simpleStyle: false,
+        langDetector: "-",
+        enDict: "-",
+        enSug: "-",
+        aiDictApiSlug: "-",
+        autoFocusInput: false,
+      };
+      const { container, root } = renderTranForm(props);
+      await flushEffects();
+
+      const input = container.querySelector("textarea");
+      act(() => {
+        input.focus();
+      });
+
+      // 编辑（原生 value setter 触发受控 onChange → setEditMode(true)）
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value"
+      ).set;
+      act(() => {
+        setter.call(input, "edited");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+      // 真离场（relatedTarget=null）：立即提交
+      await act(async () => {
+        input.blur();
+        await Promise.resolve();
+      });
+      expect(setText).toHaveBeenLastCalledWith("edited");
+
+      // 外部划词更新 text：输入框必须同步新词
+      act(() => {
+        root.render(<TranForm {...props} text="second word" />);
+      });
+      await flushEffects();
+      expect(container.querySelector("textarea").value).toBe("second word");
+
+      act(() => root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+      // 防御性恢复真实 timers（AGENTS §五.2 C 类模板的收尾形态）。静态已证本用例
+      // 不创建也不继承 fake timers：文件内 10 处 useFakeTimers 均 try/finally 成对
+      // （:576→:606 等）、无 setupTests.js 全局配置、目标 describe（:408）在所有
+      // timer 用例（:524 起）之前执行——此处非正确性必需，属卫生性收尾。
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe("TranForm original text edit and submit controls", () => {
+  beforeEach(() => {
+    apiDict.mockReset();
+    tryDetectLang.mockResolvedValue("en");
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 构造一个带 touches 数组的触摸事件。
+   *
+   * @param {Array<{clientY: number}>} touches 触点数组。
+   * @returns {Event} 可被 React 与 jsdom 识别的触摸事件。
+   */
+  function makeTouchEvent(type, touches) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "touches", { value: touches });
+    Object.defineProperty(event, "targetTouches", { value: touches });
+    return event;
+  }
+
+  /**
+   * 使用原生 value setter 修改受控 textarea 的值并触发 React onChange。
+   *
+   * @param {HTMLTextAreaElement} input textarea 元素。
+   * @param {string} value 新值。
+   */
+  function changeInputValue(input, value) {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value"
+    ).set;
+    act(() => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  test("shows the submit button while editing and hides everything on blur", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root } = renderTranForm({
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+      // 失焦时整个右上操作组卸载，不留可命中热区
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+
+      act(() => {
+        input.focus();
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+
+      // 失焦：rail 播放退出动画，120ms 内仍滞留
+      act(() => {
+        input.blur();
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+
+      // 退出动画结束后控件卸载
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("clicking submit keeps focus on the textarea and commits exactly once", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "hello",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+
+    act(() => {
+      input.focus();
+    });
+    changeInputValue(input, "  hello world  ");
+
+    // 浏览器真实事件顺序：按钮 mousedown 先于任何 blur 发生。
+    // onMouseDown 的 preventDefault 阻止 textarea 因按下按钮而失焦，
+    // 因此随后不会触发卸载打勾按钮的 blur。
+    const submit = container.querySelector('[aria-label="Submit"]');
+    act(() => {
+      submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(document.activeElement).toBe(input);
+    expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+
+    await act(async () => {
+      submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+    expect(setText).toHaveBeenCalledWith("hello world");
+    // 提交后退出编辑模式，打勾按钮不再渲染
+    expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("blur arriving between mousedown and click does not double-commit", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const setText = jest.fn();
+      const { container, root } = renderTranForm({
+        text: "hello",
+        setText,
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+
+      act(() => {
+        input.focus();
+      });
+      changeInputValue(input, "  hello world  ");
+
+      const submit = container.querySelector('[aria-label="Submit"]');
+      // 最坏事件时序：mousedown 触发后，blur 仍抢先发生（例如键盘焦点转移）。
+      act(() => {
+        submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      await act(async () => {
+        input.blur();
+        await Promise.resolve();
+      });
+      // blur 路径已经完成唯一一次 trim 提交
+      expect(setText).toHaveBeenCalledTimes(1);
+      expect(setText).toHaveBeenCalledWith("hello world");
+
+      // 推进退出动画：submit 随 rail 卸载而脱离 DOM，迟到 click 不再触发二次提交
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      // 后续 click 落在已卸载的旧节点上，不应产生第二次提交
+      act(() => {
+        submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(setText).toHaveBeenCalledTimes(1);
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("blur and explicit submit share the same trimmed commit path", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "hello",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+
+    // 失焦提交：一次操作只产生一次有效更新，且执行首尾空白处理
+    act(() => {
+      input.focus();
+    });
+    changeInputValue(input, "  blur commit  ");
+    await act(async () => {
+      input.blur();
+      await Promise.resolve();
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+    expect(setText).toHaveBeenLastCalledWith("blur commit");
+
+    act(() => root.unmount());
+  });
+
+  test("clearing the buffer switches the rail to paste immediately and unmounts on blur", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const setText = jest.fn();
+      const { container, root } = renderTranForm({
+        text: "hello",
+        setText,
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+
+      act(() => {
+        input.focus();
+      });
+      // 清空缓冲：rail 立即切换为空态粘贴（内容随编辑缓冲真源，无需先提交空串）
+      changeInputValue(input, "");
+      expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+
+      // 失焦：退出动画期间 rail 内容仍是 Paste（随缓冲），120ms 后卸载不留热区
+      act(() => {
+        input.blur();
+      });
+      expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(container.querySelector('[aria-label="Paste"]')).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("shows paste, copy, submit and the resize handle only while focused", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      // 记录父组件最新 text，模拟 setText 生效后的父组件重渲染
+      let committed = "";
+      const setText = jest.fn().mockImplementation((next) => {
+        committed = next;
+      });
+      const { container, root } = renderTranForm({
+        text: "",
+        setText,
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+
+      // 失焦空态：粘贴、提交、复制与缩放手柄全部卸载，不留可命中热区
+      expect(container.querySelector('[aria-label="Paste"]')).toBeNull();
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+
+      // 聚焦空缓冲：右上切换为粘贴，缩放手柄仍隐藏
+      act(() => {
+        input.focus();
+      });
+      expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+
+      // 输入内容并通过打勾按钮提交（mousedown 阻止失焦）：焦点保留、退出编辑态
+      changeInputValue(input, "hello");
+      const submit = container.querySelector('[aria-label="Submit"]');
+      await act(async () => {
+        submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      act(() => {
+        root.render(
+          <TranForm
+            text={committed}
+            setText={setText}
+            apiSlugs={[]}
+            fromLang="en"
+            toLang="zh-CN"
+            toLang2="-"
+            transApis={[]}
+            simpleStyle={false}
+            autoFocusInput={false}
+            langDetector="-"
+            enDict="Bing"
+            enSug="-"
+            aiDictApiSlug="-"
+          />
+        );
+      });
+      await flushEffects();
+
+      // 聚焦且有已提交内容、非编辑态：显示复制和缩放手柄
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(true);
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).not.toBeNull();
+
+      // 失焦：缩放手柄与复制 rail 同构，均播放退出动画后卸载（不再瞬时卸载）
+      act(() => {
+        input.blur();
+      });
+      // 退出动画期间复制按钮与缩放手柄仍在 DOM（淡出中）
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(true);
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).not.toBeNull();
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+
+      // 再次聚焦有内容：进入编辑态显示提交；右下缩放手柄在聚焦且有内容时显示
+      act(() => {
+        input.focus();
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).not.toBeNull();
+
+      // 编辑态清空：rail 立即恢复为空态粘贴（焦点保留，无需先提交空串）
+      changeInputValue(input, "");
+      act(() => {
+        root.render(
+          <TranForm
+            text={committed}
+            setText={setText}
+            apiSlugs={[]}
+            fromLang="en"
+            toLang="zh-CN"
+            toLang2="-"
+            transApis={[]}
+            simpleStyle={false}
+            autoFocusInput={false}
+            langDetector="-"
+            enDict="Bing"
+            enSug="-"
+            aiDictApiSlug="-"
+          />
+        );
+      });
+      await flushEffects();
+      expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("typing again after a Done submit restores the edit mode and keeps new characters", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      let committed = "";
+      const setText = jest.fn().mockImplementation((next) => {
+        committed = next;
+      });
+      const { container, root } = renderTranForm({
+        text: "hello",
+        setText,
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+
+      act(() => {
+        input.focus();
+      });
+      // 编辑并点击勾选提交（Done 的 mousedown preventDefault 保持 textarea 焦点）
+      changeInputValue(input, "hello world");
+      const submit = container.querySelector('[aria-label="Submit"]');
+      await act(async () => {
+        submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      expect(committed).toBe("hello world");
+
+      // 真实父组件把提交值回写回 TranForm
+      act(() => {
+        root.render(
+          <TranForm
+            text={committed}
+            setText={setText}
+            apiSlugs={[]}
+            fromLang="en"
+            toLang="zh-CN"
+            toLang2="-"
+            transApis={[]}
+            simpleStyle={false}
+            autoFocusInput={false}
+            langDetector="-"
+            enDict="Bing"
+            enSug="-"
+            aiDictApiSlug="-"
+          />
+        );
+      });
+      await flushEffects();
+
+      // 提交后非编辑态：rail 显示复制
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(true);
+
+      // Done 的 mousedown preventDefault 使焦点保留在 textarea，继续输入
+      expect(document.activeElement).toBe(input);
+      changeInputValue(input, "hello world!  ");
+      expect(input.value).toBe("hello world!  ");
+
+      // 继续输入必须恢复编辑/提交态（onChange 应调用 setEditMode(true)）
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("pasting restores the edit mode and keeps the rail in the Done submit state", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      let committed = "hello";
+      const setText = jest.fn().mockImplementation((next) => {
+        committed = next;
+      });
+      const { container, root } = renderTranForm({
+        text: committed,
+        setText,
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      const input = container.querySelector("textarea");
+
+      act(() => {
+        input.focus();
+      });
+      // 清空缓冲：rail 立即切换为空态粘贴（无需先提交空串）
+      changeInputValue(input, "");
+      act(() => {
+        root.render(
+          <TranForm
+            text={committed}
+            setText={setText}
+            apiSlugs={[]}
+            fromLang="en"
+            toLang="zh-CN"
+            toLang2="-"
+            transApis={[]}
+            simpleStyle={false}
+            autoFocusInput={false}
+            langDetector="-"
+            enDict="Bing"
+            enSug="-"
+            aiDictApiSlug="-"
+          />
+        );
+      });
+      await flushEffects();
+
+      // 空态非编辑聚焦：rail 显示粘贴按钮
+      expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+
+      // stub 剪贴板：点击粘贴后必须恢复编辑/提交态
+      const originalClipboard = global.navigator.clipboard;
+      global.navigator.clipboard = {
+        readText: jest.fn().mockResolvedValue("  pasted text  "),
+      };
+      try {
+        await act(async () => {
+          const pasteBtn = container.querySelector('[aria-label="Paste"]');
+          pasteBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      } finally {
+        global.navigator.clipboard = originalClipboard;
+      }
+
+      // 父组件收到 trim 后的粘贴文本
+      expect(setText).toHaveBeenLastCalledWith("pasted text");
+      // 粘贴后 rail 必须进入编辑/提交态（handlePaste 应 setEditMode(true)）
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Paste"]')).toBeNull();
+      expect(input.value).toBe("pasted text");
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("copy in the non-edit rail copies the current edit buffer", async () => {
+    let committed = "hello";
+    const setText = jest.fn().mockImplementation((next) => {
+      committed = next;
+    });
+    const { container, root } = renderTranForm({
+      text: committed,
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+
+    act(() => {
+      input.focus();
+    });
+    // 编辑缓冲后提交退出编辑态：非编辑 rail 显示复制按钮，复制源为当前缓冲
+    changeInputValue(input, "hello world");
+    const submit = container.querySelector('[aria-label="Submit"]');
+    await act(async () => {
+      submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    // 父组件回写提交文本后重渲染（非编辑态 editText 从 text 同步）
+    act(() => {
+      root.render(
+        <TranForm
+          text={committed}
+          setText={setText}
+          apiSlugs={[]}
+          fromLang="en"
+          toLang="zh-CN"
+          toLang2="-"
+          transApis={[]}
+          simpleStyle={false}
+          autoFocusInput={false}
+          langDetector="-"
+          enDict="Bing"
+          enSug="-"
+          aiDictApiSlug="-"
+        />
+      );
+    });
+    await flushEffects();
+    const copyBtn = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "copy"
+    );
+    expect(copyBtn).toBeDefined();
+    expect(copyBtn.dataset.copyText).toBe("hello world");
+
+    // 提交后继续输入回到编辑态：rail 切回提交按钮，复制按钮消失
+    changeInputValue(input, "hello world!");
+    expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+    expect(
+      [...container.querySelectorAll("button")].some(
+        (button) => button.textContent === "copy"
+      )
+    ).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("copy reflects the synced external text after done without a parent re-render", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "hello",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+
+    act(() => {
+      input.focus();
+    });
+    // 输入带尾随空格的缓冲并点 Done：父组件 setText 被调用，但 harness 不回写
+    // 重渲染（text prop 恒为 "hello"）
+    changeInputValue(input, "hello ");
+    const submit = container.querySelector('[aria-label="Submit"]');
+    await act(async () => {
+      submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    // 稳态恒等回归锁（预期通过，非缺陷修复）：Done 翻转 editMode 后，同步
+    // effect 以外部 text 归位 editText，非编辑 rail 的复制缓冲不残留尾随空格
+    await flushEffects();
+    const copyBtn = container.querySelector("[data-copy-text]");
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.dataset.copyText).toBe("hello");
+
+    act(() => root.unmount());
+  });
+
+  test("paste is harmless when the clipboard API is unavailable", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+
+    // 空框聚焦：rail 直接显示粘贴按钮（空缓冲即 Paste，无需先提交空串）
+    act(() => {
+      input.focus();
+    });
+    expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+    // 聚焦本身不触发 setText，以该基线计数判定粘贴是否额外回写
+    const setTextCallsAfterSetup = setText.mock.calls.length;
+
+    // 剪贴板能力缺失（非安全上下文等）：粘贴必须无操作、无 unhandled rejection
+    const originalClipboard = global.navigator.clipboard;
+    global.navigator.clipboard = undefined;
+    const unhandled = [];
+    const onUnhandled = (reason) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await act(async () => {
+        const pasteBtn = container.querySelector('[aria-label="Paste"]');
+        pasteBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandled);
+      global.navigator.clipboard = originalClipboard;
+    }
+
+    expect(unhandled.length).toBe(0);
+    // 不得改动文本或翻回编辑态
+    expect(setText.mock.calls.length).toBe(setTextCallsAfterSetup);
+    expect(input.value).toBe("");
+    expect(container.querySelector('[aria-label="Paste"]')).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("resize handle appears as soon as the box has content and hides when cleared (gated on editText)", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+    const handleSel = '[data-testid="tranform-resize-handle"]';
+
+    // 空框聚焦：缩放手柄隐藏（无内容）
+    act(() => {
+      input.focus();
+    });
+    expect(container.querySelector(handleSel)).toBeNull();
+
+    // 空框输入内容：手柄立即出现（即使父组件 text 仍为空，门控依据 editText）
+    changeInputValue(input, "abc");
+    expect(container.querySelector(handleSel)).not.toBeNull();
+
+    // 清空已有内容：手柄立即隐藏（依据当前 editText.trim()）
+    changeInputValue(input, "");
+    expect(container.querySelector(handleSel)).toBeNull();
+
+    act(() => root.unmount());
+  });
+});
+
+describe("TranForm original text ResizeHandle", () => {
+  beforeEach(() => {
+    apiDict.mockReset();
+    tryDetectLang.mockResolvedValue("en");
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 构造一个带 touches 数组的触摸事件。
+   *
+   * @param {Array<{clientY: number, identifier?: number}>} touches 当前触点数组。
+   * @param {Object} [opts] 可选参数。
+   * @param {Array<{identifier?: number}>} [opts.changedTouches] 结算触点数组
+   *   （touchend/touchcancel 传入），缺省时与 touches 相同。
+   * @returns {Event} 可被 React 与 jsdom 识别的触摸事件。
+   */
+  function makeTouchEvent(type, touches, { changedTouches } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "touches", { value: touches });
+    Object.defineProperty(event, "targetTouches", { value: touches });
+    Object.defineProperty(event, "changedTouches", {
+      value: changedTouches !== undefined ? changedTouches : touches,
+    });
+    return event;
+  }
+
+  /**
+   * 渲染原文输入框并使其聚焦：focus-gating 下操作组与缩放手柄只在聚焦时显示。
+   *
+   * @param {Object} props 覆盖默认组件参数（默认 text="hello"）。
+   * @returns {{container: HTMLElement, root: Object, input: HTMLTextAreaElement}} 渲染结果与 textarea。
+   */
+  async function renderFocusedForm(props = {}) {
+    const rendered = renderTranForm({
+      text: "hello",
+      simpleStyle: false,
+      autoFocusInput: false,
+      ...props,
+    });
+    await flushEffects();
+    const input = rendered.container.querySelector("textarea");
+    act(() => {
+      input.focus();
+    });
+    return { ...rendered, input };
+  }
+
+  test("does not resize within the 6px threshold and resizes above it", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    // TranForm 同时渲染语言下拉等 TextField，必须定位包含原文 textarea 的 InputBase
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+
+    // 纵向移动 6px 内：不进入高度调整
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 6 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    // 超过 6px 后启动高度调整（100 + 7 = 107）
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 7 }));
+    });
+    expect(textField.style.height).toBe("107px");
+
+    // 继续拖动继续调整（100 + 20 = 120）
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    expect(textField.style.height).toBe("120px");
+
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 20 }));
+    });
+    act(() => root.unmount());
+  });
+
+  test("touch path also applies the 6px threshold", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    await act(async () => {
+      handle.dispatchEvent(makeTouchEvent("touchstart", [{ clientY: 0 }]));
+    });
+    // 手指抖动 5px：低于阈值，不改变高度
+    await act(async () => {
+      window.dispatchEvent(makeTouchEvent("touchmove", [{ clientY: 5 }]));
+    });
+    expect(textField.style.height).toBe("");
+
+    // 超过 6px 后 touch 路径同样启动（100 + 8 = 108）
+    await act(async () => {
+      window.dispatchEvent(makeTouchEvent("touchmove", [{ clientY: 8 }]));
+    });
+    expect(textField.style.height).toBe("108px");
+
+    await act(async () => {
+      window.dispatchEvent(new Event("touchend"));
+    });
+    act(() => root.unmount());
+  });
+
+  test("continues resizing based on the active touch when a second touch is inserted or reordered", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 活动触点 identifier=1 发起拖动，第二个触点 identifier=2 随后加入
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+    // 第二触点排在最前移动（顺序变化），高度仍必须跟随触点 1
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [
+          { clientY: 90, identifier: 2 },
+          { clientY: 20, identifier: 1 },
+        ])
+      );
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 第二触点继续移动不影响高度
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [
+          { clientY: 40, identifier: 2 },
+          { clientY: 20, identifier: 1 },
+        ])
+      );
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 活动触点进一步移动仍生效（100 + 40 = 140）
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [
+          { clientY: 40, identifier: 2 },
+          { clientY: 40, identifier: 1 },
+        ])
+      );
+    });
+    expect(textField.style.height).toBe("140px");
+
+    // 活动触点结束
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], { changedTouches: [{ identifier: 1 }] })
+      );
+    });
+    act(() => root.unmount());
+  });
+
+  test("a non-active touch ending does not end or corrupt the active resize session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [
+          { clientY: 20, identifier: 1 },
+          { clientY: 5, identifier: 2 },
+        ])
+      );
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 非活动触点（identifier=2）抬起：不得结束活动会话
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [{ identifier: 1 }], {
+          changedTouches: [{ identifier: 2 }],
+        })
+      );
+    });
+    // 活动触点继续移动仍改变高度，会话未被非活动触点接管（100 + 30 = 130）
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 30, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // 活动触点结束
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], {
+          changedTouches: [{ identifier: 1 }],
+        })
+      );
+    });
+    // 会话结束后后续 move 不再生效
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 50, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    act(() => root.unmount());
+  });
+
+  test("active touchcancel and unmount stop further height changes", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // touchcancel：活动触点被系统取消，会话必须结束
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 30, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchcancel", [], {
+          changedTouches: [{ identifier: 1 }],
+        })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 50, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // 新会话开始：第二轮以第一次结束时的受控高度 130px 为基线，
+    // start -> active touchend 后 move 不再生效
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 25, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("155px");
+
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], { changedTouches: [{ identifier: 1 }] })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 60, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("155px");
+
+    act(() => root.unmount());
+  });
+
+  test("matched touchmove is default-prevented while stranger touches are not", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    // 必须经 textarea.closest 定位原文 InputBase：直接以
+    // container.querySelector(".MuiInputBase-root") 查询时首匹配命中的是
+    // apiSlugs 多选下拉根节点，offsetHeight 桩与 style 断言会双双落错节点
+    //（本套件统一采用 closest 定位模式，见首用例告诫注释）。
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 进入 Touch 会话（发起触点 identifier=1）
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+
+    // ①命中发起触点的 touchmove：必须 preventDefault（页面防滚）且高度跟随
+    const matched = makeTouchEvent("touchmove", [
+      { clientY: 30, identifier: 1 },
+    ]);
+    await act(async () => {
+      window.dispatchEvent(matched);
+    });
+    expect(matched.defaultPrevented).toBe(true);
+    expect(textField.style.height).toBe("130px");
+
+    // ②仅含非发起触点的 touchmove：不得 preventDefault、不得改高度
+    //（保留用户以其余手指滚动页面的能力）
+    const stranger = makeTouchEvent("touchmove", [
+      { clientY: 60, identifier: 2 },
+    ]);
+    await act(async () => {
+      window.dispatchEvent(stranger);
+    });
+    expect(stranger.defaultPrevented).toBe(false);
+    expect(textField.style.height).toBe("130px");
+
+    // 会话结束（监听撤除）后：move 不再 preventDefault、不再改高度
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], {
+          changedTouches: [{ identifier: 1 }],
+        })
+      );
+    });
+    const after = makeTouchEvent("touchmove", [
+      { clientY: 90, identifier: 1 },
+    ]);
+    await act(async () => {
+      window.dispatchEvent(after);
+    });
+    expect(after.defaultPrevented).toBe(false);
+    expect(textField.style.height).toBe("130px");
+
+    act(() => root.unmount());
+  });
+
+  test("a second pointer's move and up do not hijack or end the active session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 发起指针 pointerId=1 建立 Pointer 会话
+    await act(async () => {
+      handle.dispatchEvent(
+        makePointerEvent("pointerdown", { clientY: 0, pointerId: 1 })
+      );
+    });
+
+    // 第二指针 pointerId=2 的移动不得改变高度
+    await act(async () => {
+      window.dispatchEvent(
+        makePointerEvent("pointermove", { clientY: 40, pointerId: 2 })
+      );
+    });
+    expect(textField.style.height).toBe("");
+
+    // 第二指针抬起不得结束会话
+    await act(async () => {
+      window.dispatchEvent(
+        makePointerEvent("pointerup", { clientY: 40, pointerId: 2 })
+      );
+    });
+
+    // 发起指针继续移动仍然生效
+    await act(async () => {
+      window.dispatchEvent(
+        makePointerEvent("pointermove", { clientY: 20, pointerId: 1 })
+      );
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 发起指针 pointerup(pointerId=1) 才结束会话
+    await act(async () => {
+      window.dispatchEvent(
+        makePointerEvent("pointerup", { clientY: 20, pointerId: 1 })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makePointerEvent("pointermove", { clientY: 60, pointerId: 1 })
+      );
+    });
+    expect(textField.style.height).toBe("120px");
+
+    act(() => root.unmount());
+  });
+
+  test("a second finger touchend does not end an active pointer session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 发起指针建立 Pointer 会话并拖出阈值
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 30 }));
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // Pointer 会话期间第二指 touchend（无 touches、结算其他 identifier）
+    // 不得终止会话
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], {
+          changedTouches: [{ identifier: 2 }],
+        })
+      );
+    });
+
+    // 指针 1 继续移动仍然生效
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+    });
+    expect(textField.style.height).toBe("150px");
+
+    // 发起指针 pointerup(pointerId=1) 才结束会话
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 50 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 80 }));
+    });
+    expect(textField.style.height).toBe("150px");
+
+    act(() => root.unmount());
+  });
+
+  test("a stray pointerup does not end an active touch session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 发起触点 identifier=1 建立 Touch 会话并拖出阈值
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 30, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // Touch 会话期间杂散 pointerup（鼠标/第二设备）不得终止会话
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 30 }));
+    });
+
+    // 发起触点继续移动仍然生效
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 50, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("150px");
+
+    // 发起触点 touchend 才结束会话
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], {
+          changedTouches: [{ identifier: 1 }],
+        })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 80, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("150px");
+
+    act(() => root.unmount());
+  });
+
+  test("drag height lands on the InputBase root and the visible textarea scrolls internally", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 拖动 200px：受控像素高度 300px 直接落在 InputBase 根节点（已超过
+    // 10 行高度，maxRows 钳制必须释放，不得把内框压回固定行高形成死区）
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 200 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 200 }));
+    });
+    expect(textField.style.height).toBe("300px");
+    // 受控高度落在 InputBase 根节点；根节点不持有受控 overflowY
+    // （避免 MUI TextareaAutosize 每帧重写 textarea.style.overflow 与 root 级
+    // 滚动形成双滚动条）
+    expect(textField.style.overflowY).toBe("");
+
+    // 可见 textarea（过滤测量用 shadow 副本）的强制滚动规则来自 scoped sx
+    // （`& textarea:not([aria-hidden="true"])`），不写入 React inline style。
+    // MUI TextareaAutosize 每帧会重写 textarea.style.overflow（通常为 "hidden"），
+    // 但 emotion scoped 规则以 `!important` 优先——在真浏览器中强制滚动。
+    // jsdom 中仅验证 scoped 规则存在，不验证 inline overflow（MUI 会写入）。
+    const visibleTextareas = Array.from(
+      container.querySelectorAll("textarea")
+    ).filter((ta) => ta.tabIndex !== -1);
+    expect(visibleTextareas.length).toBe(1);
+    expect(visibleTextareas[0].style.maxHeight).toBe("");
+
+    // 情感样式表存在同时匹配 textarea:not([aria-hidden=...]) 与
+    // overflow: auto !important 的 scoped 强制滚动规则（Emotion speedy 模式经
+    // sheet.cssRules 写入，容忍引号/空格规范化）
+    expect(emotionCssText()).toMatch(
+      /textarea:not\(\[aria-hidden=['"]true['"]\]\)\s*\{[^}]*overflow:\s*auto\s*!important/
+    );
+    // 测量用 shadow textarea 不命中强制滚动规则（aria-hidden="true" 排除），
+    // 其测量关键基准 height:0 必须原样保留
+    const shadowTextareas = Array.from(
+      container.querySelectorAll("textarea")
+    ).filter((ta) => ta.tabIndex === -1);
+    for (const shadow of shadowTextareas) {
+      expect(shadow.style.height).toBe("0px");
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("pointer and touch start events never reach the outer container", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    // 模拟外层拖动/缩放容器（DraggableResizable）挂载的事件监听器
+    const outerPointerSpy = jest.fn();
+    const outerTouchSpy = jest.fn();
+    document.body.addEventListener("pointerdown", outerPointerSpy);
+    document.body.addEventListener("touchstart", outerTouchSpy);
+
+    act(() => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      handle.dispatchEvent(makeTouchEvent("touchstart", [{ clientY: 0 }]));
+    });
+
+    expect(outerPointerSpy).not.toHaveBeenCalled();
+    expect(outerTouchSpy).not.toHaveBeenCalled();
+
+    document.body.removeEventListener("pointerdown", outerPointerSpy);
+    document.body.removeEventListener("touchstart", outerTouchSpy);
+    act(() => root.unmount());
+  });
+
+  test("a gesture starting outside the hot area never starts resizing", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    const textarea = container.querySelector("textarea");
+
+    // 手势从热区外的正文区开始，即使之后移动任意距离也不得进入缩放
+    await act(async () => {
+      textarea.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 100 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    act(() => root.unmount());
+  });
+
+  test("removes all window listeners on unmount while dragging a pointer session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    // 进入拖动会话。jsdom 无 Pointer capture，pointerdown 激活完整 window fallback，
+    // 会话期间 window 上存在 pointermove/pointerup/pointercancel 降级监听。
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    act(() => root.unmount());
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type);
+    for (const type of ["pointermove", "pointerup", "pointercancel", "blur"]) {
+      expect(removedTypes).toContain(type);
+    }
+    removeSpy.mockRestore();
+  });
+
+  test("removes all window listeners on unmount while dragging a touch session", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    // 进入 Touch 会话：touchmove/touchend/touchcancel 监听仅随活动会话安装
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent("touchstart", [{ clientY: 0, identifier: 1 }])
+      );
+    });
+
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    act(() => root.unmount());
+
+    const removedTypes = removeSpy.mock.calls.map(([type]) => type);
+    for (const type of ["touchmove", "touchend", "touchcancel", "blur"]) {
+      expect(removedTypes).toContain(type);
+    }
+    removeSpy.mockRestore();
+  });
+
+  test("gives the resize handle a non-empty accessible name via the real i18n dictionary", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+    // 使用真实 I18N 字典获取本地化文案，不依赖硬编码 fallback
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+    expect(handle.getAttribute("title")).toBeTruthy();
+    expect(handle.getAttribute("aria-label")).toBe(
+      jest.requireActual("../../config").newI18n("en")("field_resize_height")
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("keeps the scoped textarea rule free of reserved right/bottom padding", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    // 未拖动输入框不得携带常驻 paddingRight/paddingBottom：它们会把可见
+    // textarea 排版宽度压窄于 shadow 测量框（paddingRight）或把最小高度下的
+    // 可显示区压成不足一行（paddingBottom）。jsdom 下经 emotion cssRules
+    // 断言 scoped 规则文本本身。
+    const emotionCss = Array.from(
+      document.querySelectorAll("style[data-emotion]")
+    )
+      .flatMap((tag) => {
+        const rules = tag.sheet && tag.sheet.cssRules;
+        if (rules && rules.length) {
+          return Array.from(rules).map((r) => r.cssText || "");
+        }
+        return [tag.textContent || ""];
+      })
+      .join("\n");
+    expect(emotionCss).not.toMatch(
+      /textarea:not\(\[aria-hidden=['"]true['"]\]\)\s*\{[^}]*padding-(right|bottom)/
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("a manually resized box keeps the handle visible after clearing content so it can be shrunk back", async () => {
+    const setText = jest.fn();
+    const { container, root } = renderTranForm({
+      text: "",
+      setText,
+      simpleStyle: false,
+      autoFocusInput: false,
+    });
+    await flushEffects();
+    const input = container.querySelector("textarea");
+    const handleSel = '[data-testid="tranform-resize-handle"]';
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value"
+    ).set;
+
+    // 空框聚焦：无内容时手柄隐藏
+    act(() => {
+      input.focus();
+    });
+    expect(container.querySelector(handleSel)).toBeNull();
+
+    // 输入内容：手柄出现
+    act(() => {
+      setter.call(input, "abc");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const handle = container.querySelector(handleSel);
+    expect(handle).not.toBeNull();
+
+    // 拖动放大产生手动高度
+    const textField = input.closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 200 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 200 }));
+    });
+    expect(textField.style.height).toBe("300px");
+
+    // 清空内容：已有手动高度构成显示手柄的理由，仍可继续缩回
+    act(() => {
+      setter.call(input, "");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(container.querySelector(handleSel)).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("exposes a keyboard-operable separator with arrow-key resizing", async () => {
+    const { container, root, input } = await renderFocusedForm();
+
+    const textField = input.closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // keyboard-operable separator：保留可读名称，且可聚焦、支持方向键调整
+    expect(handle.getAttribute("role")).toBe("separator");
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+    expect(handle.getAttribute("title")).toBeTruthy();
+    expect(handle.getAttribute("tabindex")).toBe("0");
+    // 手柄物理上是贴在字段底边框上的横向分隔条：横向语义与 ArrowUp/Down 对应
+    expect(handle.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(handle.getAttribute("aria-valuemin")).toBe(
+      String(MIN_RESIZE_HEIGHT)
+    );
+    // 未受控态：实测自动高度作为 aria-valuenow（ARIA 1.2 focusable separator
+    // MUST set aria-valuenow）。jsdom 无 ResizeObserver，测量 effect 只在挂载
+    // 与 window resize 时重跑，故 stub offsetHeight 后须显式派发 resize 重测。
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(handle.getAttribute("aria-valuenow")).toBe("100");
+
+    // W3C Window Splitter 语义（上方文本框为主区域）：
+    // ArrowDown：增加高度（从测量基线 100 增加一个步进 12px → 112px）
+    await act(async () => {
+      handle.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await Promise.resolve();
+    });
+    expect(textField.style.height).toBe(`${100 + KEYBOARD_RESIZE_STEP}px`);
+    // 持有受控高度后 valuenow 输出真实值
+    expect(handle.getAttribute("aria-valuenow")).toBe(
+      String(100 + KEYBOARD_RESIZE_STEP)
+    );
+
+    // ArrowUp：以受控高度为基线递减一个步进（112 - 12 = 100px）
+    await act(async () => {
+      handle.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowUp",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await Promise.resolve();
+    });
+    expect(textField.style.height).toBe("100px");
+
+    // 连续 ArrowUp 触底：不得低于 MIN_RESIZE_HEIGHT
+    for (let i = 0; i < 6; i += 1) {
+      await act(async () => {
+        handle.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "ArrowUp",
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+        await Promise.resolve();
+      });
+    }
+    expect(textField.style.height).toBe(`${MIN_RESIZE_HEIGHT}px`);
+
+    // 非方向键不触发调整
+    await act(async () => {
+      handle.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowLeft",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await Promise.resolve();
+    });
+    expect(textField.style.height).toBe(`${MIN_RESIZE_HEIGHT}px`);
+
+    act(() => root.unmount());
+  });
+
+  test("omits aria-valuenow when no measured height is available", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    // jsdom offsetHeight=0 且未 stub：按硬红线省略 valuenow，不得写 aria-valuenow="0"
+    // （0 与非有限值一律省略，宁缺勿造）
+    expect(handle.getAttribute("aria-valuenow")).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("tabbing focus to the handle keeps the field open (relatedTarget keep-alive)", async () => {
+    const { container, root, input } = await renderFocusedForm();
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 焦点从 textarea 迁移到手柄（Tab 等价场景）：focusout 冒泡到字段包装层，
+    // relatedTarget 在包装层内 → 不关闭、不卸载，reduced-motion 用户也能
+    // Tab 进手柄/按钮进行键盘操作
+    await act(async () => {
+      handle.focus();
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(handle);
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).not.toBeNull();
+    // rail 同样保持挂载（字段未关闭）
+    expect(
+      container.querySelector('[data-testid="tranform-rail"]')
+    ).not.toBeNull();
+    // 字段未进入关闭动画
+    expect(handle.style.pointerEvents).toBe("auto");
+
+    act(() => root.unmount());
+  });
+
+  test("blurring the handle with no related target still closes the field", async () => {
+    const { container, root, input } = await renderFocusedForm();
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 先 Tab 进手柄（保活路径），再无目标失焦：必须正常走关闭分支
+    await act(async () => {
+      handle.focus();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).not.toBeNull();
+
+    await act(async () => {
+      handle.blur();
+      await Promise.resolve();
+    });
+    // 退出动画 120ms 后手柄与 rail 卸载
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 130));
+    });
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="tranform-rail"]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("pointercancel and window blur terminate an active drag session", async () => {
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // pointercancel（如系统手势接管指针）终止会话：后续移动不再改变高度
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 30 }));
+    });
+    expect(textField.style.height).toBe("130px");
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointercancel", { clientY: 30 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 60 }));
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // window blur（浏览器窗口失焦）终止会话：第二轮以 130px 为基线，
+    // 移动 25px 达到 155px 后失焦，后续移动不再改变高度
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 25 }));
+    });
+    expect(textField.style.height).toBe("155px");
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 70 }));
+    });
+    expect(textField.style.height).toBe("155px");
+
+    act(() => root.unmount());
+  });
+
+  test("a matching lostpointercapture terminates an element-captured pointer session", async () => {
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 启用元素 capture 主路径：hasPointerCapture 返回 true
+    HTMLElement.prototype.setPointerCapture = jest.fn(function () {
+      return true;
+    });
+    HTMLElement.prototype.hasPointerCapture = jest.fn(function () {
+      return true;
+    });
+    try {
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      });
+      // 元素会话：移动直接在句柄元素上派发（window 降级监听不参与）
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+      });
+      expect(textField.style.height).toBe("120px");
+
+      // gotpointercapture 确认元素接管（撤除 window fallback）
+      await act(async () => {
+        handle.dispatchEvent(
+          makePointerEvent("gotpointercapture", { clientY: 0 })
+        );
+      });
+
+      // 匹配的 lostpointercapture：元素会话终止，后续移动不再改变高度
+      await act(async () => {
+        handle.dispatchEvent(
+          makePointerEvent("lostpointercapture", { clientY: 20 })
+        );
+      });
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointermove", { clientY: 60 }));
+      });
+      expect(textField.style.height).toBe("120px");
+    } finally {
+      delete HTMLElement.prototype.hasPointerCapture;
+      delete HTMLElement.prototype.setPointerCapture;
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("capture failure activates the window fallback and gotpointercapture deactivates it", async () => {
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // capture 失败：setPointerCapture 缺失 → window fallback 同步激活
+    HTMLElement.prototype.setPointerCapture = undefined;
+    HTMLElement.prototype.hasPointerCapture = undefined;
+    try {
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      });
+      // window 承接 move 仍可调高（拖出元素仍有效）
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 30 }));
+      });
+      expect(textField.style.height).toBe("130px");
+
+      // gotpointercapture 确认元素接管：撤除 window fallback，此后 window move
+      // 不得再次改高度（防双写）
+      await act(async () => {
+        handle.dispatchEvent(
+          makePointerEvent("gotpointercapture", { clientY: 0 })
+        );
+      });
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 40 }));
+      });
+      expect(textField.style.height).toBe("130px");
+
+      // 元素路径的 pointerup 结束会话
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointerup", { clientY: 40 }));
+      });
+    } finally {
+      delete HTMLElement.prototype.hasPointerCapture;
+      delete HTMLElement.prototype.setPointerCapture;
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("immediate matching pointerup/pointercancel after pointerdown still ends the session", async () => {
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 立即 pointerup：即使尚无任何状态驱动 effect 重渲染，也必须结束会话并允许下一次 pointerdown
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 0 }));
+    });
+    // 新一轮会话以 130px 为基线（上一轮未改变高度，仍从 100 起）
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 30 }));
+    });
+    expect(textField.style.height).toBe("130px");
+
+    act(() => root.unmount());
+  });
+
+  test("touch start binds the handle's new finger even when an older finger is already on screen", async () => {
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 屏幕已有旧手指 identifier=2（排在最前），手柄新手指 identifier=1 随后按下：
+    // 必须绑定 changedTouches[0] 的手柄新触点，而不是 touches[0] 的旧手指。
+    await act(async () => {
+      handle.dispatchEvent(
+        makeTouchEvent(
+          "touchstart",
+          [
+            { clientY: 0, identifier: 2 },
+            { clientY: 0, identifier: 1 },
+          ],
+          {
+            // touchstart 的结算清单是本次新按下/变更的触点：id=1 是手柄新手指
+            changedTouches: [{ clientY: 0, identifier: 1 }],
+          }
+        )
+      );
+    });
+    // 按 identifier=1 跟踪：移动到 30 → 130px（旧手指 id=2 排最前移动也无效）
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [
+          { clientY: 90, identifier: 2 },
+          { clientY: 30, identifier: 1 },
+        ])
+      );
+    });
+    expect(textField.style.height).toBe("130px");
+
+    // 非发起触点（identifier=2）抬起：changedTouches 结算 id=2，
+    // 但发起触点 id=1 仍在当前 touches 中，不得结束会话
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [{ clientY: 30, identifier: 1 }], {
+          changedTouches: [{ identifier: 2 }],
+        })
+      );
+    });
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchmove", [{ clientY: 50, identifier: 1 }])
+      );
+    });
+    expect(textField.style.height).toBe("150px");
+
+    // 发起触点（identifier=1）抬起结束会话
+    await act(async () => {
+      window.dispatchEvent(
+        makeTouchEvent("touchend", [], {
+          changedTouches: [{ identifier: 1 }],
+        })
+      );
+    });
+
+    act(() => root.unmount());
+  });
+
+  test("controlled height is re-clamped once when the viewport shrinks and is not revived", async () => {
+    // 初始视口足够高（2000），允许拖出 900px 的受控高度
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 2000,
+    });
+    const { container, root } = await renderFocusedForm();
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 700,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 建立一个 900px 的受控高度（700 + 200）
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 200 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 200 }));
+    });
+    expect(textField.style.height).toBe("900px");
+
+    // 视口缩小到 500：上界收紧到 < 900，一次性重 clamp
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 500,
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(parseInt(textField.style.height, 10)).toBeLessThan(900);
+    // aria-valuemax 不得反转：始终 >= valuemin (40)
+    const valuemax = parseInt(handle.getAttribute("aria-valuemax"), 10);
+    const valuemin = parseInt(handle.getAttribute("aria-valuemin"), 10);
+    expect(valuemax).toBeGreaterThanOrEqual(valuemin);
+    expect(valuemax).toBeLessThan(900);
+
+    // 视口恢复：被截断的旧高度不得自动复活
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 2000,
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(parseInt(textField.style.height, 10)).toBeLessThan(900);
+
+    act(() => root.unmount());
+  });
+
+  test("keeps dragging when the textarea blurs mid-drag until pointerup", async () => {
+    const { container, root, input } = await renderFocusedForm();
+    const textField = input.closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 进入拖动会话并移动超过阈值
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    expect(textField.style.height).toBe("120px");
+
+    // 缩放中途失焦：进入退出动画，但活动会话期间手柄保持挂载与监听
+    act(() => {
+      input.blur();
+    });
+    // 退出动画期间（closing=true）拖动不受 pointer-events 阻断
+    expect(handle.style.pointerEvents).toBe("auto");
+
+    // 等待超过 120ms 退出动画：失焦不再终止会话（新契约）
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 130));
+    });
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).not.toBeNull();
+
+    // 失焦后 height 仍在跟随鼠标
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 40 }));
+    });
+    expect(textField.style.height).toBe("140px");
+
+    // 松手结束会话：重渲染后按新门控自然卸载
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointerup", { clientY: 40 }));
+    });
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).toBeNull();
+
+    // 后续 pointermove 不再改变高度
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 60 }));
+    });
+    expect(textField.style.height).toBe("140px");
+
+    act(() => root.unmount());
+  });
+
+  test("unmounts the handle and ignores pointer moves when blur happens without a drag session", async () => {
+    const { container, root, input } = await renderFocusedForm();
+    const textField = input.closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+
+    // 从未进入拖动会话：失焦后按旧契约卸载，且后续指针移动无效
+    // （无监听器响应，等价于"监听器已移除"的功能性断言）。
+    act(() => {
+      input.blur();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 130));
+    });
+    expect(
+      container.querySelector('[data-testid="tranform-resize-handle"]')
+    ).toBeNull();
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+    });
+    expect(textField.style.height).toBe("");
+
+    act(() => root.unmount());
+  });
+
+  test("prevents default on compatible mousedown to guard textarea focus", async () => {
+    const { container, root } = await renderFocusedForm();
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 兼容 mousedown 必须被 preventDefault 抑制（防失焦兜底，与提交按钮/
+    // CopyBtn 同一套先例），且 mousedown 本身不是拖动会话入口。
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      handle.dispatchEvent(event);
+    });
+    expect(event.defaultPrevented).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  test("keeps resizing after instant blur when prefers-reduced-motion is enabled", async () => {
+    const originalMatchMedia = window.matchMedia;
+    try {
+      window.matchMedia = matchMediaStub(true);
+      const { container, root, input } = await renderFocusedForm();
+      const textField = input.closest(".MuiInputBase-root");
+      Object.defineProperty(textField, "offsetHeight", {
+        configurable: true,
+        value: 100,
+      });
+      const handle = container.querySelector(
+        '[data-testid="tranform-resize-handle"]'
+      );
+
+      // 进入拖动会话并移动超过阈值
+      await act(async () => {
+        handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+      });
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+      });
+      expect(textField.style.height).toBe("120px");
+
+      // 减少动态效果：失焦跳过退出动画立即翻转 visible，活动会话必须存活
+      act(() => {
+        input.blur();
+      });
+      // 拖动继续：高度仍在跟随，且不被 pointer-events 阻断
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 50 }));
+      });
+      expect(textField.style.height).toBe("150px");
+      expect(handle.style.pointerEvents).not.toBe("none");
+
+      // 松手结束会话：按新门控卸载；后续移动不再改变高度
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointerup", { clientY: 50 }));
+      });
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+      await act(async () => {
+        window.dispatchEvent(makePointerEvent("pointermove", { clientY: 80 }));
+      });
+      expect(textField.style.height).toBe("150px");
+
+      act(() => root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test("reads prefers-reduced-motion and subscribes/unsubscribes to runtime changes", async () => {
+    // 模拟系统开启"减少动态效果"：matchMedia 返回 matches=true。
+    // 验证 hook 在组件挂载时读取真实偏好并注册 change 订阅，卸载时移除订阅。
+    const originalMatchMedia = window.matchMedia;
+    const changeHandlers = [];
+    const removeFn = jest.fn();
+    const mql = {
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+      addEventListener: (type, handler) => {
+        if (type === "change") changeHandlers.push(handler);
+      },
+      removeEventListener: removeFn,
+    };
+    window.matchMedia = jest.fn().mockReturnValue(mql);
+
+    try {
+      const { container, root } = renderTranForm({
+        text: "hello",
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      // focus-gating：聚焦后右上操作组才显示（编辑态显示提交按钮）
+      act(() => {
+        container.querySelector("textarea").focus();
+      });
+
+      // 组件确以"减少动态效果"媒体查询读取系统偏好
+      expect(window.matchMedia).toHaveBeenCalledWith(
+        "(prefers-reduced-motion: reduce)"
+      );
+      // TranForm 唯一注册运行时订阅：ResizeHandle 改由 prop 接收偏好值，
+      // 不再内部重复订阅（单一状态真源）。
+      expect(changeHandlers.length).toBe(1);
+
+      // 偏好从还原为不还原时，订阅处理器会同步更新组件状态（不抛错）
+      act(() => {
+        changeHandlers[0]({ matches: false });
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+
+      // 卸载时移除 change 订阅
+      act(() => root.unmount());
+      expect(removeFn).toHaveBeenCalledWith("change", expect.any(Function));
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test("the resize handle relies on a single reduced-motion mechanism (no duplicate @media rules)", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+    const handleClasses = (handle.className || "").split(" ").filter(Boolean);
+
+    // ResizeHandle 的过渡样式由 usePrefersReducedMotion hook 唯一驱动：
+    // 不得残留 "@media (prefers-reduced-motion: reduce)" 的第二套 CSS 机制
+    const ownMediaRules = Array.from(document.styleSheets).flatMap((sheet) => {
+      try {
+        return Array.from(sheet.cssRules);
+      } catch {
+        return [];
+      }
+    });
+    expect(
+      ownMediaRules.filter(
+        (rule) =>
+          rule.type === CSSRule.MEDIA_RULE &&
+          /prefers-reduced-motion/.test(rule.media?.mediaText || "") &&
+          Array.from(rule.cssRules).some(
+            (inner) =>
+              inner.selectorText &&
+              handleClasses.some((c) =>
+                inner.selectorText
+                  .split(",")
+                  .some((sel) => sel.trim() === `.${c}`)
+              )
+          )
+      ).length
+    ).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("does not inject the enter animation when prefers-reduced-motion is enabled", async () => {
+    const originalMatchMedia = window.matchMedia;
+
+    // 依次渲染"不减少动态效果"与"减少动态效果"两种实例，
+    // 并各自检查其控制组的样式规则是否引用了进入动画关键帧。
+    // 只按元素自身生成的类名过滤规则，避免其他实例残留样式干扰断言。
+    try {
+      const matchMediaStub = (matches) =>
+        jest.fn().mockReturnValue({
+          matches,
+          media: "(prefers-reduced-motion: reduce)",
+          onchange: null,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        });
+
+      // 未开启减少动态效果：进入动画关键帧应注入
+      window.matchMedia = matchMediaStub(false);
+      const normal = renderTranForm({
+        text: "hello",
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      act(() => {
+        normal.container.querySelector("textarea").focus();
+      });
+      const normalCopy = normal.container.querySelector(
+        '[aria-label="Submit"]'
+      );
+      const normalStack = normalCopy.parentElement;
+      const normalClasses = (normalStack.className || "")
+        .split(" ")
+        .filter(Boolean);
+      const normalRules = Array.from(document.styleSheets).flatMap((sheet) => {
+        try {
+          return Array.from(sheet.cssRules);
+        } catch {
+          return [];
+        }
+      });
+      const normalOwnAnimations = normalRules.filter(
+        (rule) =>
+          rule.selectorText &&
+          normalClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(normalOwnAnimations.length).toBeGreaterThan(0);
+      act(() => normal.root.unmount());
+
+      // 开启减少动态效果：该实例的控制组不得注入进入动画关键帧
+      window.matchMedia = matchMediaStub(true);
+      const reduced = renderTranForm({
+        text: "hello",
+        simpleStyle: false,
+        autoFocusInput: false,
+      });
+      await flushEffects();
+      act(() => {
+        reduced.container.querySelector("textarea").focus();
+      });
+      const reducedCopy = reduced.container.querySelector(
+        '[aria-label="Submit"]'
+      );
+      const reducedStack = reducedCopy.parentElement;
+      const reducedClasses = (reducedStack.className || "")
+        .split(" ")
+        .filter(Boolean);
+      const reducedOwnAnimations = Array.from(document.styleSheets)
+        .flatMap((sheet) => {
+          try {
+            return Array.from(sheet.cssRules);
+          } catch {
+            return [];
+          }
+        })
+        .filter(
+          (rule) =>
+            rule.selectorText &&
+            reducedClasses.some((c) =>
+              rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+            ) &&
+            /transition[^;]*opacity/.test(rule.cssText)
+        );
+      expect(reducedOwnAnimations.length).toBe(0);
+
+      act(() => reduced.root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+});
+
+describe("TranForm embedded border controls", () => {
+  beforeEach(() => {
+    apiDict.mockReset();
+    tryDetectLang.mockResolvedValue("en");
+    document.body.innerHTML = "";
+  });
+
+  /**
+   * 渲染原文输入框并使其聚焦：focus-gating 下操作 rail 与缩放手柄只在聚焦时显示。
+   *
+   * @param {Object} props 覆盖默认组件参数（默认 text="hello"）。
+   * @returns {{container: HTMLElement, root: Object, input: HTMLTextAreaElement}} 渲染结果与 textarea。
+   */
+  async function renderFocusedForm(props = {}) {
+    const rendered = renderTranForm({
+      text: "hello",
+      simpleStyle: false,
+      autoFocusInput: false,
+      ...props,
+    });
+    await flushEffects();
+    const input = rendered.container.querySelector("textarea");
+    act(() => {
+      input.focus();
+    });
+    return { ...rendered, input };
+  }
+
+  /**
+   * 使用原生 value setter 修改受控 textarea 的值并触发 React onChange。
+   *
+   * @param {HTMLTextAreaElement} input textarea 元素。
+   * @param {string} value 新值。
+   */
+  function changeInputValue(input, value) {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value"
+    ).set;
+    act(() => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  /**
+   * 收集当前 document.styleSheets 中所有 CSS 规则。
+   *
+   * @returns {Array<CSSRule>} 全部规则（跨源样式表读取失败时跳过）。
+   */
+  function collectRules() {
+    return Array.from(document.styleSheets).flatMap((sheet) => {
+      try {
+        return Array.from(sheet.cssRules);
+      } catch {
+        return [];
+      }
+    });
+  }
+
+  test("resize handle and rail are not shielded by the overlay pointer-events none", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    const rail = container.querySelector('[data-testid="tranform-rail"]');
+    expect(handle).not.toBeNull();
+    expect(rail).not.toBeNull();
+
+    // 覆盖层父级显式 pointer-events: none，控件自身必须内联覆盖为 auto，
+    // 使 jsdom 能读取到该样式，浏览器中也不会被父层屏蔽而无法接收指针事件。
+    expect(getComputedStyle(handle).pointerEvents).toBe("auto");
+    expect(getComputedStyle(rail).pointerEvents).toBe("auto");
+    expect(getComputedStyle(handle).cursor).toBe("row-resize");
+
+    act(() => root.unmount());
+  });
+
+  test("anchors the resize handle centered on the bottom border", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+
+    // 跨底边框居中：共享中心轴距右边缘 12px，热区宽 16，中心偏移 8
+    expect(parseFloat(handle.style.right)).toBe(CONTROL_CENTER_FROM_RIGHT - 8);
+    expect(parseFloat(handle.style.bottom)).toBe(-8);
+    // jsdom 下桌面命中热区 = 16
+    expect(parseFloat(handle.style.width)).toBe(16);
+    expect(parseFloat(handle.style.height)).toBe(16);
+
+    act(() => root.unmount());
+  });
+
+  test("rail and handle share the same right center axis", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    const rail = container.querySelector('[data-testid="tranform-rail"]');
+
+    // 右上 rail 与缩放手柄均以共享中心轴定位：中心 = right + 自身宽度/2 = CONTROL_CENTER_FROM_RIGHT
+    const railCenter = parseFloat(rail.style.right) + CONTROL_HEIGHT / 2;
+    expect(railCenter).toBe(CONTROL_CENTER_FROM_RIGHT);
+
+    // rail 以顶边为中心垂直居中：top = -CONTROL_HEIGHT/2，中心落在边框线 y=0
+    expect(parseFloat(rail.style.top)).toBe(-Math.round(CONTROL_HEIGHT / 2));
+    expect(parseFloat(rail.style.top) + CONTROL_HEIGHT / 2).toBe(0);
+
+    // 手柄同样以共享中心轴定位（跨底边框居中）
+    const handleCenter =
+      parseFloat(handle.style.right) + parseFloat(handle.style.width) / 2;
+    expect(handleCenter).toBe(CONTROL_CENTER_FROM_RIGHT);
+
+    act(() => root.unmount());
+  });
+
+  test("rail and handle both have notch strips", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const railNotch = container.querySelector(
+      '[data-testid="tranform-rail-notch"]'
+    );
+    expect(railNotch).not.toBeNull();
+    const resizeNotch = container.querySelector(
+      '[data-testid="tranform-resize-notch"]'
+    );
+    expect(resizeNotch).not.toBeNull();
+
+    // rail 遮罩 top 在顶边框线，宽度 = 控件宽度 + 两侧水平 padding
+    expect(parseFloat(railNotch.style.top)).toBe(
+      -Math.round(NOTCH_STRIP_HEIGHT / 2)
+    );
+    expect(parseFloat(railNotch.style.width)).toBe(
+      CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2
+    );
+
+    // 缩放手柄遮罩 bottom 在底边框线，宽度 = 控件宽度 + 两侧水平 padding
+    expect(parseFloat(resizeNotch.style.bottom)).toBe(
+      -Math.round(NOTCH_STRIP_HEIGHT / 2)
+    );
+    expect(parseFloat(resizeNotch.style.width)).toBe(
+      CONTROL_HEIGHT + NOTCH_HORIZONTAL_PAD * 2
+    );
+
+    // 两个遮罩条均以 background.paper 主题色遮盖边框
+    const rules = collectRules();
+    const notchPairs = [
+      (railNotch.className || "").split(" ").filter(Boolean),
+      (resizeNotch.className || "").split(" ").filter(Boolean),
+    ];
+    notchPairs.forEach((classes) => {
+      const ownRules = rules.filter(
+        (rule) =>
+          rule.selectorText &&
+          classes.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          rule.cssText.includes("background-color")
+      );
+      expect(ownRules.length).toBeGreaterThan(0);
+      expect(
+        ownRules.every((rule) => !rule.cssText.includes("background.paper"))
+      ).toBe(true);
+    });
+
+    act(() => root.unmount());
+  });
+
+  test("renders the DragIndicatorIcon inside the resize handle", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+    expect(handle).not.toBeNull();
+    // 六点 DragIndicator 图标渲染在手柄热区内
+    expect(
+      handle.querySelector('[data-testid="DragIndicatorIcon"]')
+    ).not.toBeNull();
+
+    // 不再使用 ::before 折角画线：styleSheets 中不应存在该伪元素的规则
+    const handleClasses = (handle.className || "").split(" ").filter(Boolean);
+    const ownBeforeRules = collectRules().filter(
+      (rule) =>
+        rule.selectorText &&
+        handleClasses.some((c) =>
+          rule.selectorText
+            .split(",")
+            .some((sel) => sel.trim() === `.${c}::before`)
+        )
+    );
+    expect(ownBeforeRules.length).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("hidden state leaves no rail, handle or notch in the DOM", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root, input } = await renderFocusedForm();
+
+      // 失焦：缩放手柄与 rail-notch 同构，均播放退出动画后卸载（不再瞬时卸载）
+      act(() => {
+        input.blur();
+      });
+      // 退出动画期间缩放手柄与 rail-notch 仍在 DOM（淡出中）
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-notch"]')
+      ).not.toBeNull();
+
+      // 退出动画期间 rail 与 notch 仍在 DOM
+      expect(
+        container.querySelector('[data-testid="tranform-rail"]')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-rail-notch"]')
+      ).not.toBeNull();
+
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        container.querySelector('[data-testid="tranform-rail"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-rail-notch"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("plays the rail exit animation on blur and unmounts after 120ms", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root, input } = await renderFocusedForm();
+
+      act(() => {
+        input.blur();
+      });
+
+      // 退出动画期间 rail 仍在 DOM，且注入 opacity/visibility 过渡规则。
+      // 注意：closing 翻转会使 rail 的 emotion 类名变化，须在 blur 后重新取类名过滤。
+      const rail = container.querySelector('[data-testid="tranform-rail"]');
+      expect(rail).not.toBeNull();
+      const railClasses = (rail.className || "").split(" ").filter(Boolean);
+      const ownOutAnimations = collectRules().filter(
+        (rule) =>
+          rule.selectorText &&
+          railClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(ownOutAnimations.length).toBeGreaterThan(0);
+
+      // 缩放手柄同构：失焦后参与退出动画（淡出中仍在 DOM），退出期间禁用命中
+      const exitHandle = container.querySelector(
+        '[data-testid="tranform-resize-handle"]'
+      );
+      expect(exitHandle).not.toBeNull();
+      expect(getComputedStyle(exitHandle).pointerEvents).toBe("none");
+
+      // 退出动画期间 rail 屏蔽指针事件，防止残留按钮被点击触发提交/复制
+      expect(
+        getComputedStyle(
+          container.querySelector('[data-testid="tranform-rail"]')
+        ).pointerEvents
+      ).toBe("none");
+
+      // 120ms 后 rail 与缩放手柄均卸载
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        container.querySelector('[data-testid="tranform-rail"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="tranform-resize-handle"]')
+      ).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("removes the rail immediately on blur without exit animation when prefers-reduced-motion is enabled", async () => {
+    const originalMatchMedia = window.matchMedia;
+    try {
+      window.matchMedia = matchMediaStub(true);
+      const { container, root, input } = await renderFocusedForm();
+      const rail = container.querySelector('[data-testid="tranform-rail"]');
+      const railClasses = (rail.className || "").split(" ").filter(Boolean);
+
+      act(() => {
+        input.blur();
+      });
+
+      // reduced-motion：跳过 120ms 滞留，立即卸载
+      expect(
+        container.querySelector('[data-testid="tranform-rail"]')
+      ).toBeNull();
+
+      // 未注入 opacity/visibility 退出过渡（reduced-motion 下 transition: none）
+      const ownOutAnimations = collectRules().filter(
+        (rule) =>
+          rule.selectorText &&
+          railClasses.some((c) =>
+            rule.selectorText.split(",").some((sel) => sel.trim() === `.${c}`)
+          ) &&
+          /transition[^;]*opacity/.test(rule.cssText)
+      );
+      expect(ownOutAnimations.length).toBe(0);
+
+      act(() => root.unmount());
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test("keeps the submit button in the rail during the exit animation after blurring while editing", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      const { container, root, input } = await renderFocusedForm();
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+
+      act(() => {
+        input.blur();
+      });
+
+      // closing 期间 editMode 保持失焦前值：rail 仍显示正在淡出的提交按钮（非被替换为 copy）
+      expect(container.querySelector('[aria-label="Submit"]')).not.toBeNull();
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(container.querySelector('[aria-label="Submit"]')).toBeNull();
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("keeps the copy button in the rail during the exit animation after blurring while not editing", async () => {
+    jest.useFakeTimers("legacy");
+    try {
+      let committed = "hello";
+      const setText = jest.fn().mockImplementation((next) => {
+        committed = next;
+      });
+      const { container, root, input } = await renderFocusedForm({ setText });
+
+      // 提交退出编辑态（mousedown 阻止失焦，焦点保留在 textarea 上）
+      changeInputValue(input, "hello");
+      const submit = container.querySelector('[aria-label="Submit"]');
+      await act(async () => {
+        submit.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        submit.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      act(() => {
+        root.render(
+          <TranForm
+            text={committed}
+            setText={setText}
+            apiSlugs={[]}
+            fromLang="en"
+            toLang="zh-CN"
+            toLang2="-"
+            transApis={[]}
+            simpleStyle={false}
+            autoFocusInput={false}
+            langDetector="-"
+            enDict="Bing"
+            enSug="-"
+            aiDictApiSlug="-"
+          />
+        );
+      });
+      await flushEffects();
+
+      // 复制态：rail 显示 copy 按钮
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(true);
+
+      act(() => {
+        input.blur();
+      });
+
+      // closing 期间 rail 仍显示正在淡出的 copy 按钮
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(120);
+      });
+      expect(
+        [...container.querySelectorAll("button")].some(
+          (button) => button.textContent === "copy"
+        )
+      ).toBe(false);
+
+      act(() => root.unmount());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 解析真实浏览器级联下 fieldset 的 border-width。
+   *
+   * jsdom 的级联按样式表文档顺序解析而不是按选择器特异性，而 emotion 把每条
+   * 规则注入到独立的 <style> 标签，标签顺序随挂载顺序变化（同一 DOM 在不同
+   * 测试文件里的计算值可能不同）。这里取"实际匹配该元素且类数量最多"的选择器
+   * 所声明的 border-width，模拟浏览器的特异性级联，可靠断言聚焦边框宽度。
+   *
+   * @param {HTMLElement} outline .MuiOutlinedInput-notchedOutline 元素。
+   * @returns {string} 胜者规则中声明的 border-width（如 "1px" / "2px"）。
+   */
+  function winningBorderWidth(outline) {
+    const matched = collectRules()
+      .filter((rule) => rule.selectorText && /border-width/.test(rule.cssText))
+      .map((rule) => ({
+        rule,
+        selectors: rule.selectorText.split(",").map((s) => s.trim()),
+      }))
+      .filter(({ selectors }) => selectors.some((sel) => outline.matches(sel)))
+      .map(({ rule, selectors }) => ({
+        rule,
+        classCount: Math.max(
+          ...selectors.map(
+            (sel) => (sel.match(/\.-?[_a-zA-Z][\w-]*/g) || []).length
+          )
+        ),
+      }))
+      .sort((a, b) => b.classCount - a.classCount)[0];
+    expect(matched).toBeDefined();
+    return /border-width:\s*([^;]+)/.exec(matched.rule.cssText)?.[1]?.trim();
+  }
+
+  test("keeps the focused notched outline at 2px border width", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const focusedOutline = container.querySelector(
+      ".MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline"
+    );
+    expect(focusedOutline).not.toBeNull();
+    // 保留 MUI 原生 2px 聚焦边框（键盘焦点可见性，WCAG 2.4.7）；装饰缺口由
+    // NOTCH_STRIP_HEIGHT=4 的遮罩条把两层边框一起清掉，不再用字段局部样式压制。
+    expect(winningBorderWidth(focusedOutline)).toBe("2px");
+
+    act(() => root.unmount());
+  });
+
+  test("keeps rail, handle and notches outside the scrollable input root after a drag", async () => {
+    const { container, root } = await renderFocusedForm();
+
+    const textField = container
+      .querySelector("textarea")
+      .closest(".MuiInputBase-root");
+    Object.defineProperty(textField, "offsetHeight", {
+      configurable: true,
+      value: 100,
+    });
+    const handle = container.querySelector(
+      '[data-testid="tranform-resize-handle"]'
+    );
+
+    // 完成一次超过 6px 阈值的高度拖动，使 resizeHeight 进入受控状态
+    await act(async () => {
+      handle.dispatchEvent(makePointerEvent("pointerdown", { clientY: 0 }));
+    });
+    await act(async () => {
+      window.dispatchEvent(makePointerEvent("pointermove", { clientY: 20 }));
+    });
+    // 受控高度已接管 InputBase 根节点；根节点不持有受控 overflowY
+    // （jsdom/cssstyle 不展开 overflow shorthand，且 MUI TextareaAutosize 会
+    // 每帧重写 textarea.style.overflow——root 级 overflowY 会让可见 textarea
+    // 无法成为唯一滚动容器）
+    expect(textField.style.height).toBe("120px");
+    expect(textField.style.overflowY).toBe("");
+
+    // rail、六点手柄与两处 notch 必须与滚动根节点同级（或其外层），
+    // 祖先链不得包含该滚动节点，否则会被 overflow-y: auto 裁切。
+    for (const testId of [
+      "tranform-rail",
+      "tranform-resize-handle",
+      "tranform-resize-notch",
+    ]) {
+      const node = container.querySelector(`[data-testid="${testId}"]`);
+      expect(node).not.toBeNull();
+      expect(node.closest(".MuiInputBase-root")).toBeNull();
+    }
+
     act(() => root.unmount());
   });
 });


### PR DESCRIPTION
## 概述

优化划词翻译 / 主动文本翻译输入框的交互体验，统一输入框右下角拖拽调高手柄，并重设计右上角操作按钮 rail。

## 主要改动

1. **统一 `ResizeHandle` 组件** (`src/components/ResizeHandle.js`, `useTextareaResize.js`)：
   - 解决原生 `textarea` 拖拽与 focus-gating 的交互冲突，提供平滑的高度调节体验。
   - 包含三层防失焦防御机制（`mousedown` preventDefault / 活动会话保活 / closing 期间保持命中区）。
   - 支持 `prefers-reduced-motion` 媒体查询，兼顾无障碍与动效偏好。

2. **右上角操作 Rail 重构** (`TranForm.js`, `TranCont.js`, `CopyBtn.js`)：
   - 重新整合复制、粘贴、提交等快捷操作的按钮布局与展示时机。
   - focus-gating：操作组随输入框聚焦渐入、失焦淡出，避免非聚焦态下的视觉和点击热区干扰。

3. **字幕分割测试台渲染隔离** (`SubtitleSegmentationPlayground.js`)：
   - 采用 `ResizableSubtitleField` 局部重渲染隔离包装，避免拖拽手柄时触发整页无谓重渲染导致的掉帧。

## 测试与验证

- 对应单元测试全部通过（`TranForm.test.js`, `TranCont.test.js`, `CopyBtn.test.js`, `SubtitleSegmentationPlayground.test.js` 共 102/102 通过）。
- 代码已通过 Prettier 格式化检查。
- `pnpm build:firefox` 构建验证通过。

## 关联与依赖

- 独立 PR，不依赖其他分支，可单独合入。

---
<img width="539" height="671" alt="Screenshot 2026-08-18 at 16-36-50 划词翻译输入框外观预览" src="https://github.com/user-attachments/assets/31c6b2d9-ec24-41c9-93e2-1334832a35c9" />

---

特别问题: 肉眼感觉 Playground 专业术语页面 #1056  和字幕断句页面的输入框，如果采用了这个样式，它在右下角点这个下拉调整行高的这个按钮的时候，动画不太流畅，似乎它的拉伸粒度比较大，就有一种卡顿的感觉。 更通俗的来说，就是似乎要拉伸缩减到一定阈值之后才会真正在页面产生变化，有一个跃升的感觉。

Playground 文本翻译页的话就没有这种现象，似乎拉伸粒度更小 动画更流畅