### PR TITLE
✨ feat(core): 术语库本地替换引擎重构并新增专业术语 Playground 测试台

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build+zip": "cross-env CI=true pnpm build && pnpm zip",
     "test": "react-app-rewired test",
     "test:subtitle-segmentation": "babel-node src/scripts/test-subtitle-segmentation.js",
+    "test:terms": "babel-node src/scripts/test-term-replace.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -709,6 +709,7 @@ export const apiTranslate = async ({
   translateVariants = true,
   textFormat = "text",
   signal,
+  capture,
 }) => {
   if (!text) {
     throw new Error("The text cannot be empty.");
@@ -822,6 +823,7 @@ export const apiTranslate = async ({
       onStreamChunk,
       docInfo,
       signal,
+      capture,
     });
   } else {
     // 2.3 不支持批量翻译、需要单个请求执行的 API (如某些流式大模型 API)
@@ -838,6 +840,7 @@ export const apiTranslate = async ({
       docInfo,
       onStreamChunk,
       signal,
+      capture,
     });
 
     for await (const item of generator) {

--- a/src/apis/index.test.js
+++ b/src/apis/index.test.js
@@ -926,3 +926,97 @@ describe("apiTranslate non-batch stream", () => {
     });
   });
 });
+
+describe("apiTranslate capture 透传", () => {
+  // 诊断通路：Playground 的术语测试依赖 apiTranslate 把 capture 原样交给翻译执行体，
+  // 删掉 index.js 非批量分支或批量分支的 capture 透传行，对应用例必须变红。
+  beforeEach(() => {
+    mockGetCacheDigest.mockResolvedValue("a".repeat(64));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("非批量路径把 capture 原样交给 handleTranslate 并触发两端回调", async () => {
+    const capture = { onRequest: jest.fn(), onResponse: jest.fn() };
+    const rawResponse = { choices: [{ message: { content: "最终译文" } }] };
+    handleTranslate.mockImplementationOnce(async function* (texts, options) {
+      // 以真实 handleTranslate 的调用位置为准：先请求、后响应。
+      options.capture?.onRequest?.(
+        "https://api.test/v1/chat/completions",
+        { method: "POST", body: "{}" },
+        { role: "user", content: texts[0] }
+      );
+      options.capture?.onResponse?.(rawResponse);
+      yield { id: 0, result: ["最终译文", ""] };
+    });
+
+    const result = await apiTranslate({
+      text: "hello",
+      fromLang: "en",
+      toLang: "zh-CN",
+      apiSetting: {
+        ...getOpenAiApiSetting("batch prompt A"),
+        useBatchFetch: false,
+      },
+      useCache: false,
+      capture,
+    });
+
+    expect(result.trText).toBe("最终译文");
+    expect(getBatchQueue).not.toHaveBeenCalled();
+    expect(handleTranslate).toHaveBeenCalledWith(
+      ["hello"],
+      expect.objectContaining({ capture })
+    );
+    expect(handleTranslate.mock.calls[0][1].capture).toBe(capture);
+    expect(capture.onRequest).toHaveBeenCalledTimes(1);
+    expect(capture.onRequest).toHaveBeenCalledWith(
+      "https://api.test/v1/chat/completions",
+      { method: "POST", body: "{}" },
+      { role: "user", content: "hello" }
+    );
+    expect(capture.onResponse).toHaveBeenCalledTimes(1);
+    expect(capture.onResponse.mock.calls[0][0]).toBe(rawResponse);
+  });
+
+  test("批量路径把 capture 原样交给批量队列任务并触发两端回调", async () => {
+    // 限制说明：libs/batchQueue 在本套件被整体 mock（真实实现是按 key 复用的单例 +
+    // 时间窗口合并，直连会引入跨用例耦合与时序抖动），因此这里以白盒方式断言
+    // capture 抵达 addTask 的任务参数，再由任务体转交给 handleTranslate 的回调位置。
+    const capture = { onRequest: jest.fn(), onResponse: jest.fn() };
+    const rawResponse = { choices: [{ message: { content: "batched text" } }] };
+    const addTask = jest.fn(async (text, options) => {
+      options.capture?.onRequest?.(
+        "https://api.test/v1/chat/completions",
+        { method: "POST", body: "{}" },
+        { role: "user", content: text }
+      );
+      options.capture?.onResponse?.(rawResponse);
+      return ["batched text", ""];
+    });
+    getBatchQueue.mockImplementation(() => ({ addTask }));
+
+    const result = await apiTranslate({
+      text: "hello",
+      fromLang: "en",
+      toLang: "zh-CN",
+      apiSetting: getOpenAiApiSetting("batch prompt A"),
+      useCache: false,
+      capture,
+    });
+
+    expect(result.trText).toBe("batched text");
+    expect(getBatchQueue).toHaveBeenCalledTimes(1);
+    expect(getBatchQueue.mock.calls[0][1]).toBe(handleTranslate);
+    expect(addTask).toHaveBeenCalledWith(
+      "hello",
+      expect.objectContaining({ capture })
+    );
+    expect(addTask.mock.calls[0][1].capture).toBe(capture);
+    expect(capture.onRequest).toHaveBeenCalledTimes(1);
+    expect(capture.onResponse).toHaveBeenCalledTimes(1);
+    expect(capture.onResponse.mock.calls[0][0]).toBe(rawResponse);
+  });
+});

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1953,6 +1953,7 @@ export async function* handleTranslate(
     docInfo,
     textFormat = "text",
     signal,
+    capture,
   }
 ) {
   if (signal?.aborted) return;
@@ -2011,6 +2012,7 @@ export async function* handleTranslate(
     if (!response) {
       throw new Error("translate got empty response");
     }
+    capture?.onResponse?.(response);
 
     const result = await parseTransRes(response, {
       texts,
@@ -2034,6 +2036,7 @@ export async function* handleTranslate(
   };
 
   const [input, init, userMsg] = await getRequest(enableStream);
+  capture?.onRequest?.(input, init, userMsg);
 
   if (enableStream) {
     try {

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -1336,6 +1336,108 @@ describe("handleTranslate", () => {
       { id: 1, result: ["早上好", "en"] },
     ]);
   });
+
+  test("capture 非流式：先捕获真实请求，再捕获原始响应", async () => {
+    // 诊断通路（Playground 术语测试用）：capture 必须拿到真正发出的请求与未解析的响应，
+    // 且不得改变翻译输出。删掉 trans.js 里 capture?.onRequest / capture?.onResponse
+    // 任一行，本用例都会变红。
+    const rawResponse = { choices: [{ message: { content: "你好" } }] };
+    fetchData.mockResolvedValueOnce(rawResponse);
+
+    const capture = { onRequest: jest.fn(), onResponse: jest.fn() };
+    const result = await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: getNobatchApiSetting({
+          nobatchUserPrompt: "Translate: {{text}}",
+        }),
+        usePool: false,
+        capture,
+      })
+    );
+
+    expect(result).toEqual([{ id: 0, result: ["你好"] }]);
+    expect(fetchData).toHaveBeenCalledTimes(1);
+    expect(capture.onRequest).toHaveBeenCalledTimes(1);
+    expect(capture.onResponse).toHaveBeenCalledTimes(1);
+
+    // onRequest 的三个参数就是真正交给 fetchData 的 (input, init) 与本轮 userMsg。
+    const [capturedInput, capturedInit, capturedUserMsg] =
+      capture.onRequest.mock.calls[0];
+    const [fetchInput, fetchInit] = fetchData.mock.calls[0];
+    expect(capturedInput).toBe(fetchInput);
+    expect(capturedInit).toBe(fetchInit);
+    expect(capturedInit.method).toBe("POST");
+    expect(capturedInit.headers).toEqual(
+      expect.objectContaining({ Authorization: "Bearer test-key" })
+    );
+    const body = JSON.parse(capturedInit.body);
+    expect(capturedUserMsg).toEqual({
+      role: "user",
+      content: "Translate: hello",
+    });
+    expect(capturedUserMsg).toEqual(body.messages[body.messages.length - 1]);
+
+    // onResponse 拿到的是 fetchData 的原始返回值本体（解析前）。
+    expect(capture.onResponse).toHaveBeenCalledWith(rawResponse);
+    expect(capture.onResponse.mock.calls[0][0]).toBe(rawResponse);
+
+    // 顺序固定：请求捕获早于响应捕获。
+    expect(capture.onRequest.mock.invocationCallOrder[0]).toBeLessThan(
+      capture.onResponse.mock.invocationCallOrder[0]
+    );
+  });
+
+  test("capture 流式：仍捕获请求，但不捕获响应", async () => {
+    async function* streamChunks() {
+      yield JSON.stringify({ choices: [{ delta: { content: "你好" } }] });
+    }
+
+    fetchStream.mockReturnValueOnce(streamChunks());
+
+    const capture = { onRequest: jest.fn(), onResponse: jest.fn() };
+    const result = await collectAsyncGenerator(
+      handleTranslate(["hello"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting: getNobatchApiSetting({
+          useStream: true,
+          streamRenderMode: "realtime",
+          nobatchUserPrompt: "Translate: {{text}}",
+        }),
+        usePool: false,
+        capture,
+      })
+    );
+
+    expect(fetchStream).toHaveBeenCalledTimes(1);
+    expect(fetchData).not.toHaveBeenCalled();
+    expect(result[result.length - 1]).toEqual({ id: 0, result: ["你好"] });
+
+    // 请求捕获与非流式一致；响应捕获只覆盖非流式分支（流式没有整体响应对象）。
+    expect(capture.onRequest).toHaveBeenCalledTimes(1);
+    expect(capture.onResponse).not.toHaveBeenCalled();
+    const [capturedInput, capturedInit, capturedUserMsg] =
+      capture.onRequest.mock.calls[0];
+    const [streamInput, streamInit] = fetchStream.mock.calls[0];
+    expect(capturedInput).toBe(streamInput);
+    expect(capturedInit).toBe(streamInit);
+    expect(JSON.parse(capturedInit.body).stream).toBe(true);
+    expect(capturedUserMsg).toEqual({
+      role: "user",
+      content: "Translate: hello",
+    });
+  });
+
 });
 
 describe("gemini thinking effort clamp (#1048)", () => {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1149,7 +1149,8 @@ ${INPUT_PLACE_GLOSSARY}
 Translate the Source Text below to ${INPUT_PLACE_TO}.
 1. Use the Context to ensure accuracy.
 2. Adapt the wording to match the specified Tone.
-3. Output ONLY the translated text. No markdown, no explanations.
+3. If a Source Text term exactly matches a Glossary entry, output ONLY that entry's value; never repeat the source term, never wrap the value in parentheses.
+4. Output ONLY the translated text. No markdown, no explanations.
 
 Source Text: ${INPUT_PLACE_TEXT}
 
@@ -1167,7 +1168,7 @@ Rules:
 1.  Use title/description for context only; do not output them.
 2.  Keep id, order, and count of segments.
 3.  Preserve whitespace, HTML entities, and all HTML-like tags (e.g., <i1>, <a1>). Translate inner text only.
-4.  Highest priority: Follow 'glossary'. Use value for translation; if value is "", keep the key.
+4.  Highest priority: Follow 'glossary'. Use value for translation; if value is "", keep the key. When a term matches the glossary, output ONLY the glossary value; never echo the source term alongside it and never wrap the value in parentheses.
 5.  Do not translate: content in <code>, <pre>, text enclosed in backticks, or placeholders like {1}, {{1}}, [1], [[1]].
 6.  Apply the specified tone to the translation.
 7.  Detect sourceLanguage for each segment.
@@ -1194,7 +1195,7 @@ Rules:
 1.  **Strict Format**: Output ONLY the <root> element and its children. Do not include "xml" version declarations or markdown code blocks.
 2.  **Structure**: Maintain the exact "id" from the input in the "id" attribute. Detect the source language for the "sourceLanguage" attribute.
 3.  **HTML & Whitespace**: Preserve all HTML tags (e.g., <b>, <span>, <br>) and whitespace exactly as they appear in the structure. Only translate the text content inside them.
-4.  **Glossary**: Highest priority. Use the glossary value for translation. If the value is "", keep the source term as is.
+4.  **Glossary**: Highest priority. Use the glossary value for translation. If the value is "", keep the source term as is. When a term matches the glossary, output ONLY the glossary value; never echo the source term alongside it and never wrap the value in parentheses.
 5.  **Do Not Translate**: Content inside <code>, <pre>, text in backticks ("code"), and placeholders like {1}, {{1}}, [1], [[1]].
 6.  **Context**: Use the "title" and "description" fields to understand the context for better translation accuracy, but do not output them.
 7.  **Tone**: Apply the specified "tone" (formal/casual).
@@ -1225,7 +1226,7 @@ Rules:
 4.  **Separator**: Use the pipe symbol " | " strictly to separate the ID and the text.
 5.  **Context**: Use title/description for context only; do not output them.
 6.  **HTML/Tags**: Preserve whitespace, HTML entities, and all HTML-like tags (e.g., <i1>, <b>). Translate inner text only.
-7.  **Glossary**: Highest priority. Follow 'glossary'. Use value for translation; if value is "", keep the key.
+7.  **Glossary**: Highest priority. Follow 'glossary'. Use value for translation; if value is "", keep the key. When a term matches the glossary, output ONLY the glossary value; never echo the source term alongside it and never wrap the value in parentheses.
 8.  **Do Not Translate**: content in <code>, <pre>, text enclosed in backticks, or placeholders like {1}, {{1}}, [1].
 9.  **Tone**: Apply the specified tone.
 
@@ -1472,7 +1473,7 @@ Group the input word-level JSON array into readable, well-paced bilingual subtit
 3. Pause Indicators: An optional "pauseMs" field is the timeline gap in milliseconds after the current input item. If "pauseMs" is missing, treat it as 0 milliseconds and do not infer a pause. Larger positive values indicate stronger sentence boundaries, but grammatical correctness and semantic coherence always take priority.
 4. Exact Translation Alignment: Build "o" first from the exact source span covered by the current "e", starting after the previous "e". Then translate only the current "o" into "t". The "t" field MUST NOT omit that span, translate future input items, or carry text from adjacent segments.
 5. Silent Self-Check: Before returning, silently verify that every "e", "o", and "t" correspond one-to-one, every "o" matches its exact input range, all source-length limits are satisfied, and all input items are covered exactly once. Do not output the self-check or any reasoning.
-6. Translation Quality: Keep "t" concise, accurate, and natural while strictly adhering to the provided Context, Tone, and Glossary.
+6. Translation Quality: Keep "t" concise, accurate, and natural while strictly adhering to the provided Context, Tone, and Glossary. When a term matches the Glossary, output ONLY the glossary value; never echo the source term alongside it and never wrap the value in parentheses.
 
 # Example
 Input: [{"id":0,"text":"Once"},{"id":1,"text":"the"},{"id":2,"text":"assets"},{"id":3,"text":"are"},{"id":4,"text":"ready,"},{"id":5,"text":"open"},{"id":6,"text":"the"},{"id":7,"text":"storyboard"},{"id":8,"text":"tab.","pauseMs":850},{"id":9,"text":"This"},{"id":10,"text":"is"},{"id":11,"text":"where"},{"id":12,"text":"everything"},{"id":13,"text":"comes"},{"id":14,"text":"together."},{"id":15,"text":"If"},{"id":16,"text":"a"},{"id":17,"text":"scene"},{"id":18,"text":"does"},{"id":19,"text":"not"},{"id":20,"text":"match"},{"id":21,"text":"your"},{"id":22,"text":"idea,"},{"id":23,"text":"regenerate"},{"id":24,"text":"it"},{"id":25,"text":"or"},{"id":26,"text":"adjust"},{"id":27,"text":"the"},{"id":28,"text":"prompt"},{"id":29,"text":"carefully"},{"id":30,"text":"until"},{"id":31,"text":"it"},{"id":32,"text":"feels"},{"id":33,"text":"right."}]
@@ -1513,7 +1514,7 @@ const defaultApi = {
   tone: BUILTIN_STONES[0], // 翻译风格
   placeholder: BUILTIN_PLACEHOLDERS[0], // 占位符
   placetag: BUILTIN_PLACETAGS[0], // 占位标签
-  aiTerms: "", // AI智能专业术语 （todo: 备用）
+  aiTerms: "", // AI智能专业术语（apiSetting.aiTerms，全路径生效：整页/划词/输入框/字幕；与规则级 #glossary 逐 key 合并时接口级覆盖同名）
   customHeader: "",
   customBody: "",
   reqHook: "", // request 钩子函数

--- a/src/config/i18n.js
+++ b/src/config/i18n.js
@@ -1018,8 +1018,1118 @@ const SUBTITLE_PLAYGROUND_I18N = {
   ),
 };
 
+/** 为专业术语工作台集中生成七种界面语言的文案映射。 */
+const terminologyPlaygroundText = (zh, en, zh_TW, ja, ko, tr, vi) => ({
+  zh,
+  en,
+  zh_TW,
+  ja,
+  ko,
+  tr,
+  vi,
+});
+
+const TERMINOLOGY_PLAYGROUND_I18N = {
+  terminology_playground: terminologyPlaygroundText(
+    "专业术语",
+    "Terminology",
+    "專業術語",
+    "専門用語",
+    "전문 용어",
+    "Terminoloji",
+    "Thuật ngữ chuyên môn"
+  ),
+  terminology_playground_title: terminologyPlaygroundText(
+    "专业术语库（本地替换预览）",
+    "Terminology list (local replacement preview)",
+    "專業術語庫（本機替換預覽）",
+    "専門用語リスト（ローカル置換プレビュー）",
+    "전문 용어 목록 (로컬 교체 미리보기)",
+    "Terminoloji listesi (yerel değiştirme önizlemesi)",
+    "Danh sách thuật ngữ (xem trước thay thế cục bộ)"
+  ),
+  terminology_playground_terms_label: terminologyPlaygroundText(
+    "术语库（键值对，每行或 ; 分隔）",
+    "Terms (key,value, one per line or separated by ;)",
+    "術語庫（鍵值對，每行或 ; 分隔）",
+    "用語リスト（key,value、改行または「;」区切り）",
+    "용어 목록 (key,value, 한 줄에 하나 또는 ; 로 구분)",
+    "Terimler (key,value, her satırda bir veya ; ile ayrılmış)",
+    "Thuật ngữ (key,value, mỗi dòng một mục hoặc ngăn cách bằng ;)"
+  ),
+  terminology_playground_terms_helper: terminologyPlaygroundText(
+    "术语键按正则语义解析：含正则元字符（如 .）需转义，例如字面点号写为 Dr\\.whob；译文留空 = 不翻译（保留原文，只写术语键不加尾部逗号）；重复的术语键只保留首次；术语按正则语义在原文任意位置匹配（与生产一致），建议长度长的术语写在前面。",
+    "Term keys are parsed as regex: escape regex metacharacters (e.g. a literal dot as Dr\\.whob). An empty value keeps the original (write the key only, without a trailing comma); duplicate keys keep the first; terms match anywhere in the source text by regex semantics (identical to production), so put longer terms first.",
+    "術語鍵依正則語意解析：含正則元字元（如 .）需跳脫，例如字面點號寫為 Dr\\.whob；譯文留空 = 不翻譯（保留原文，只寫術語鍵不加尾部逗號）；重複的術語鍵只保留首次；術語依正則語意在原文任意位置匹配（與生產一致），建議長度較長的術語寫在前面。",
+    "用語 key は正規表現として解析されます。正規表現メタ文字（例：.）はエスケープが必要です（例：リテラルのドットは Dr\\.whob）。value を空にすると翻訳しません（原文保持、カンマなしで key のみ記述）。重複 key は最初のみ有効です。用語は正規表現の意味で原文の任意の位置に一致します（本番と同一）。長い用語ほど先に書くことを推奨します。",
+    "용어 key 는 정규식으로 해석됩니다. 정규식 메타 문자(예: .)는 이스케이프가 필요합니다(예: 리터럴 점은 Dr\\.whob). value 가 비어 있으면 번역하지 않고 원문을 유지합니다(key 만 작성, 끝에 쉼표 없음). 중복 key 는 첫 번째만 유지됩니다. 용어는 정규식 의미로 원문의 어느 위치에서나 일치합니다(프로덕션과 동일). 길이가 긴 용어를 앞에 쓰는 것을 권장합니다.",
+    "Terim anahtarları normal ifade olarak ayrıştırılır: normal ifade meta karakterlerini (ör. .) kaçışlayın (ör. değişmez nokta Dr\\.whob). Boş value = çevrilmez (orijinal korunur, virgülsüz yalnızca key yazın); aynı key'den yalnızca ilki tutulur. Terimler normal ifade anlamına göre kaynak metnin herhangi bir yerinde eşleşir (üretimle aynı); daha uzun terimleri önce yazın.",
+    "Khóa thuật ngữ được phân tích cú pháp như regex: hãy thoát các ký tự đặc biệt regex (ví dụ dấu chấm chữ thường viết là Dr\\.whob). value trống = không dịch (giữ nguyên văn bản, chỉ viết key không thêm dấu phẩy cuối); key trùng chỉ giữ lần đầu. Thuật ngữ khớp ở bất kỳ vị trí nào trong văn bản gốc theo ngữ nghĩa regex (giống bản chính thức); nên đặt thuật ngữ dài hơn ở trước."
+  ),
+  terminology_playground_sample: terminologyPlaygroundText(
+    "填入冲突矩阵 4 类示例",
+    "Load the 4-type conflict sample",
+    "填入衝突矩陣 4 類範例",
+    "4 タイプの衝突サンプルを入力",
+    "충돌 매트릭스 4가지 유형 샘플 입력",
+    "4 tür çakışma örneğini yükle",
+    "Tải mẫu 4 loại xung đột"
+  ),
+  terminology_playground_rule_load_failed: terminologyPlaygroundText(
+    "当前规则术语加载失败，已回退到全局规则：{message}",
+    "Failed to load the active rule terms, fell back to the global rule: {message}",
+    "目前規則術語載入失敗，已回退到全域規則：{message}",
+    "現在のルール用語の読み込みに失敗し、グローバルルールにフォールバックしました：{message}",
+    "현재 규칙 용어를 불러오지 못해 전역 규칙으로 대체했습니다: {message}",
+    "Etkin kural terimleri yüklenemedi, genel kurala geri dönüldü: {message}",
+    "Không tải được thuật ngữ của quy tắc hiện tại, đã quay về quy tắc toàn cục: {message}"
+  ),
+  terminology_playground_placeholder_label: terminologyPlaygroundText(
+    "占位符格式",
+    "Placeholder format",
+    "佔位符格式",
+    "プレースホルダー形式",
+    "플레이스홀더 형식",
+    "Yer tutucu biçimi",
+    "Định dạng placeholder"
+  ),
+  terminology_playground_seed_label: terminologyPlaygroundText(
+    "例句序号",
+    "Example seed",
+    "例句序號",
+    "例文シード",
+    "예문 시드",
+    "Örnek tohumu",
+    "Seed câu ví dụ"
+  ),
+  terminology_playground_rotate_seed: terminologyPlaygroundText(
+    "换一个例句",
+    "Change example",
+    "換一句例句",
+    "別の例文を表示",
+    "다른 예문 보기",
+    "Örneği değiştir",
+    "Đổi câu ví dụ"
+  ),
+  terminology_playground_invalid_terms: terminologyPlaygroundText(
+    "检测到 {count} 条非法术语段，未生成本地替换结果：{reasons}",
+    "{count} illegal term segments detected, so no local replacement was produced: {reasons}",
+    "偵測到 {count} 條非法術語段，未產生本機替換結果：{reasons}",
+    "不正な用語セグメントが {count} 件あるため、ローカル置換は生成されませんでした：{reasons}",
+    "잘못된 용어 세그먼트 {count}개가 감지되어 로컬 교체가 생성되지 않았습니다: {reasons}",
+    "{count} geçersiz terim bölümü algılandı, yerel değiştirme üretilmedi: {reasons}",
+    "Đã phát hiện {count} đoạn thuật ngữ không hợp lệ, không tạo thay thế cục bộ: {reasons}"
+  ),
+  terminology_playground_invalid_state: terminologyPlaygroundText(
+    "存在被拒绝的非法段（已跳过，不影响仍可应用的合法术语）。为免误导，未生成整体“通过”摘要；仍可应用的合法术语：{terms}。完整诊断见控制台（logger.error [TermPlayground]）。",
+    'Some segments were rejected (skipped; they do not affect valid terms that still apply). To avoid a misleading result, no overall "pass" summary was generated; valid terms that still apply: {terms}. Full diagnostics are in the console (logger.error [TermPlayground]).',
+    "存在被拒絕的非法段（已略過，不影響仍可應用的合法術語）。為免誤導，未產生整體「通過」摘要；仍可應用的合法術語：{terms}。完整診斷見控制台（logger.error [TermPlayground]）。",
+    "拒否された不正なセグメントがあります（スキップ済み。適用可能な有効な用語には影響しません）。誤解を避けるため全体の「成功」サマリーは生成していません。適用可能な有効な用語：{terms}。完全な診断はコンソール（logger.error [TermPlayground]）をご覧ください。",
+    "거부된 잘못된 세그먼트가 있습니다(건너뜀. 여전히 적용되는 유효한 용어에는 영향 없음). 오해를 피하기 위해 전체 '통과' 요약은 생성하지 않았습니다. 여전히 적용되는 유효한 용어: {terms}. 전체 진단은 콘솔(logger.error [TermPlayground])을 확인하세요.",
+    "Reddedilen geçersiz bölümler var (atlandı; hâlâ uygulanabilir geçerli terimleri etkilemez). Yanıltıcı sonuç vermemek için genel 'geçti' özeti oluşturulmadı; hâlâ uygulanabilir geçerli terimler: {terms}. Tam teşhis konsoldadır (logger.error [TermPlayground]).",
+    "Có đoạn không hợp lệ đã bị từ chối (được bỏ qua; không ảnh hưởng đến thuật ngữ hợp lệ vẫn được áp dụng). Để tránh gây hiểu nhầm, không tạo bản tóm tắt 'đạt' tổng thể; các thuật ngữ hợp lệ vẫn được áp dụng: {terms}. Chẩn đoán đầy đủ trong console (logger.error [TermPlayground])."
+  ),
+  terminology_playground_none: terminologyPlaygroundText(
+    "（无）",
+    "(none)",
+    "（無）",
+    "（なし）",
+    "(없음)",
+    "(yok)",
+    "(không có)"
+  ),
+  terminology_playground_meta_warning: terminologyPlaygroundText(
+    "{count} 个术语含未转义正则元字符（术语按正则语义解析）：{terms}。若要字面匹配，请在字符前加反斜杠，例如 Dr.whob 应写为 Dr\\.whob。",
+    "{count} terms contain unescaped regex metacharacters (terms are parsed as regex): {terms}. For a literal match, prefix the character with a backslash, e.g. write Dr\\.whob for Dr.whob.",
+    "{count} 個術語含未跳脫正則元字元（術語依正則語意解析）：{terms}。若要字面匹配，請在字元前加反斜線，例如 Dr.whob 應寫為 Dr\\.whob。",
+    "{count} 件の用語にエスケープされていない正規表現メタ文字があります（用語は正規表現として解析）：{terms}。リテラル一致にするには文字の前にバックスラッシュを付けます。例：Dr.whob は Dr\\.whob と記述。",
+    "{count}개 용어에 이스케이프되지 않은 정규식 메타 문자가 있습니다(용어는 정규식으로 해석됨): {terms}. 리터럴 일치를 원하면 문자 앞에 백슬래시를 추가하세요(예: Dr.whob → Dr\\.whob).",
+    "{count} terim, kaçışlanmamış normal ifade meta karakterleri içeriyor (terimler normal ifade olarak ayrıştırılır): {terms}. Birebir eşleşme için karakterden önce ters eğik çizgi koyun, ör. Dr.whob yerine Dr\\.whob yazın.",
+    "{count} thuật ngữ chứa ký tự đặc biệt regex chưa thoát (thuật ngữ được phân tích như regex): {terms}. Để khớp ký tự theo nghĩa đen, hãy thêm dấu gạch chéo ngược trước ký tự, ví dụ viết Dr\\.whob cho Dr.whob."
+  ),
+  terminology_playground_web_note: terminologyPlaygroundText(
+    "当前为 web 模式（普通浏览器标签页）：AI 翻译请求可能被浏览器 CORS 拦截（多数 AI 接口未开放跨域）。本地术语替换预览不受影响；真实 AI 翻译测试请在打包后的扩展（background 代发）或油猴（GM.xmlHttpRequest）环境中验证。",
+    "You are in web mode (a normal browser tab): AI translation requests may be blocked by browser CORS (most AI APIs do not allow cross-origin access). Local term replacement preview is unaffected; verify real AI translation in a packaged extension (background proxy) or a userscript (GM.xmlHttpRequest) environment.",
+    "目前為 web 模式（一般瀏覽器分頁）：AI 翻譯請求可能被瀏覽器 CORS 攔截（多數 AI 介面未開放跨域）。本機術語替換預覽不受影響；真實 AI 翻譯測試請在打包後的擴充功能（background 代發）或油猴（GM.xmlHttpRequest）環境中驗證。",
+    "現在は web モード（通常のブラウザータブ）です：AI 翻訳リクエストはブラウザーの CORS でブロックされる可能性があります（多くの AI API はクロスオリジンを許可していません）。ローカル用語置換プレビューには影響しません。実際の AI 翻訳テストは、パッケージ化した拡張機能（background 経由）またはユーザースクリプト（GM.xmlHttpRequest）環境で検証してください。",
+    "현재 web 모드(일반 브라우저 탭)입니다: AI 번역 요청이 브라우저 CORS로 차단될 수 있습니다(대부분 AI API가 교차 출처를 허용하지 않음). 로컬 용어 교체 미리보기에는 영향을 주지 않습니다. 실제 AI 번역 테스트는 패키징된 확장 프로그램(background 대리 요청) 또는 유저스크립트(GM.xmlHttpRequest) 환경에서 검증하세요.",
+    "Şu anda web modundasınız (normal bir tarayıcı sekmesi): AI çeviri istekleri tarayıcı CORS tarafından engellenebilir (çoğu AI API'si çapraz kaynak erişimine izin vermez). Yerel terim değiştirme önizlemesi etkilenmez. Gerçek AI çeviri testini paketlenmiş uzantı (background vekâleti) veya kullanıcı betiği (GM.xmlHttpRequest) ortamında doğrulayın.",
+    "Bạn đang ở chế độ web (tab trình duyệt thông thường): các yêu cầu dịch AI có thể bị chặn bởi CORS của trình duyệt (hầu hết API AI không cho phép truy cập chéo nguồn gốc). Xem trước thay thế thuật ngữ cục bộ không bị ảnh hưởng. Hãy xác minh kiểm tra dịch AI thực trong môi trường tiện ích mở rộng đã đóng gói (ủy quyền background) hoặc userscript (GM.xmlHttpRequest)."
+  ),
+  // ── _delivery_*：四态 Chip 与实际值包装 ─────────────────────────────
+  terminology_playground_delivery_delivered: terminologyPlaygroundText(
+    "已发出",
+    "Sent",
+    "已發送",
+    "送信済み",
+    "전송됨",
+    "Gönderildi",
+    "Đã gửi"
+  ),
+  terminology_playground_delivery_mismatch: terminologyPlaygroundText(
+    "值不一致",
+    "Value mismatch",
+    "值不一致",
+    "値が不一致",
+    "값 불일치",
+    "Değer uyuşmuyor",
+    "Giá trị không khớp"
+  ),
+  terminology_playground_delivery_missing: terminologyPlaygroundText(
+    "未发出",
+    "Not sent",
+    "未發送",
+    "未送信",
+    "전송되지 않음",
+    "Gönderilmedi",
+    "Không gửi"
+  ),
+  terminology_playground_delivery_uncaptured: terminologyPlaygroundText(
+    "未捕获",
+    "Not captured",
+    "未捕獲",
+    "未検出",
+    "검출 안 됨",
+    "Yakalanamadı",
+    "Không phát hiện"
+  ),
+  terminology_playground_delivery_value_wrap: terminologyPlaygroundText(
+    "{label}（实际值：{value}）",
+    "{label} (actual: {value})",
+    "{label}（實際值：{value}）",
+    "{label}（実際の値：{value}）",
+    "{label}（실제 값：{value}）",
+    "{label} (gerçek değer: {value})",
+    "{label}（giá trị thực: {value}）"
+  ),
+  terminology_playground_delivery_empty: terminologyPlaygroundText(
+    "（空）",
+    "(empty)",
+    "（空）",
+    "（空）",
+    "（없음）",
+    "(boş)",
+    "（trống）"
+  ),
+
+  // ── _channel_*：注入通道描述 ────────────────────────────────────────
+  terminology_playground_channel_custom: terminologyPlaygroundText(
+    "自定义接口：不注入提示词与术语（需自行实现 reqHook）",
+    "Custom API: no prompt or terms injected (implement reqHook yourself)",
+    "自訂介面：不注入提示詞與術語（需自行實作 reqHook）",
+    "カスタムAPI：プロンプトや用語を注入しません（reqHook を自分で実装）",
+    "사용자 정의 API: 프롬프트와 용어를 주입하지 않음 (reqHook 직접 구현 필요)",
+    "Özel API: istem veya terim enjekte edilmez (reqHook'u kendiniz uygulayın)",
+    "API tùy chỉnh: không chèn lời nhắc và thuật ngữ (tự triển khai reqHook)"
+  ),
+  terminology_playground_channel_qwenmt: terminologyPlaygroundText(
+    "服务端原生术语 translation_options.terms",
+    "Server-side native terms translation_options.terms",
+    "服務端原生術語 translation_options.terms",
+    "サーバー側ネイティブ用語 translation_options.terms",
+    "서버 네이티브 용어 translation_options.terms",
+    "Sunucu tarafı yerel terimler translation_options.terms",
+    "Thuật ngữ gốc phía máy chủ translation_options.terms"
+  ),
+  terminology_playground_channel_batch: terminologyPlaygroundText(
+    "批量 JSON glossary 字段",
+    "Batch JSON glossary field",
+    "批次 JSON glossary 欄位",
+    "バッチ JSON glossary フィールド",
+    "배치 JSON glossary 필드",
+    "Toplu JSON glossary alanı",
+    "Trường JSON glossary dạng lô"
+  ),
+  terminology_playground_channel_nobatch: terminologyPlaygroundText(
+    "非批量 {{glossary}} 占位符",
+    "Non-batch {{glossary}} placeholder",
+    "非批次 {{glossary}} 佔位符",
+    "非バッチ {{glossary}} プレースホルダー",
+    "비배치 {{glossary}} 플레이스홀더",
+    "Batch olmayan {{glossary}} yer tutucusu",
+    "Giữ chỗ {{glossary}} không theo lô"
+  ),
+
+  // ── _prompt_*：提示词标签 ───────────────────────────────────────────
+  terminology_playground_prompt_none: terminologyPlaygroundText(
+    "不使用翻译提示词",
+    "No translation prompt used",
+    "不使用翻譯提示詞",
+    "翻訳プロンプトを使用しない",
+    "번역 프롬프트를 사용하지 않음",
+    "Çeviri istemi kullanılmaz",
+    "Không dùng lời khách dịch"
+  ),
+  terminology_playground_prompt_json: terminologyPlaygroundText(
+    "JSON 聚合翻译提示词",
+    "JSON batch translation prompt",
+    "JSON 聚合翻譯提示詞",
+    "JSON 一括翻訳プロンプト",
+    "JSON 일괄 번역 프롬프트",
+    "JSON toplu çeviri istemi",
+    "Lời khách dịch lô JSON"
+  ),
+  terminology_playground_prompt_xml: terminologyPlaygroundText(
+    "XML 聚合翻译提示词",
+    "XML batch translation prompt",
+    "XML 聚合翻譯提示詞",
+    "XML 一括翻訳プロンプト",
+    "XML 일괄 번역 프롬프트",
+    "XML toplu çeviri istemi",
+    "Lời khách dịch lô XML"
+  ),
+  terminology_playground_prompt_line: terminologyPlaygroundText(
+    "LINE 聚合翻译提示词",
+    "LINE batch translation prompt",
+    "LINE 聚合翻譯提示詞",
+    "LINE 一括翻訳プロンプト",
+    "LINE 일괄 번역 프롬프트",
+    "LINE toplu çeviri istemi",
+    "Lời khách dịch lô LINE"
+  ),
+  terminology_playground_prompt_custom_batch: terminologyPlaygroundText(
+    "自定义聚合提示词",
+    "Custom batch prompt",
+    "自訂聚合提示詞",
+    "カスタム一括プロンプト",
+    "사용자 정의 일괄 프롬프트",
+    "Özel toplu istem",
+    "Lời khách lô tùy chỉnh"
+  ),
+  terminology_playground_prompt_nobatch: terminologyPlaygroundText(
+    "非批量翻译提示词",
+    "Non-batch translation prompt",
+    "非批次翻譯提示詞",
+    "非バッチ翻訳プロンプト",
+    "비배치 번역 프롬프트",
+    "Batch olmayan çeviri istemi",
+    "Lời khách dịch không theo lô"
+  ),
+  terminology_playground_prompt_custom_nobatch: terminologyPlaygroundText(
+    "自定义非批量提示词",
+    "Custom non-batch prompt",
+    "自訂非批次提示詞",
+    "カスタム非バッチプロンプト",
+    "사용자 정의 비배치 프롬프트",
+    "Özel non-batch istemi",
+    "Custom prompt không theo lô"
+  ),
+
+  // ── _alert_*：Snackbar 与错误弹窗文案 ──────────────────────────────
+  terminology_playground_alert_invalid_terms: terminologyPlaygroundText(
+    "存在非法术语段，请先修正输入后再测试。",
+    "Invalid term segments found. Fix the input before testing.",
+    "存在非法術語段，請先修正輸入後再測試。",
+    "不正な用語セグメントがあります。テスト前に入力を修正してください。",
+    "잘못된 용어 세그먼트가 있습니다. 테스트 전에 입력을 수정하세요.",
+    "Geçersiz terim bölümleri var; testten önce girdiyi düzeltin.",
+    "Có đoạn thuật ngữ không hợp lệ; hãy sửa đầu vào trước khi kiểm tra."
+  ),
+  terminology_playground_alert_no_example: terminologyPlaygroundText(
+    "未生成可测试的例句。",
+    "No testable example was generated.",
+    "未產生可測試的例句。",
+    "テスト可能な例文が生成されませんでした。",
+    "테스트 가능한 예문이 생성되지 않았습니다.",
+    "Test edilebilir örnek oluşturulmadı.",
+    "Không tạo được câu ví dụ kiểm tra được."
+  ),
+  terminology_playground_alert_test_passed: terminologyPlaygroundText(
+    "测试通过",
+    "Test passed",
+    "測試通過",
+    "テスト成功",
+    "테스트 통과",
+    "Test geçti",
+    "Kiểm tra đạt"
+  ),
+  terminology_playground_alert_example_label: terminologyPlaygroundText(
+    "例句：",
+    "Example: ",
+    "例句：",
+    "例文：",
+    "예문: ",
+    "Örnek: ",
+    "Ví dụ: "
+  ),
+  terminology_playground_alert_replaced_label: terminologyPlaygroundText(
+    "替换后：",
+    "Replaced: ",
+    "替換後：",
+    "置換後：",
+    "교체 후: ",
+    "Değiştirilmiş: ",
+    "Sau thay thế: "
+  ),
+  terminology_playground_alert_test_failed: terminologyPlaygroundText(
+    "测试失败",
+    "Test failed",
+    "測試失敗",
+    "テスト失敗",
+    "테스트 실패",
+    "Test başarısız",
+    "Kiểm tra thất bại"
+  ),
+  terminology_playground_alert_no_api: terminologyPlaygroundText(
+    "请先在顶部选择要测试的翻译接口。",
+    "Select a translation API at the top first.",
+    "請先在頂部選擇要測試的翻譯介面。",
+    "先に上部でテストする翻訳 API を選択してください。",
+    "먼저 상단에서 테스트할 번역 API를 선택하세요.",
+    "Önce üstten test edilecek çeviri API'sini seçin.",
+    "Hãy chọn API dịch để kiểm tra ở phía trên trước."
+  ),
+  terminology_playground_alert_api_not_supported: terminologyPlaygroundText(
+    "该接口不支持 AI 专业术语",
+    "This API does not support AI terms",
+    "該介面不支援 AI 專業術語",
+    "この API は AI 専門用語をサポートしていません",
+    "이 API는 AI 전문 용어를 지원하지 않습니다",
+    "Bu API AI terimlerini desteklemiyor",
+    "API này không hỗ trợ thuật ngữ AI"
+  ),
+  terminology_playground_alert_api_not_supported_body:
+    terminologyPlaygroundText(
+      "{apiName} 是 {type}接口，不支持注入提示词，AI 专业术语（规则级/接口级）不会生效。 请选 AI 接口（OpenAI 兼容/Gemini/Claude 等）。",
+      "{apiName} is a {type} API. It does not support prompt injection, so AI terms (rule-level/API-level) will not take effect. Choose an AI API (OpenAI-compatible/Gemini/Claude, etc.).",
+      "{apiName} 是{type}介面，不支援注入提示詞，AI 專業術語（規則級/介面級）不會生效。請選 AI 介面（OpenAI 相容/Gemini/Claude 等）。",
+      "{apiName} は{type} API です。プロンプト注入に対応していないため、AI 専門用語（ルールレベル/APIレベル）は反映されません。AI 対応 API（OpenAI 互換/Gemini/Claude など）を選択してください。",
+      "{apiName}는 {type} API입니다. 프롬프트 주입을 지원하지 않아 AI 전문 용어(규칙급/API급)가 적용되지 않습니다. AI API(OpenAI 호환/Gemini/Claude 등)를 선택하세요.",
+      "{apiName} bir {type} API'sidir. Prompt enjeksiyonu desteklemediğinden AI terimleri (kural/API düzeyi) uygulanmaz. Bir AI API'si (OpenAI uyumlu/Gemini/Claude vb.) seçin.",
+      "{apiName} là API {type}. Không hỗ trợ prompt injection nên thuật ngữ AI (cấp quy tắc/cấp API) sẽ không hiệu lực. Hãy chọn API AI (tương thích OpenAI/Gemini/Claude...)."
+    ),
+  terminology_playground_api_type_machine: terminologyPlaygroundText(
+    "机器翻译",
+    "machine translation",
+    "機器翻譯",
+    "機械翻訳",
+    "기계 번역",
+    "makine çevirisi",
+    "dịch máy"
+  ),
+  terminology_playground_api_type_traditional: terminologyPlaygroundText(
+    "传统翻译",
+    "traditional translation",
+    "傳統翻譯",
+    "従来型翻訳",
+    "전통 번역",
+    "geleneksel çeviri",
+    "dịch truyền thống"
+  ),
+  terminology_playground_alert_ai_terms_required: terminologyPlaygroundText(
+    "请先输入 AI 专业术语以生成测试例句。",
+    "Enter AI terms to generate a test example first.",
+    "請先輸入 AI 專業術語以產生測試例句。",
+    "先に AI 専門用語を入力してテスト例を生成してください。",
+    "먼저 AI 전문 용어를 입력하여 테스트 예문을 생성하세요.",
+    "Önce AI terimlerini girip bir test örneği oluşturun.",
+    "Hãy nhập thuật ngữ AI để tạo câu ví dụ kiểm tra trước."
+  ),
+  terminology_playground_alert_ai_test_failed: terminologyPlaygroundText(
+    "AI 翻译测试失败",
+    "AI translation test failed",
+    "AI 翻譯測試失敗",
+    "AI 翻訳テストに失敗",
+    "AI 번역 테스트 실패",
+    "AI çeviri testi başarısız",
+    "Kiểm tra dịch AI thất bại"
+  ),
+
+  // ── _api_*：接口选择器区 ────────────────────────────────────────────
+  terminology_playground_api_title: terminologyPlaygroundText(
+    "接口选择",
+    "API selection",
+    "介面選擇",
+    "API 選択",
+    "API 선택",
+    "API seçimi",
+    "Chọn API"
+  ),
+  terminology_playground_api_desc: terminologyPlaygroundText(
+    "机器翻译与传统翻译接口（Microsoft、DeepL、Google 等）不支持 AI 专业术语；AI 模型接口与 QwenMT 支持。",
+    "Machine- and traditional-translation APIs (Microsoft, DeepL, Google, etc.) do not support AI terms; AI model APIs and QwenMT do.",
+    "機器翻譯與傳統翻譯介面（Microsoft、DeepL、Google 等）不支援 AI 專業術語；AI 模型介面與 QwenMT 支援。",
+    "機械翻訳・従来型翻訳 API（Microsoft、DeepL、Google など）は AI 専門用語に非対応です。AI モデル API と QwenMT は対応します。",
+    "기계 번역 및 전통 번역 API(Microsoft, DeepL, Google 등)는 AI 전문 용어를 지원하지 않습니다. AI 모델 API와 QwenMT는 지원합니다.",
+    "Makine ve geleneksel çeviri API'leri (Microsoft, DeepL, Google vb.) AI terimlerini desteklemez; AI model API'leri ve QwenMT destekler.",
+    "API dịch máy và dịch truyền thống (Microsoft, DeepL, Google...) không hỗ trợ thuật ngữ AI; API mô hình AI và QwenMT thì có."
+  ),
+  terminology_playground_api_label: terminologyPlaygroundText(
+    "翻译接口",
+    "Translation API",
+    "翻譯介面",
+    "翻訳 API",
+    "번역 API",
+    "Çeviri API'si",
+    "API dịch"
+  ),
+  terminology_playground_api_none: terminologyPlaygroundText(
+    "未配置可用接口，请先到「接口设置」页配置",
+    'No usable API configured; add one on the "API Settings" page first.',
+    "未配置可用介面，請先到「介面設定」頁配置",
+    "有効な API が設定されていません。「API 設定」ページで先に追加してください。",
+    "사용 가능한 API가 설정되지 않았습니다. 먼저 「API 설정」페이지에서 추가하세요.",
+    'Etkin API yapılandırılmamış; önce "API Ayarları" sayfasında ekleyin.',
+    'Chưa cấu hình API khả dụng; hãy thêm ở trang "Cài đặt API" trước.'
+  ),
+  terminology_playground_api_machine_note: terminologyPlaygroundText(
+    "当前为{type}，AI 专业术语无法生效。",
+    "Currently {type}; AI terms cannot take effect.",
+    "目前為{type}，AI 專業術語無法生效。",
+    "現在は{type}です。AI 専門用語は反映されません。",
+    "현재 {type}입니다. AI 전문 용어는 적용되지 않습니다.",
+    "Şu anda {type}; AI terimleri etkili olamaz.",
+    "Hiện là {type}; thuật ngữ AI không thể có hiệu lực."
+  ),
+  terminology_playground_api_qwenmt_note: terminologyPlaygroundText(
+    "当前为 QwenMT，AI 专业术语可生效。",
+    "Currently QwenMT; AI terms can take effect.",
+    "目前為 QwenMT，AI 專業術語可生效。",
+    "現在は QwenMT です。AI 専門用語が反映されます。",
+    "현재 QwenMT입니다. AI 전문 용어가 적용됩니다.",
+    "Şu anda QwenMT; AI terimleri etkili olabilir.",
+    "Hiện là QwenMT; thuật ngữ AI có thể có hiệu lực."
+  ),
+  terminology_playground_api_ai_note: terminologyPlaygroundText(
+    "当前为 AI 翻译，AI 专业术语可生效。",
+    "Currently AI translation; AI terms can take effect.",
+    "目前為 AI 翻譯，AI 專業術語可生效。",
+    "現在は AI 翻訳です。AI 専門用語が反映されます。",
+    "현재 AI 번역입니다. AI 전문 용어가 적용됩니다.",
+    "Şu anda AI çevirisi; AI terimleri etkili olabilir.",
+    "Hiện là dịch AI; thuật ngữ AI có thể có hiệu lực."
+  ),
+
+  // ── _local_*：本地术语区按钮与标签 ──────────────────────────────────
+  terminology_playground_local_test: terminologyPlaygroundText(
+    "测试",
+    "Test",
+    "測試",
+    "テスト",
+    "테스트",
+    "Test",
+    "Kiểm tra"
+  ),
+  terminology_playground_local_default: terminologyPlaygroundText(
+    "默认",
+    "Default",
+    "預設",
+    "デフォルト",
+    "기본",
+    "Varsayılan",
+    "Mặc định"
+  ),
+  terminology_playground_local_example: terminologyPlaygroundText(
+    "例句",
+    "Example",
+    "例句",
+    "例文",
+    "예문",
+    "Örnek",
+    "Ví dụ"
+  ),
+  terminology_playground_local_pass: terminologyPlaygroundText(
+    "本地替换通过",
+    "Local replace OK",
+    "本地替換通過",
+    "ローカル置換 合格",
+    "로컬 치환 통과",
+    "Yerel değiştirme başarılı",
+    "Thay thế cục bộ đạt"
+  ),
+  terminology_playground_local_fail: terminologyPlaygroundText(
+    "本地替换异常",
+    "Local replace failed",
+    "本地替換異常",
+    "ローカル置換 失敗",
+    "로컬 치환 실패",
+    "Yerel değiştirme hatası",
+    "Lỗi thay thế cục bộ"
+  ),
+  // 徽标语义澄清：该断言只覆盖本地正则替换自检，不代表 AI 接口的遵循效果。
+  terminology_playground_local_replace_hint: terminologyPlaygroundText(
+    "本地自检：已对当前例句执行一次正则替换断言，全部术语命中并按预期替换；不代表 AI 接口的实际遵循效果。",
+    "Local self-check: a regex replacement assertion ran on this example; all terms matched and were replaced as expected. It does not reflect actual AI API adherence.",
+    "本地自檢：已對當前例句執行一次正則替換斷言，全部術語命中並按預期替換；不代表 AI 介面的實際遵循效果。",
+    "ローカル自己チェック：この例文に正規表現置換アサーションを実行し、全用語が命中・期待どおりに置換されました。AI API の実際の遵守を示すものではありません。",
+    "로컬 자가 검사: 현재 예문에 정규식 치환 단언을 실행했으며 모든 용어가 일치하고 예상대로 치환되었습니다. AI API의 실제 준수 여부를 나타내지 않습니다.",
+    "Yerel öz-denetim: Bu örnek üzerinde regex değiştirme doğrulaması çalıştırıldı; tüm terimler eşleşti ve beklendiği gibi değiştirildi. AI API'nin gerçek uyumunu yansıtmaz.",
+    "Tự kiểm tra cục bộ: Đã chạy xác nhận thay thế regex trên ví dụ này; mọi thuật ngữ đều khớp và được thay đúng như mong đợi. Không phản ánh mức tuân thủ thực tế của AI API."
+  ),
+
+  // ── _terms_*：AI 专业术语输入区 ─────────────────────────────────────
+  terminology_playground_terms_title: terminologyPlaygroundText(
+    "AI 专业术语（术语表预览 + 真实 AI 翻译测试）",
+    "AI terms (glossary preview + real AI translation test)",
+    "AI 專業術語（術語表預覽 + 真實 AI 翻譯測試）",
+    "AI 専門用語（用語集プレビュー + 実際の AI 翻訳テスト）",
+    "AI 전문 용어(용어 사전 미리보기 + 실제 AI 번역 테스트)",
+    "AI terimleri (sözlük önizlemesi + gerçek AI çeviri testi)",
+    "Thuật ngữ AI (xem trước glossary + kiểm tra dịch AI thực)"
+  ),
+  terminology_playground_terms_help_intro: terminologyPlaygroundText(
+    "键值对，每行或 `;` 分隔。选 AI 接口后点「测试」发起真实请求。 术语表为**软注入**，模型不保证遵循。",
+    'Key-value pairs, one per line or separated by `;`. Select an AI API and click "Test" to send a real request. The glossary is a **soft injection**; the model does not guarantee to follow it.',
+    "鍵值對，每行或 `;` 分隔。選 AI 介面後點「測試」發起真實請求。術語表為**軟注入**，模型不保證遵循。",
+    "key:value、1行1つまたは `;` 区切りです。AI 対応 API を選んで「テスト」をクリックすると実際のリクエストを送信します。用語集は**ソフト注入**で、モデルは必ず従うとは限りません。",
+    'key:value, 한 줄에 하나 또는 `;` 로 구분합니다. AI API를 선택하고 "테스트"를 클릭하면 실제 요청을 보냅니다. 용어 사전은 **소프트 주입**이며 모델이 반드시 따르는 것은 아닙니다.',
+    'key:value çiftleri, her satırda bir veya `;` ile ayrılmış. Bir AI API\'si seçip "Test"e tıklayınca gerçek bir istek gönderilir. Sözlük **yumuşak enjeksiyon**dur; modelin uyacağı garanti edilmez.',
+    'Cặp key:value, mỗi dòng một mục hoặc ngăn cách bằng `;`. Chọn API AI và bấm "Kiểm tra" để gửi yêu cầu thực. Glossary được **nhúng mềm**; model không đảm bảo tuân theo.'
+  ),
+  terminology_playground_terms_help_more: terminologyPlaygroundText(
+    "更多",
+    "More",
+    "更多",
+    "もっと見る",
+    "더 보기",
+    "Daha fazla",
+    "Xem thêm"
+  ),
+  terminology_playground_terms_help_collapse: terminologyPlaygroundText(
+    "收起",
+    "Collapse",
+    "收起",
+    "閉じる",
+    "접기",
+    "Kapat",
+    "Thu gọn"
+  ),
+  // 译者须知：** 与 ` 标记必须保留，标记内文本可翻译。
+  terminology_playground_terms_help_detail_a: terminologyPlaygroundText(
+    "本区数据为临时测试数据，已自动保留上一次输入，正式保存请复制到「规则/接口设置」页。 AI 专业术语不支持正则表达式。 注意：术语表是通过提示词**软注入**的，模型不保证一定遵循；遇到强先验词 （模型已熟知的专有名词/固定译法，如 API、token）可能压不住，建议用造词 （如 zorp,数据管道）排除干扰。要**必定**替换请写到本地专业术语 （规则 → 术语）：那是正则硬替换、原词不进请求，但注意它按正则语义解析， 元字符 `. + * ? ( ) [ ] \\ | ^ $` 需转义，且只作用于整页翻译的段落正文。 AI 专业术语仅作辅助。",
+    "The data here is temporary test data; the last input is kept automatically. To save it for real, copy it to the Rules/API Settings page. AI terms do not support regex. Note: the glossary is **soft-injected** via the prompt, and the model does not guarantee to follow it. Strong prior terms (well-known names or fixed translations the model already knows, e.g. API, token) may not be suppressed, so we recommend using invented terms (e.g. `zorp,data pipeline`) to remove interference. For a **guaranteed** replacement, put it in the local terms (Rule → Terms): that is a hard regex replacement and the original word is not sent, but note it is parsed by regex semantics, metacharacters `. + * ? ( ) [ ] \\ | ^ $` must be escaped, and it only applies to the body of the page translation.",
+    "本區資料為臨時測試資料，已自動保留上次輸入，正式儲存請複製到「規則/介面設定」頁。AI 專業術語不支援正則。注意：術語表是透過提示詞**軟注入**的，模型不保證一定遵循；遇到強先驗詞（模型已熟知的專有名稱/固定譯法，如 API、token）可能壓不住，建議用造詞（如 zorp,資料管線）排除干擾。要**必定**替換請寫到本機專業術語（規則 → 術語）：那是正則硬替換、原詞不進請求，但注意它依正則語意解析，元字符 `. + * ? ( ) [ ] \\ | ^ $` 需跳脫，且只作用於整頁翻譯的段落正文。AI 專業術語僅作輔助。",
+    "ここは一時的なテストデータです。前回の入力は自動で保持され、正式に保存するには「ルール/API設定」ページへコピーしてください。AI専門用語は正規表現非対応。用語集はプロンプトによる**ソフト注入**で、モデルが必ず従うとは限りません。強い事前知識のある用語（API、パッケージなどモデルが既に知っている固有名）は抑制できない場合があるため、造語（例：zorp,データパイプライン）で干渉を排除することを推奨します。**確実に**置換したい場合はローカル専門用語（ルール → 用語）に書いてください：正規表現によるハード置換で原文はリクエストに送られませんが、正規表現メタ文字 `. + * ? ( ) [ ] \\ | ^ $` はエスケープが必要で、ページ翻訳の本文にのみ適用されます。AI専門用語は補助です。",
+    '여기 데이터는 임시 테스트 데이터입니다. 마지막 입력은 자동으로 유지되며 실제 저장은 "규칙/API 설정" 페이지에 복사하세요. AI 용어는 정규식을 지원하지 않습니다. 용어집은 프롬프트를 통해 **소프트 주입**되며 모델이 반드시 따르지 않습니다. 강한 사전 지식(모델이 아는 고유명사/고정 번역, 예: API, package)은 눌리지 않을 수 있으니 인공 단어(예: zorp,데이터 파이프라인)로 간섭을 제거하는 것을 권장합니다. **반드시** 교체하려면 로컬 전문 용어(규칙 → 용어)에 작성하세요. 정규식 하드 교체로 원본이 요청에 포함되지 않지만 정규식 의미로 해석되므로 메타 문자 `. + * ? ( ) [ ] \\ | ^ $` 는 이스케이프해야 하며 페이지 본문에만 적용됩니다. AI 전문 용어는 보조적입니다.',
+    'Buradaki veri geçici test verisidir; son girdi otomatik saklanır, kalıcı kayıt için "Kurallar/API Ayarları" sayfasına kopyalayın. AI terimleri regex desteklemez. Sözlük istem yoluyla **yumuşak enjekte** edilir ve modelin uyacağı garanti edilmez; güçlü önceliği (modelin zaten bildiği özel isimler/teslim çeviriler, ör. API, token) bastırılamaz, bu yüzden uydurma terimler (ör. zorp) ile etkileşimi giderin. **Kesin** uygulama için yerel terimlere (Kural → Terimler) yazın: bu regex ile sert değiştirmedir ve orijinal kelime gönderilmez; ancak regex meta karakterleri (`. + * ? ( ) [ ] \\ | ^ $`) kaçışlanmalı ve yalnızca sayfa çevirisinin gövdesine uygulanır. AI terimleri yalnızca yardımcıdır.',
+    'Dữ liệu ở đây là dữ liệu kiểm tra tạm thời; nhập cuối được giữ tự động, muốn lưu chính thức hãy copy sang trang "Quy tắc/Cài đặt API". Thuật ngữ AI không hỗ trợ regex. Glossary được **nhúng mềm** qua prompt; model không đảm bảo tuân theo. Với từ mạnh tiên nghiệm (tên riêng/bản dịch cố định model đã biết, như API, token) có thể không chặn được, nên dùng từ chế ra (như zorp,đường ống dữ liệu) để loại nhiễu. Muốn **chắc chắn** thay thế hãy viết vào thuật ngữ cục bộ (Quy tắc → Thuật ngữ): đó là thay thế cứng bằng regex, từ gốc không vào yêu cầu; nhưng nó được phân tích theo ngữ nghĩa regex, ký tự đặc biệt `. + * ? ( ) [ ] \\ | ^ $` phải thoát và chỉ tác dụng lên thân bài dịch toàn trang. Thuật ngữ AI chỉ mang tính hỗ trợ.'
+  ),
+  terminology_playground_terms_help_detail_b: terminologyPlaygroundText(
+    "另外，接口的**「聚合发送翻译请求」开关会影响遵循率**：开启时术语作为结构化 `glossary` 字段发出，且系统提示词带「最高优先级、只输出术语值」的显式指令； 关闭时术语退化为提示词里的 `- 原词: 译文` 文本行，无结构、指令权重低， 小参数模型（8B 级）经常压不住。实测 Qwen3-8B 关闭聚合时替换不稳定、开启后显著改善； Qwen3.6-27B 与 Gemini 3.5 Flash Lite 两种模式都能稳定替换。**术语不生效时优先试着开启聚合。**",
+    'Also, the API\'s **"batch send translation request" switch affects adherence**: when enabled, terms are sent as a structured `glossary` field and the system prompt carries an explicit "highest priority, output term values only" instruction; when disabled, terms degrade to `- original: translation` text lines in the prompt, with no structure and low instruction weight, which small models (8B class) often fail to follow. In practice Qwen3-8B is unstable without the aggregate switch and significantly better with it; Qwen3.6-27B and Gemini 3.5 Flash Lite follow both modes stably. **Prefer turning on aggregation when terms do not take effect.**',
+    "另外，介面的**「聚合傳送翻譯請求」開關會影響遵循率**：開啟時術語作為結構化 `glossary` 欄位發出，且系統提示詞帶「最高優先級、只輸出術語值」的顯式指令；關閉時術語退化為提示詞裡的 `- 原詞: 譯文` 文字行，無結構、指令權重低，小參數模型（8B 級）經常壓不住。實測 Qwen3-8B 關閉聚合時替換不穩定、開啟後顯著改善；Qwen3.6-27B 與 Gemini 3.5 Flash Lite 兩種模式都能穩定替換。**術語不生效時優先試著開啟聚合。**",
+    "また、API の**「一括送信翻訳リクエスト」スイッチは順守率に影響します**：ON のとき用語は構造化 `glossary` フィールドとして送られ、システムプロンプトに「最優先・用語値のみ出力」の明示命令が付きます。OFF のとき用語はプロンプト内の `- 原語: 訳語` テキスト行に退化し、構造がなく命令の重みが低いため、小規模モデル（8B級）では抑えられないことがよくあります。実測では Qwen3-8B は集約OFF で置換が不安定、ON で大幅改善。Qwen3.6-27B と Gemini 3.5 Flash Lite はどちらも安定しています。**用語が効かないときはまず集約をONにしてください。**",
+    '또한 인터페이스의 **"일괄 보내기" 스위치는 준수율에 영향을**: 켜져 있으면 용어가 구조적 `glossary` 필드로 나가고 시스템 프롬프트에 "최우선, 용어 값만 출력" 명령이 포함됩니다. 꺼져 있으면 용어는 프롬프트의 `- 원어: 번역` 텍스트로 퇴화하고 구조가 없어 명령 가중치가 낮아 소규모 모델(8B 급)이 자주 못 지킵니다. Qwen3-8B 실제 측정에서는 일괄 꺼짐 시 불안정, 켜짐 시 크게 개선; Qwen3.6-27B와 Gemini 3.5 Flash Lite는 두 모드 모두 안정적입니다. **용어가 적용되지 않으면 먼저 일괄을 켜보세요.**',
+    'Ayrıca API\'nin **"toplu gönder" anahtarı uyum oranını etkiler**: açıkken terimler yapısal `glossary` alanı olarak gönderilir ve sistem istemine "en yüksek öncelik, yalnızca terim değeri" talimatı eklenir. Kapalıyken terimler `- kelime: çeviri` metin satırlarına dönüşür, yapı ve öncelik ağırlığı düşer; küçük modeller (8B) çoğunlukla uyamaz. Qwen3-8B kapatılınca tutarsız, açılınca belirgin iyileşti; Qwen3.6-27B ve Gemini 3.5 Flash Lite her iki modda da sabittir. **Terimler uygulanmazsa önce toplu özelliği açmayı deneyin.**',
+    'Ngoài ra, **công tắc "gửi lô" của API ảnh hưởng tỷ lệ tuân thủ**: khi bật, thuật ngữ được gửi dưới dạng trường `glossary` có cấu trúc và prompt hệ thống có chỉ thị rõ "ưu tiên cao nhất, chỉ xuất giá trị thuật ngữ"; khi tắt, thuật ngữ suy thành dòng văn bản `- từ gốc: bản dịch`, không cấu trúc và trọng số chỉ dẫn thấp, model nhỏ (cấp 8B) thường không giữ được. Qwen3-8B tắt lô thay thế không ổn định, bật lên cải thiện rõ; Qwen3.6-27B và Gemini 3.5 Flash Lite đều ổn định ở cả hai chế độ. **Nếu thuật ngữ không hiệu quả, hãy thử bật lô trước.**'
+  ),
+  terminology_playground_terms_input_label: terminologyPlaygroundText(
+    "AI 专业术语",
+    "AI terms",
+    "AI 專業術語",
+    "AI 専門用語",
+    "AI 전문 용어",
+    "AI terimleri",
+    "Thuật ngữ AI"
+  ),
+  // 示例术语：zorp / quzzle 为造词，全语言保持不变（见计划 §4.1）。
+  terminology_playground_terms_sample: terminologyPlaygroundText(
+    "zorp,数据管道\nquzzle,缓存节点",
+    "zorp,data pipeline\nquzzle,cache node",
+    "zorp,資料管線\nquzzle,快取節點",
+    "zorp,データパイプライン\nquzzle,キャッシュノード",
+    "zorp,데이터 파이프라인\nquzzle,캐시 노드",
+    "zorp,veri hattı\nquzzle,önbellek düğümü",
+    "zorp,đường ống dữ liệu\nquzzle,nút bộ đệm"
+  ),
+  terminology_playground_terms_count: terminologyPlaygroundText(
+    "解析出 {count} 条术语",
+    "{count} terms parsed",
+    "解析出 {count} 條術語",
+    "{count} 件の用語を解析",
+    "{count}개 용어 파싱됨",
+    "{count} terim ayrıştırıldı",
+    "Đã phân tích {count} thuật ngữ"
+  ),
+  terminology_playground_terms_helper_empty: terminologyPlaygroundText(
+    "输入键值对格式的术语，每行或 ; 分隔",
+    "Enter terms in key,value format, one per line or separated by ;",
+    "輸入鍵值對格式的術語，每行或 ; 分隔",
+    "key,value 形式の用語を入力（改行または「;」区切り）",
+    "key,value 형식으로 용어 입력(한 줄에 하나 또는 ; 구분)",
+    "key,value biçiminde terimleri girin (her satırda bir veya ; ile)",
+    "Nhập thuật ngữ dạng key,value, mỗi dòng một mục hoặc ngăn cách bằng ;"
+  ),
+  terminology_playground_terms_parsed_title: terminologyPlaygroundText(
+    "解析后的术语表键值对（将按此格式合并到提示词中的术语表占位符）：",
+    "Parsed glossary key/value pairs (merged into the glossary placeholder in this format):",
+    "解析後的術語表鍵值對（將依此格式合併到提示詞中的術語表佔位符）：",
+    "解析後の用語集のキー/値（この形式で用語集プレースホルダーにマージされます）：",
+    "파싱된 용어 사전 key/value(이 형식으로 glossary placeholder에 병합됨):",
+    "Ayrıştırılan sözlük key/value çiftleri (bu biçimde sözlük yer tutucusuna birleştirilir):",
+    "Cặp key/value glossary đã phân tích (sẽ được hợp vào placeholder glossary theo định dạng này):"
+  ),
+  terminology_playground_terms_col_term: terminologyPlaygroundText(
+    "术语（键）",
+    "Term (key)",
+    "術語（鍵）",
+    "用語（key）",
+    "용어(key)",
+    "Terim (key)",
+    "Thuật ngữ (key)"
+  ),
+  terminology_playground_terms_col_value: terminologyPlaygroundText(
+    "定义（值）",
+    "Definition (value)",
+    "定義（值）",
+    "定義（value）",
+    "정의(value)",
+    "Tanım (value)",
+    "Định nghĩa (value)"
+  ),
+  terminology_playground_terms_col_format: terminologyPlaygroundText(
+    "提示词格式",
+    "Prompt format",
+    "提示詞格式",
+    "プロンプト形式",
+    "프롬프트 형식",
+    "İstem biçimi",
+    "Định dạng prompt"
+  ),
+  terminology_playground_terms_no_translation: terminologyPlaygroundText(
+    "（无译文，保留原文）",
+    "(no translation; keep original)",
+    "（無譯文，保留原文）",
+    "（訳なし、原文保持）",
+    "（번역 없음, 원문 유지）",
+    "(çeviri yok, orijinal korunur)",
+    "（không dịch, giữ nguyên văn bản）"
+  ),
+  terminology_playground_terms_example_title: terminologyPlaygroundText(
+    "AI 术语例句",
+    "AI term example",
+    "AI 術語例句",
+    "AI 用語の例文",
+    "AI 용어 예문",
+    "AI terimi örneği",
+    "Ví dụ thuật ngữ AI"
+  ),
+  terminology_playground_terms_hint: terminologyPlaygroundText(
+    "要专门测试某一个术语是否生效，只需填入该术语；其他术语留空有助于观察单个术语的生效情况。",
+    "To test whether a specific term takes effect, enter only that term; leaving others empty makes it easier to observe a single term's effect.",
+    "若要專門測試某個術語是否生效，只需填入該術語；其他術語留空有助於觀察單一術語的生效情況。",
+    "特定の用語が効くかテストするにはその用語だけを入力してください；他は空にすると単一の用語の効果を観察しやすくなります。",
+    "특정 용어가 적용되는지 테스트하려면 그 용어만 입력하세요; 다른 용어를 비워두면 단일 용어의 적용 여부를 관찰하기 쉽습니다.",
+    "Belirli bir terimin etki edip etmediğini test etmek için yalnızca o terimi girin; diğerleri boş bırakmak tek terimin etkisini gözlemlemeyi kolaylaştırır.",
+    "Muốn kiểm tra một thuật ngữ cụ thể có hiệu quả, chỉ cần nhập thuật ngữ đó; để trống các thuật ngữ khác giúp quan sát hiệu quả từng thuật ngữ."
+  ),
+  terminology_playground_terms_sample_button: terminologyPlaygroundText(
+    "填入示例",
+    "Load sample",
+    "填入示例",
+    "サンプルを入力",
+    "샘플 입력",
+    "Örneği yükle",
+    "Nhập mẫu"
+  ),
+  terminology_playground_terms_rotate_button: terminologyPlaygroundText(
+    "换一个例句",
+    "Change example",
+    "換一個例句",
+    "別の例を表示",
+    "다른 예문",
+    "Örneği değiştir",
+    "Đổi ví dụ"
+  ),
+  terminology_playground_terms_testing: terminologyPlaygroundText(
+    "测试中…",
+    "Testing…",
+    "測試中…",
+    "テスト中…",
+    "테스트 중…",
+    "Test ediliyor…",
+    "Đang kiểm tra…"
+  ),
+  terminology_playground_terms_test: terminologyPlaygroundText(
+    "测试",
+    "Test",
+    "測試",
+    "テスト",
+    "테스트",
+    "Test",
+    "Kiểm tra"
+  ),
+  terminology_playground_terms_cancel: terminologyPlaygroundText(
+    "取消",
+    "Cancel",
+    "取消",
+    "キャンセル",
+    "취소",
+    "İptal",
+    "Hủy"
+  ),
+
+  // ── _result_*：测试结果区（含发送/接收面板） ────────────────────────
+  terminology_playground_result_title: terminologyPlaygroundText(
+    "测试结果（{name}）",
+    "Test result ({name})",
+    "測試結果（{name}）",
+    "テスト結果（{name}）",
+    "테스트 결과({name})",
+    "Test sonucu ({name})",
+    "Kết quả kiểm tra ({name})"
+  ),
+  terminology_playground_result_req_title: terminologyPlaygroundText(
+    "发送的请求（Request）",
+    "Sent request (Request)",
+    "傳送的請求（Request）",
+    "送信リクエスト（Request）",
+    "보낸 요청(Request)",
+    "Gönderilen istek (Request)",
+    "Yêu cầu đã gửi (Request)"
+  ),
+  terminology_playground_result_req_view_summary: terminologyPlaygroundText(
+    "返回摘要视图",
+    "Back to summary view",
+    "返回摘要視圖",
+    "サマリビューに戻る",
+    "요약 보기로 돌아가기",
+    "Özet görünüme dön",
+    "Về chế độ xem tóm tắt"
+  ),
+  terminology_playground_result_req_view_json: terminologyPlaygroundText(
+    "查看原始 JSON",
+    "View raw JSON",
+    "查看原始 JSON",
+    "生 JSON を表示",
+    "원시 JSON 보기",
+    "Ham JSON'ı görüntüle",
+    "Xem JSON thô"
+  ),
+  terminology_playground_result_req_uncaptured: terminologyPlaygroundText(
+    "未捕获到请求",
+    "Request not captured",
+    "未捕獲到請求",
+    "リクエストを検出できません",
+    "요청을 포착하지 못함",
+    "İstek yakalanamadı",
+    "Không phát hiện yêu cầu"
+  ),
+  terminology_playground_result_soft_glossary_title: terminologyPlaygroundText(
+    "AI 专业术语（软提示词注入）",
+    "AI terms (soft prompt injection)",
+    "AI 專業術語（軟提示詞注入）",
+    "AI 専門用語（ソフトプロンプト注入）",
+    "AI 전문 용어(소프트 프롬프트 주입)",
+    "AI terimleri (yumuşak istem enjeksiyonu)",
+    "Thuật ngữ AI (prompt nhúng mềm)"
+  ),
+  terminology_playground_result_prompt_label: terminologyPlaygroundText(
+    "翻译提示词：",
+    "Translation prompt: ",
+    "翻譯提示詞：",
+    "翻訳プロンプト：",
+    "번역 프롬프트: ",
+    "Çeviri istemi: ",
+    "Lời khách dịch: "
+  ),
+  terminology_playground_result_channel_label: terminologyPlaygroundText(
+    "注入通道：",
+    "Injection channel: ",
+    "注入通道：",
+    "注入チャネル：",
+    "주입 채널: ",
+    "Enjeksiyon kanalı: ",
+    "Kênh nhúng: "
+  ),
+  terminology_playground_result_request_label: terminologyPlaygroundText(
+    "翻译例句：",
+    "Translation example: ",
+    "翻譯例句：",
+    "翻訳例：",
+    "번역 예문: ",
+    "Çeviri örneği: ",
+    "Ví dụ dịch: "
+  ),
+  terminology_playground_result_model_host: terminologyPlaygroundText(
+    "模型：{model} · 接口地址：{host}",
+    "Model: {model} · API URL: {host}",
+    "模型：{model} · 介面地址：{host}",
+    "モデル：{model} · API URL：{host}",
+    "모델: {model} · API 주소: {host}",
+    "Model: {model} · API adresi: {host}",
+    "Mô hình: {model} · URL API: {host}"
+  ),
+  terminology_playground_result_auth: terminologyPlaygroundText(
+    "鉴权：{key}",
+    "Auth: {key}",
+    "鑒權：{key}",
+    "認証：{key}",
+    "인증: {key}",
+    "Kimlik: {key}",
+    "Xác thực: {key}"
+  ),
+  terminology_playground_result_actual_prompt: terminologyPlaygroundText(
+    "实际发出的提示词",
+    "Actual prompt sent",
+    "實際傳送的提示詞",
+    "実際に送信したプロンプト",
+    "실제로 보낸 프롬프트",
+    "Gönderilen gerçek istem",
+    "Prompt thực tế đã gửi"
+  ),
+  terminology_playground_result_uncaptured_prompt: terminologyPlaygroundText(
+    "未捕获到提示词",
+    "Prompt not captured",
+    "未捕獲提示詞",
+    "プロンプトを検出できません",
+    "프롬프트 포착 실패",
+    "İstem yakalanamadı",
+    "Không phát hiện prompt"
+  ),
+  terminology_playground_result_resp_title: terminologyPlaygroundText(
+    "接收的响应（Response）",
+    "Received response (Response)",
+    "接收的響應（Response）",
+    "受信レスポンス（Response）",
+    "받은 응답(Response)",
+    "Alınan yanıt (Response)",
+    "Phản hồi nhận được (Response)"
+  ),
+  terminology_playground_result_resp_uncaptured: terminologyPlaygroundText(
+    "未捕获到响应（可能失败/被取消）",
+    "Response not captured (may have failed/been cancelled)",
+    "未捕獲響應（可能失敗/被取消）",
+    "レスポンスを検出できません（失敗/キャンセル）",
+    "응답 포착 실패(실패/취소 가능)",
+    "Yanıt yakalanamadı (başarısız/iptal edilmiş olabilir)",
+    "Không phát phản hồi (có thể thất bại/đã hủy)"
+  ),
+  terminology_playground_result_translation_label: terminologyPlaygroundText(
+    "翻译译文：",
+    "Translation: ",
+    "翻譯譯文：",
+    "翻訳文：",
+    "번역문: ",
+    "Çeviri: ",
+    "Bản dịch: "
+  ),
+  terminology_playground_result_lang_same: terminologyPlaygroundText(
+    "语言：{lang}（{code}）· 同语言：{same}",
+    "Language: {lang} ({code}) · Same language: {same}",
+    "語言：{lang}（{code}）· 同語言：{same}",
+    "言語：{lang}（{code}）· 同一言語：{same}",
+    "언어: {lang}({code}) · 같은 언어: {same}",
+    "Dil: {lang} ({code}) · Aynı dil: {same}",
+    "Ngôn ngữ: {lang} ({code}) · Cùng ngôn ngữ: {same}"
+  ),
+  terminology_playground_result_yes: terminologyPlaygroundText(
+    "是",
+    "Yes",
+    "是",
+    "はい",
+    "예",
+    "Evet",
+    "Có"
+  ),
+  terminology_playground_result_no: terminologyPlaygroundText(
+    "否",
+    "No",
+    "否",
+    "いいえ",
+    "아니요",
+    "Hayır",
+    "Không"
+  ),
+  // ── _check_*：术语表贡献与生效检测表 ────────────────────────────────
+  terminology_playground_check_heuristic: terminologyPlaygroundText(
+    "以下术语表生效检测为启发式参考（模型可能改写措辞/加括号/不保留占位符），真实对照以上方原始返回译文为准。",
+    "The following glossary effect check is a heuristic (the model may rephrase, add parentheses, or drop placeholders); treat the raw translated output above as the ground truth.",
+    "以下術語表生效檢測為啟發式參考（模型可能改寫措辭/加括號/不保留佔位符），請以上方原始返回譯文為準。",
+    "以下の用語集の効果判定はヒューリスティック参考です（モデルが表現を変えたり括弧を付けたりする可能性があります）。上部の生の翻訳出力を基準にしてください。",
+    "아래 용어 사전 적용 검사는 휴리스틱 참고입니다(모델이 표현을 바꾸거나 괄호를 추가할 수 있음). 위의 원시 번역 출력을 기준으로 하세요.",
+    "Aşağıdaki sözlük uygulama kontrolü buluşsal bir referanstır (model ifadeyi değiştirebilir parantez ekleyebilir); yukarıdaki ham çeviri çıktısını esas alın.",
+    "Kiểm tra hiệu lực glossary bên dưới chỉ là tham khảo heuristic (model có thể viết lại/hay thêm ngoặc); hãy dựa vào bản dịch gốc ở trên."
+  ),
+  terminology_playground_check_title: terminologyPlaygroundText(
+    "术语表贡献与生效检测",
+    "Glossary contribution and effect check",
+    "術語表貢獻與生效檢測",
+    "用語集の貢献と効果の確認",
+    "용어 사전 기여 및 적용 확인",
+    "Sözlük katkısı ve etki kontrolü",
+    "Đóng góp glossary và kiểm tra hiệu lực"
+  ),
+  terminology_playground_check_col_source: terminologyPlaygroundText(
+    "来源",
+    "Source",
+    "來源",
+    "ソース",
+    "출처",
+    "Kaynak",
+    "Nguồn"
+  ),
+  terminology_playground_check_col_term: terminologyPlaygroundText(
+    "术语（键→值）",
+    "Term (key→value)",
+    "術語（鍵→值）",
+    "用語（key→value）",
+    "용어(key→value)",
+    "Terim (key→value)",
+    "Thuật ngữ (key→value)"
+  ),
+  terminology_playground_check_col_delivered: terminologyPlaygroundText(
+    "已发出（事实）",
+    "Sent (fact)",
+    "已發送（事實）",
+    "送信（事実）",
+    "전송됨(실제)",
+    "Gönderildi (gerçek)",
+    "Đã gửi (thực tế)"
+  ),
+  terminology_playground_check_col_hit: terminologyPlaygroundText(
+    "译文命中（启发式）",
+    "Translation hit (heuristic)",
+    "譯文命中（啟發式）",
+    "訳語一致（ヒューリスティック）",
+    "번역 일치(휴리스틱)",
+    "Çeviri vuruşu (heuristic)",
+    "Trúng bản dịch (heuristic)"
+  ),
+  terminology_playground_check_source_input: terminologyPlaygroundText(
+    "用户输入",
+    "User input",
+    "用戶輸入",
+    "ユーザー入力",
+    "사용자 입력",
+    "Kullanıcı girdisi",
+    "Người dùng nhập"
+  ),
+  terminology_playground_check_source_api: terminologyPlaygroundText(
+    "接口级",
+    "API level",
+    "介面級",
+    "API レベル",
+    "API 급",
+    "API düzeyi",
+    "Cấp API"
+  ),
+  terminology_playground_check_source_rule: terminologyPlaygroundText(
+    "规则级",
+    "Rule level",
+    "規則級",
+    "ルールレベル",
+    "규칙급",
+    "Kural düzeyi",
+    "Cấp quy tắc"
+  ),
+  terminology_playground_check_hit_empty: terminologyPlaygroundText(
+    "不翻译（空值）",
+    "No translation (empty value)",
+    "不翻譯（空值）",
+    "翻訳しない（空値）",
+    "번역 안 함(빈 값)",
+    "Çevrilmez (boş değer)",
+    "Không dịch (giá trị rỗng)"
+  ),
+  terminology_playground_check_hit_not_covered: terminologyPlaygroundText(
+    "例句未覆盖",
+    "Not covered by the example",
+    "例未覆蓋",
+    "例文でカバーされず",
+    "예문 미포함",
+    "Örnekte kapsanmıyor",
+    "Ví dụ không bao phủ"
+  ),
+  terminology_playground_check_hit_applied: terminologyPlaygroundText(
+    "已应用",
+    "Applied",
+    "已套用",
+    "適用済み",
+    "적용됨",
+    "Uygulandı",
+    "Đã áp dụng"
+  ),
+  terminology_playground_check_hit_not_applied: terminologyPlaygroundText(
+    "未应用",
+    "Not applied",
+    "未套用",
+    "未適用",
+    "미적용",
+    "Uygulanmadı",
+    "Chưa áp dụng"
+  ),
+  terminology_playground_check_empty_value: terminologyPlaygroundText(
+    "（空值）",
+    "(empty value)",
+    "（空值）",
+    "（空値）",
+    "(빈 값)",
+    "(boş değer)",
+    "（giá trị rỗng）"
+  ),
+
+  // ── _truncated：截断提示 ────────────────────────────────────────────
+  terminology_playground_truncated: terminologyPlaygroundText(
+    "…[已省略 {n} 字符]",
+    "…[{n} characters omitted]",
+    "…[已省略 {n} 字元]",
+    "…[{n} 文字省略]",
+    "…[{n}자 생략됨]",
+    "…[{n} karakter atlandı]",
+    "…[{n} ký tự bị lược bỏ]"
+  ),
+
+  // ── 诊断提示多语言（Task 5：替换 terms.js 内部硬编码中文直出）────────────
+  terminology_playground_diag_empty_source_term: terminologyPlaygroundText(
+    "第 {segmentIndex} 段「{segment}」的逗号前没有源术语（空源术语）",
+    "Segment {segmentIndex} \"{segment}\" has no source term before the comma (empty source term)",
+    "第 {segmentIndex} 段「{segment}」的逗號前沒有來源術語（空來源術語）",
+    "第 {segmentIndex} セグメント「{segment}」のカンマの前にソース用語がありません（空のソース用語）",
+    "{segmentIndex}번째 세그먼트 \"{segment}\"의 쉼표 앞에 소스 용어가 없습니다(빈 소스 용어)",
+    "Bölüm {segmentIndex} \"{segment}\" virgülün önünde kaynak terim içermiyor (boş kaynak terim)",
+    "Đoạn {segmentIndex} \"{segment}\" không có thuật ngữ nguồn trước dấu phẩy (thuật ngữ nguồn trống)"
+  ),
+  terminology_playground_diag_invalid_regex: terminologyPlaygroundText(
+    "第 {segmentIndex} 段「{segment}」无法作为正则解析：{error}",
+    "Segment {segmentIndex} \"{segment}\" cannot be parsed as regex: {error}",
+    "第 {segmentIndex} 段「{segment}」無法作為正規表示式解析：{error}",
+    "第 {segmentIndex} セグメント「{segment}」を正規表現として解析できません：{error}",
+    "{segmentIndex}번째 세그먼트 \"{segment}\"을(를) 정규식으로 구문 분석할 수 없습니다: {error}",
+    "Bölüm {segmentIndex} \"{segment}\" normal ifade olarak ayrıştırılamıyor: {error}",
+    "Đoạn {segmentIndex} \"{segment}\" không thể phân tích cú pháp dưới dạng biểu thức chính quy: {error}"
+  ),
+  terminology_playground_diag_empty_matching_pattern: terminologyPlaygroundText(
+    "第 {segmentIndex} 段「{segment}」的正则可匹配空字符串（{key}），会在任意位置注入译文导致错乱，请改用非空匹配的正则",
+    "Segment {segmentIndex} \"{segment}\" has a regex that matches empty strings ({key}), which injects translations everywhere; please use a non-empty matching regex",
+    "第 {segmentIndex} 段「{segment}」的正規表示式可匹配空字串（{key}），會在任意位置注入譯文導致錯亂，請改用非空匹配的正規表示式",
+    "第 {segmentIndex} セグメント「{segment}」の正規表現は空文字列に一致します（{key}）。任意の位置に訳文が注入されて乱れが生じるため、非空に一致する正規表現に変更してください",
+    "{segmentIndex}번째 세그먼트 \"{segment}\"의 정규식이 빈 문자열과 일치합니다({key}). 임의 위치에 번역이 삽입되어 오류가 발생하므로 비어 있지 않은 문자열과 일치하는 정규식으로 변경하세요",
+    "Bölüm {segmentIndex} \"{segment}\" normal ifadesi boş dizeyle eşleşiyor ({key}), her yere çeviri enjekte eder; lütfen boş olmayan bir eşleşme ifadesi kullanın",
+    "Biểu thức chính quy ở đoạn {segmentIndex} \"{segment}\" khớp với chuỗi rỗng ({key}), có thể chèn bản dịch ở mọi vị trí gây lỗi; vui lòng đổi sang biểu thức khớp chuỗi không rỗng"
+  ),
+  terminology_playground_diag_conflicting_mapping: terminologyPlaygroundText(
+    "第 {segmentIndex} 段「{segment}」与第 {prevIndex} 段「{key},{prevValue}」同源但译文不同（冲突映射）",
+    "Segment {segmentIndex} \"{segment}\" shares the source with segment {prevIndex} \"{key},{prevValue}\" but has a different translation (conflicting mapping)",
+    "第 {segmentIndex} 段「{segment}」與第 {prevIndex} 段「{key},{prevValue}」同源但譯文不同（衝突對應）",
+    "第 {segmentIndex} セグメント「{segment}」は第 {prevIndex} セグメント「{key},{prevValue}」と同じソースですが訳文が異なります（競合マッピング）",
+    "{segmentIndex}번째 세그먼트 \"{segment}\"은(는) {prevIndex}번째 세그먼트 \"{key},{prevValue}\"와(과) 소스는 같으나 번역이 다릅니다(충돌 매핑)",
+    "Bölüm {segmentIndex} \"{segment}\", bölüm {prevIndex} \"{key},{prevValue}\" ile aynı kaynağa sahip ancak çevirisi farklı (çakışan eşleme)",
+    "Đoạn {segmentIndex} \"{segment}\" có cùng nguồn với đoạn {prevIndex} \"{key},{prevValue}\" nhưng bản dịch khác nhau (ánh xạ xung đột)"
+  ),
+  terminology_playground_diag_conflicting_pattern: terminologyPlaygroundText(
+    "第 {segmentIndexA} 段「{keyA}」与第 {segmentIndexB} 段「{keyB}」的正则同时命中同一原文「{literal}」（冲突映射），请转义或统一术语写法",
+    "Segment {segmentIndexA} \"{keyA}\" and segment {segmentIndexB} \"{keyB}\" regexes both match the same text \"{literal}\" (conflicting mapping); please escape or standardize",
+    "第 {segmentIndexA} 段「{keyA}」與第 {segmentIndexB} 段「{keyB}」的正規表示式同時命中同一原文「{literal}」（衝突對應），請跳脫或統一術語寫法",
+    "第 {segmentIndexA} セグメント「{keyA}」と第 {segmentIndexB} セグメント「{keyB}」の正規表現が同じ原文「{literal}」に同時に一致します（競合マッピング）。エスケープするか表記を統一してください",
+    "{segmentIndexA}번째 세그먼트 \"{keyA}\"와(과) {segmentIndexB}번째 세그먼트 \"{keyB}\"의 정규식이 동일한 원문 \"{literal}\"과(과) 동시에 일치합니다(충돌 매핑). 이스케이프하거나 표기를 통일하세요",
+    "Bölüm {segmentIndexA} \"{keyA}\" ve bölüm {segmentIndexB} \"{keyB}\" normal ifadeleri aynı metinle \"{literal}\" eşleşiyor (çakışan eşleme); lütfen kaçışlayın veya birleştirin",
+    "Biểu thức chính quy ở đoạn {segmentIndexA} \"{keyA}\" và đoạn {segmentIndexB} \"{keyB}\" đều khớp cùng văn bản gốc \"{literal}\" (ánh xạ xung đột); vui lòng thoát ký tự hoặc thống nhất cách viết"
+  ),
+  terminology_playground_diag_zero_width_matching_pattern: terminologyPlaygroundText(
+    "第 {segmentIndex} 段「{segment}」的正则不消费任何字符（{key}），会在原文任意位置零宽注入译文导致错乱，请改用消费字符的正则",
+    "Segment {segmentIndex} \"{segment}\" has a regex that consumes no characters ({key}), which injects translations at arbitrary positions of the text; please use a character-consuming regex",
+    "第 {segmentIndex} 段「{segment}」的正規表示式不消費任何字元（{key}），會在原文任意位置零寬注入譯文導致錯亂，請改用消費字元的正規表示式",
+    "第 {segmentIndex} セグメント「{segment}」の正規表現は文字を一切消費しません（{key}）。原文の任意の位置に幅ゼロで訳文が注入され崩れるため、文字を消費する正規表現に変更してください",
+    "{segmentIndex}번째 세그먼트 \"{segment}\"의 정규식은 문자를 전혀 소비하지 않습니다({key}). 원문의 임의 위치에 폭 0으로 번역이 삽입되어 깨지므로 문자를 소비하는 정규식으로 변경하세요",
+    "Bölüm {segmentIndex} \"{segment}\" normal ifadesi hiçbir karakter tüketmiyor ({key}); metnin rastgele konumlarına sıfır genişlikte çeviri enjekte ederek bozar. Lütfen karakter tüketen bir ifade kullanın",
+    "Biểu thức chính quy ở đoạn {segmentIndex} \"{segment}\" không tiêu thụ ký tự nào ({key}), sẽ chèn bản dịch vào vị trí tùy ý của văn bản khiến lỗi; vui lòng dùng biểu thức có tiêu thụ ký tự"
+  ),
+};
+
 export const I18N = {
   ...SUBTITLE_PLAYGROUND_I18N,
+  ...TERMINOLOGY_PLAYGROUND_I18N,
   app_name: {
     zh: `简约翻译`,
     en: `KISS Translator`,

--- a/src/libs/rules.test.js
+++ b/src/libs/rules.test.js
@@ -3,6 +3,7 @@ import { getDisabledSubRules, getRulesWithDefault, setRules } from "./storage";
 import { loadOrFetchSubRules } from "./subRules";
 import { GLOBLA_RULE } from "../config/rules";
 import { OPT_TRANS_MICROSOFT, OPT_TRANS_TENCENT } from "../config/api";
+import { DEFAULT_API_SETTING } from "../config";
 
 jest.mock("./storage", () => ({
   getRulesWithDefault: jest.fn(),
@@ -23,6 +24,21 @@ jest.mock("./log", () => ({
   LogLevel: {
     INFO: { value: 3 },
   },
+}));
+
+// Translator 链路集成测试所需的替身（与 translator.test.js 相同的模式）
+jest.mock("../apis", () => ({
+  apiMicrosoftDict: jest.fn(),
+  apiTranslate: jest.fn(),
+  apiYoudaoDict: jest.fn(),
+}));
+
+jest.mock("./msg", () => ({
+  sendBgMsg: jest.fn(),
+}));
+
+jest.mock("./detect", () => ({
+  tryDetectLang: jest.fn(),
 }));
 
 test("uses Microsoft as the default webpage translator", () => {
@@ -307,5 +323,205 @@ describe("rules enabled state", () => {
         }),
       ])
     );
+  });
+});
+
+// ─── 术语规则链路集成测试 ─────────────────────────────────────────────────
+// 覆盖完整链路：原始规则（含 terms/aiTerms）→ mergeRules（rules.js:121-139）
+// → matchRule → Translator 构造消费 rule.terms（translator.js:872）
+// → 占位符替换与还原。断言经规则合并后的 terms 在翻译器中产生正确替换。
+describe("rules terms integration（规则链路：原始规则 → 合并 → Translator → 占位符还原）", () => {
+  let originalIntersectionObserver;
+  let originalCSSStyleSheet;
+  let originalScrollBy;
+
+  const { Translator } = require("./translator");
+  const { apiTranslate } = require("../apis");
+  const { tryDetectLang } = require("./detect");
+
+  const flushAsync = async () => {
+    // 译文 渲染链路较长（占位符还原 + 插入 wrapper），多轮推进 timer 与微任务
+    for (let i = 0; i < 5; i++) {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
+    }
+  };
+
+  const createApiSetting = (apiSlug, isDisabled = false) => ({
+    ...DEFAULT_API_SETTING,
+    apiSlug,
+    apiName: apiSlug,
+    isDisabled,
+  });
+
+  const createTranslatorWithRule = (rule, text) => {
+    document.body.innerHTML =
+      '<main id="root"><span id="target"></span></main>';
+    document.getElementById("target").textContent = text;
+    return new Translator({
+      rule: {
+        transOpen: "true",
+        rootsSelector: "#root",
+        fromLang: "en",
+        toLang: "zh-CN",
+        autoScan: "false",
+        selector: "#target",
+        hasShadowroot: "false",
+        scanAll: "false",
+        transTitle: "false",
+        ...rule,
+      },
+      setting: {
+        transInterval: 0,
+        rootMargin: 0,
+        mouseHoverSetting: {},
+        customStyles: [],
+        // 合并后的规则保留 GLOBLA_RULE 的 apiSlug（Microsoft），
+        // 因此 transApis 需配置与该 apiSlug 一致的 API 设置才会真正发起翻译
+        transApis: [
+          {
+            ...createApiSetting(rule.apiSlug || OPT_TRANS_MICROSOFT),
+            placeholder: "[[ ]]",
+          },
+        ],
+      },
+      favWords: [],
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    document.documentElement.innerHTML = "<head></head><body></body>";
+    getDisabledSubRules.mockResolvedValue([]);
+    loadOrFetchSubRules.mockResolvedValue([]);
+    tryDetectLang.mockResolvedValue("en");
+    apiTranslate.mockImplementation(({ text }) =>
+      Promise.resolve({ trText: text, isSame: false })
+    );
+
+    originalIntersectionObserver = global.IntersectionObserver;
+    global.IntersectionObserver = class {
+      constructor(callback) {
+        this.callback = callback;
+      }
+
+      observe(target) {
+        this.callback([{ target, isIntersecting: true }]);
+      }
+
+      unobserve() {}
+
+      disconnect() {}
+    };
+
+    originalCSSStyleSheet = global.CSSStyleSheet;
+    global.CSSStyleSheet = class {
+      replaceSync() {}
+    };
+
+    originalScrollBy = window.scrollBy;
+    window.scrollBy = jest.fn();
+  });
+
+  afterEach(() => {
+    global.IntersectionObserver = originalIntersectionObserver;
+    global.CSSStyleSheet = originalCSSStyleSheet;
+    window.scrollBy = originalScrollBy;
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test("合并后的 terms 在翻译器中正确替换：API,接口;APIKey 不出现 接口Key", async () => {
+    getRulesWithDefault.mockResolvedValue([
+      {
+        pattern: "example.com",
+        selector: "article",
+        transOpen: "true",
+        terms: "API,接口;APIKey",
+      },
+      { pattern: GLOBLA_RULE.pattern, selector: "p" },
+    ]);
+
+    const rule = await matchRule("https://example.com/post", {
+      injectRules: false,
+      subrulesList: [],
+    });
+    expect(rule.terms).toBe("API,接口;APIKey");
+
+    createTranslatorWithRule(rule, "APIKey and API");
+    await flushAsync();
+
+    const requestedText = apiTranslate.mock.calls[0][0].text;
+    // 长词整体占位符保护，短词单独命中 → 不出现 "接口Key"
+    expect(requestedText).toBe("[[1]] and [[2]]");
+    const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+    expect(inner.textContent).toBe("APIKey and 接口");
+    expect(inner.textContent).not.toContain("接口Key");
+  });
+
+  test("个人规则 terms 覆盖全局规则，未覆盖的 aiTerms 保留", async () => {
+    getRulesWithDefault.mockResolvedValue([
+      {
+        pattern: "example.com",
+        selector: "article",
+        transOpen: "true",
+        terms: "GPT;GPTs,智能体集合",
+      },
+      {
+        pattern: GLOBLA_RULE.pattern,
+        selector: "p",
+        terms: "API,接口;APIKey",
+        aiTerms: "React,React",
+      },
+    ]);
+
+    const rule = await matchRule("https://example.com/post", {
+      injectRules: false,
+      subrulesList: [],
+    });
+    // 高优先级非空则覆盖 terms（mergeRules 字符串字段合并规则）
+    expect(rule.terms).toBe("GPT;GPTs,智能体集合");
+    // 个人规则无 aiTerms → 继承全局的 aiTerms
+    expect(rule.aiTerms).toBe("React,React");
+
+    createTranslatorWithRule(rule, "GPTs and GPT");
+    await flushAsync();
+
+    const requestedText = apiTranslate.mock.calls[0][0].text;
+    // 长词 GPTs 整体触发，短词 GPT 不抢占
+    expect(requestedText).toBe("[[1]] and [[2]]");
+    const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+    expect(inner.textContent).toBe("智能体集合 and GPT");
+  });
+
+  test("aiTerms 与本地 terms 是两条独立链路：aiTerms 不进入本地占位符替换", async () => {
+    getRulesWithDefault.mockResolvedValue([
+      {
+        pattern: "example.com",
+        selector: "article",
+        transOpen: "true",
+        terms: "API,接口",
+        aiTerms: "React,React",
+      },
+      { pattern: GLOBLA_RULE.pattern, selector: "p" },
+    ]);
+
+    const rule = await matchRule("https://example.com/post", {
+      injectRules: false,
+      subrulesList: [],
+    });
+    expect(rule.terms).toBe("API,接口");
+    expect(rule.aiTerms).toBe("React,React");
+
+    createTranslatorWithRule(rule, "API only");
+    await flushAsync();
+
+    const requestedText = apiTranslate.mock.calls[0][0].text;
+    // aiTerms 只注入翻译 prompt（glossary 字段），不做本地替换 → 文本中仅 API 变占位符
+    expect(requestedText).toBe("[[1]] only");
+    const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+    expect(inner.textContent).toBe("接口 only");
   });
 });

--- a/src/libs/termTestUtils.js
+++ b/src/libs/termTestUtils.js
@@ -1,0 +1,824 @@
+// 专业术语冲突检测、自然语境测试文本生成与结构化断言模块
+// 纯本地、零网络、确定性 hash，无随机数。
+// 供 Playground UI / CLI 脚本 / 单元测试三方复用。
+//
+// 依赖：terms.js（parseTerms / applyTermReplace / applyNaiveReplace）
+
+import {
+  applyTermReplace,
+  applyNaiveReplace,
+  parseTerms,
+  isStrictLiteralPattern,
+} from "./terms";
+
+// ─── 确定性字符串 hash（djb2）───────────────────────────────────────────────
+// 同一术语每次生成同一 hash，保证可复现为 fixture。
+export function hashKey(key) {
+  if (typeof key !== "string") return 0;
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash << 5) + hash + key.charCodeAt(i);
+    hash |= 0; // 32-bit integer
+  }
+  return Math.abs(hash);
+}
+
+// ─── 内置自然语境模板库 ──────────────────────────────────────────────────────
+// 纯英文，覆盖多种句式/场景，读起来像人写的文档/对话。
+// {term} / {short} / {long} 为插入位。
+
+// 单术语模板（覆盖句首/句中/句末）
+const SINGLE_TERM_TEMPLATES = [
+  "Please make sure the {term} is configured correctly before deploying.",
+  "This section explains how {term} works in practice.",
+  "Could you check whether {term} needs to be updated?",
+  "We ran into an issue with {term} during testing.",
+  "The team discussed the {term} at yesterday's meeting.",
+  "Our documentation covers {term} in detail.",
+  "In this project, {term} is used for handling requests.",
+  "The {term} feature will ship in the next release.",
+];
+
+// 冲突对模板：同句同现 {short} 与 {long}。
+// 两条方向各一组，覆盖短词→长词（short-first）与长词→短词（long-first）
+// 两种自然语序；两组模板措辞不同，防止用机械交换词序冒充方向覆盖。
+// short-first 模板（{short} 在前）
+const CONFLICT_TEMPLATES = [
+  "Please check the {short} and {long} configuration in this document.",
+  "We support both standard {short} and custom {long} in our product.",
+  "Make sure to compare the {short} and {long} settings before applying them.",
+  "Could you explain the difference between {short} and {long}?",
+];
+
+// long-first 模板（{long} 在前）
+const LONG_FIRST_CONFLICT_TEMPLATES = [
+  "The {long} configuration, as well as the {short} one, must be reviewed.",
+  "Our guidance document covers {long} before the {short} section.",
+  "To configure {long} correctly, the {short} setting needs to align first.",
+  "Please note that {long} depends on the {short} parameter below.",
+];
+
+// 固定诊断样例：4 组独立冲突对（8 个术语），每组对应一类冲突矩阵。
+// 冲突对数量与冲突类别覆盖分开统计：这里的 4 对 = 四类各一对的真矩阵覆盖，
+// 不等于任意输入的用例数量保证。
+const DIAGNOSTIC_SAMPLE_TERMS = [
+  "API,接口",
+  "APIKey,应用编程接口",
+  "UI,界面",
+  "UIView",
+  "GPT",
+  "GPTs,智能体集合",
+  "React",
+  "ReactNative",
+].join(";");
+
+// ─── 冲突检测 ────────────────────────────────────────────────────────────────
+// 检测长短词冲突：两个 key 不同且短词文本能命中长词 key。
+// 先检查字面子串，再尝试用正则 pattern 匹配。
+
+// 冲突结果记忆化：按 terms 数组引用做 WeakMap 记忆化（GC 友好）。
+// Playground runCompute 与 generateTermTestText 多次读取同一 parsed 的冲突结果时
+// 只分析一次。契约：缓存命中期间不得就地变异 terms 条目的 key 字段。
+const termConflictsCache = new WeakMap();
+
+/**
+ * 检测 parsedTerms 中的长短词冲突对
+ * @param {Array|object} parsedTerms - parseTerms 输出的 terms 数组或 { terms } 对象
+ * @returns {Array<{ short: object, long: object, shortHasValue: boolean, longHasValue: boolean }>}
+ */
+export function detectTermConflicts(parsedTerms) {
+  const terms = Array.isArray(parsedTerms)
+    ? parsedTerms
+    : parsedTerms?.terms || [];
+  if (terms.length < 2) return [];
+
+  const cached = termConflictsCache.get(terms);
+  if (cached) return cached;
+
+  const conflicts = [];
+  const seen = new Set(); // 去重："shortKey:longKey"
+
+  for (let i = 0; i < terms.length; i++) {
+    for (let j = 0; j < terms.length; j++) {
+      if (i === j) continue;
+
+      const a = terms[i];
+      const b = terms[j];
+
+      // 确定短词和长词（按 key.length 判断）
+      const [short, long] = a.key.length <= b.key.length ? [a, b] : [b, a];
+
+      // 相同长度但不是同一个 key → 跳过（非严格子串关系）
+      if (short.key.length === long.key.length && short.key !== long.key) {
+        continue;
+      }
+
+      // 检查短词文本是否能命中长词 key
+      const hits = termHitsKey(short, long.key);
+      if (!hits) continue;
+
+      const pairKey = `${short.key}:${long.key}`;
+      if (seen.has(pairKey)) continue;
+      seen.add(pairKey);
+
+      conflicts.push({
+        short,
+        long,
+        shortHasValue: short.value !== "",
+        longHasValue: long.value !== "",
+      });
+    }
+  }
+
+  termConflictsCache.set(terms, conflicts);
+  return conflicts;
+}
+
+/**
+ * 检查一个术语的 key 是否能命中另一个 key 文本
+ * 先检查纯子串，再检查正则匹配（双向检查，确保 regex 术语也能被检测）。
+ * 白名单短路（统一计划 20260829 Task 4）：双方均为严格字面量时，正则命中与
+ * 子串检查语义等价（严格字面量正则只匹配其去转义文本；对方源码中元字符必带
+ * 前置反斜杠，去转义文本不可能跨界出现），直接返回子串检查结果，零编译。
+ */
+function termHitsKey(term, targetKey) {
+  // 纯子串检查
+  if (targetKey.includes(term.key)) return true;
+
+  // 白名单短路：双方严格字面量 → 不可能再通过正则路径命中
+  if (isStrictLiteralPattern(term.key) && isStrictLiteralPattern(targetKey)) {
+    return false;
+  }
+
+  // 正则匹配检查：term.key 作为正则匹配 targetKey
+  try {
+    const regex = new RegExp(term.key);
+    if (regex.test(targetKey)) return true;
+  } catch (e) {
+    // parseTerms 已校验过，不会走到这里
+  }
+
+  // 反向检查：targetKey 作为正则匹配 term.key
+  // 处理 targetKey 是 regex pattern 而 term.key 是文本的情况
+  try {
+    const reverseRegex = new RegExp(targetKey);
+    if (reverseRegex.test(term.key)) return true;
+  } catch (e) {
+    // 非正则文本作为 regex 不安全时跳过
+  }
+
+  return false;
+}
+
+// ─── 测试文本生成 ────────────────────────────────────────────────────────────
+// 确定性生成，同一术语每次生成同一句子。
+
+/**
+ * 从 parsedTerms 生成测试用例数组
+ * 每个冲突对生成两条用例：short-first（短词在前）与 long-first（长词在前），
+ * 分别用两组措辞不同的自然模板，覆盖同句内两种出现方向。
+ * 模板选择由"术语/冲突对 + 方向 + seed"的确定性 hash 决定：
+ * - seed 缺省（空字符串）时与旧行为完全一致（可复现既有 fixture）；
+ * - 传入不同 seed 可在有限模板集合内轮换出不同的自然例句（UI"换一个例句"能力）。
+ * @param {Array|object} parsedTerms - parseTerms 输出的 terms 数组或 { terms } 对象
+ * @param {string|number} [seed=""] - 显式轮换种子（同一 seed 必产生相同结果）
+ * @param {object} [options]
+ * @param {Array} [options.conflicts] - 预计算的 detectTermConflicts 结果（调用方
+ *   已算过时传入以复用，如 Playground runCompute 只分析一次）；不传则内部自算
+ *   （向后兼容，CLI / 测试不受影响）
+ * @returns {Array<{
+ *   type: "conflict" | "single",
+ *   text: string,
+ *   short?: object,
+ *   long?: object,
+ *   shortHasValue?: boolean,
+ *   longHasValue?: boolean,
+ *   conflictType?: number,
+ *   direction?: "short-first" | "long-first",
+ *   term?: object,
+ * }>}
+ */
+export function generateTermTestText(parsedTerms, seed = "", options = {}) {
+  const seedSuffix = String(seed === undefined || seed === null ? "" : seed);
+  const withSeed = (base) => (seedSuffix ? `${base}#${seedSuffix}` : base);
+
+  const terms = Array.isArray(parsedTerms)
+    ? parsedTerms
+    : parsedTerms?.terms || [];
+  if (terms.length === 0) return [];
+
+  const cases = [];
+
+  // 1. 冲突对用例：每对冲突按两个方向各生成一条自然语境用例。
+  //    冲突分析只算一次：调用方传入预计算结果则直接复用，否则内部自算。
+  const conflicts = options?.conflicts ?? detectTermConflicts(parsedTerms);
+  for (const conflict of conflicts) {
+    const { short, long, shortHasValue, longHasValue } = conflict;
+    const conflictType = getConflictType(shortHasValue, longHasValue);
+
+    // 选模板：用"冲突对组合 key + 方向 + seed"做 hash，保证同一对方向各自稳定
+    const pairKey = `${short.key}:${long.key}`;
+    for (const direction of ["short-first", "long-first"]) {
+      const pool =
+        direction === "short-first"
+          ? CONFLICT_TEMPLATES
+          : LONG_FIRST_CONFLICT_TEMPLATES;
+      const templateIndex =
+        hashKey(withSeed(`${pairKey}#${direction}`)) % pool.length;
+      const template = pool[templateIndex];
+
+      const text = template
+        .replace(/\{short\}/g, short.key)
+        .replace(/\{long\}/g, long.key);
+
+      cases.push({
+        type: "conflict",
+        text,
+        short,
+        long,
+        shortHasValue,
+        longHasValue,
+        conflictType,
+        direction,
+      });
+    }
+  }
+
+  // 2. 无冲突术语的单术语用例
+  const conflictKeys = new Set();
+  for (const c of conflicts) {
+    conflictKeys.add(c.short.key);
+    conflictKeys.add(c.long.key);
+  }
+
+  for (const term of terms) {
+    if (conflictKeys.has(term.key)) continue;
+
+    // 选模板
+    const templateIndex =
+      hashKey(withSeed(term.key)) % SINGLE_TERM_TEMPLATES.length;
+    const template = SINGLE_TERM_TEMPLATES[templateIndex];
+    const text = template.replace(/\{term\}/g, term.key);
+
+    cases.push({
+      type: "single",
+      text,
+      term,
+    });
+  }
+
+  return cases;
+}
+
+/**
+ * 根据短词和长词是否有译文，判定冲突类型（1-4）
+ */
+function getConflictType(shortHasValue, longHasValue) {
+  if (shortHasValue && longHasValue) return 1;
+  if (shortHasValue && !longHasValue) return 2;
+  if (!shortHasValue && longHasValue) return 3;
+  return 4; // !shortHasValue && !longHasValue
+}
+
+/**
+ * 将多个测试用例的文本按序拼接为段落
+ * @param {Array} cases - generateTermTestText 的返回值
+ * @returns {string}
+ */
+export function joinIntoParagraph(cases) {
+  if (!Array.isArray(cases) || cases.length === 0) return "";
+  return cases.map((c) => c.text).join(" ");
+}
+
+// ─── 结构化断言 ──────────────────────────────────────────────────────────────
+// 每个断言失败输出 { type, message, detail }
+// message 为一行精简文案（UI 与 CLI 摘要直接展示）
+// detail 为完整上下文（含 spans、涉及术语、修复前文本等）
+
+/**
+ * 对单个测试用例执行断言
+ * @param {Array|object} parsedTerms - 完整 parsedTerms
+ * @param {object} testCase - generateTermTestText 返回的单个用例
+ * @param {object} [options]
+ * @param {"fixed"|"naive"} [options.engine="fixed"] - 断言目标引擎：
+ *   "fixed" 断言修复后引擎（默认，ok 反映修复后行为），并额外产出 evidence（旧引擎的误伤演示，不影响 ok）；
+ *   "naive" 断言旧引擎复现输出（错误引擎输出会产生对应 issue，供负向用例/演示使用）。
+ * @returns {{
+ *   ok: boolean,
+ *   issues: Array<{ type: string, message: string, detail: object }>,
+ *   evidence: Array<{ type: string, message: string, detail: object }>,
+ * }}
+ */
+export function assertTermReplacements(parsedTerms, testCase, options = {}) {
+  const issues = [];
+  const evidence = [];
+  const engine = options.engine === "naive" ? "naive" : "fixed";
+
+  // 确保 parsedTerms 是数组
+  const terms = Array.isArray(parsedTerms)
+    ? parsedTerms
+    : parsedTerms?.terms || [];
+  if (terms.length === 0) {
+    return {
+      ok: false,
+      issues: [
+        {
+          type: "no-terms",
+          message: "无有效术语，无法断言",
+          detail: { reason: "parsedTerms is empty" },
+        },
+      ],
+      evidence,
+    };
+  }
+
+  const text = testCase.text;
+  if (typeof text !== "string" || text.trim() === "") {
+    return {
+      ok: false,
+      issues: [
+        {
+          type: "empty-text",
+          message: "测试文本为空，无法断言",
+          detail: { reason: "testCase.text is empty" },
+        },
+      ],
+      evidence,
+    };
+  }
+
+  // 标准替换器：有译文用译文，无译文保留原文
+  const replacer = (term, fullMatch) => term.value || fullMatch;
+
+  // 修复后引擎输出 + 旧引擎复现输出（使用 parseTerms 的真实 originalOrder，
+  // 否则排序后的 terms 会让旧引擎"意外正确"，修复前/后对比证据失效）
+  const fixed = applyTermReplace(text, terms, replacer);
+  const naive = applyNaiveReplace(text, parsedTerms);
+  const result = engine === "naive" ? naive : fixed;
+  const { spans } = result;
+
+  // 单术语用例：检查替换正确性
+  if (testCase.type === "single") {
+    const term = testCase.term;
+    if (!term) {
+      return {
+        ok: false,
+        issues: [
+          {
+            type: "invalid-testcase",
+            message: "单术语用例缺少 term 信息",
+            detail: { testCase },
+          },
+        ],
+        evidence,
+      };
+    }
+
+    // 检查术语是否被命中
+    const termSpans = spans.filter((s) => s.termKey === term.key);
+    if (termSpans.length === 0) {
+      issues.push({
+        type: "single-term-not-found",
+        message: `术语 ${term.key} 未被命中`,
+        detail: {
+          term,
+          text,
+          spans,
+          fixedOutput: fixed.output,
+          naiveOutput: naive.output,
+        },
+      });
+    } else {
+      // 检查替换正确性
+      for (const span of termSpans) {
+        const expectedReplacement = term.value || span.termKey; // 无译文时保持原文
+        if (span.replacement !== expectedReplacement) {
+          issues.push({
+            type: "single-term-wrong-replacement",
+            message: `术语 ${term.key} 替换结果不正确`,
+            detail: {
+              term,
+              span,
+              expectedReplacement,
+              text,
+              fixedOutput: fixed.output,
+              naiveOutput: naive.output,
+            },
+          });
+        }
+      }
+    }
+
+    // 修复前/后差异对比（演示证据，不影响 ok）
+    if (engine === "fixed" && naive.output !== fixed.output) {
+      evidence.push({
+        type: "naive-vs-fixed-diff",
+        message: `术语 ${term.key} 修复前后结果不同（旧引擎 ${naive.output !== text ? "有误伤" : "无影响"}）`,
+        detail: {
+          termKey: term.key,
+          text,
+          naiveOutput: naive.output,
+          fixedOutput: fixed.output,
+          naiveSpans: naive.spans,
+          fixedSpans: spans,
+        },
+      });
+    }
+
+    return { ok: issues.length === 0, issues, evidence };
+  }
+
+  // 冲突类型用例
+  if (testCase.type === "conflict") {
+    const { short, long, shortHasValue, longHasValue, conflictType } = testCase;
+
+    // 查找长词和短词的 spans
+    const longSpans = spans.filter((s) => s.termKey === long.key);
+    const shortSpans = spans.filter((s) => s.termKey === short.key);
+
+    // 断言 1: 长词必须被命中
+    if (longSpans.length === 0) {
+      issues.push({
+        type: `conflict-type-${conflictType}`,
+        message: `长词 ${long.key} 未被命中（短词 ${short.key} 可能抢占）`,
+        detail: {
+          conflictType,
+          short: { key: short.key, value: short.value },
+          long: { key: long.key, value: long.value },
+          text,
+          spans,
+          fixedOutput: fixed.output,
+          naiveOutput: naive.output,
+        },
+      });
+    } else {
+      // 断言 2: 长词区间内不能有短词残留
+      for (const ls of longSpans) {
+        for (const ss of shortSpans) {
+          if (ss.start >= ls.start && ss.end <= ls.end) {
+            // 短词在长词区间内 → 前缀误伤
+            issues.push({
+              type: `conflict-type-${conflictType}`,
+              message: `长词 ${long.key} 被短词 ${short.key} 切割（检测到前缀误伤）`,
+              detail: {
+                conflictType,
+                short: { key: short.key, value: short.value },
+                long: { key: long.key, value: long.value },
+                longSpan: ls,
+                shortSpan: ss,
+                text,
+                spans,
+                fixedOutput: fixed.output,
+                naiveOutput: naive.output,
+              },
+            });
+          }
+        }
+      }
+
+      // 断言 3: 长词有译文时应替换为译文，无译文时应保持原文
+      for (const ls of longSpans) {
+        if (longHasValue) {
+          // 类型 1/3: 长词应有译文
+          if (ls.replacement === ls.termKey) {
+            issues.push({
+              type: `conflict-type-${conflictType}`,
+              message: `长词 ${long.key} 有译文但未被替换（仍为原文）`,
+              detail: {
+                conflictType,
+                long: { key: long.key, value: long.value },
+                longSpan: ls,
+                text,
+                spans,
+                fixedOutput: fixed.output,
+                naiveOutput: naive.output,
+              },
+            });
+          }
+        } else {
+          // 类型 2/4: 长词无译文，应保持原文
+          if (ls.replacement !== ls.termKey) {
+            issues.push({
+              type: `conflict-type-${conflictType}`,
+              message: `长词 ${long.key} 无译文但被替换为 "${ls.replacement}"`,
+              detail: {
+                conflictType,
+                long: { key: long.key, value: long.value },
+                longSpan: ls,
+                text,
+                spans,
+                fixedOutput: fixed.output,
+                naiveOutput: naive.output,
+              },
+            });
+          }
+        }
+      }
+    }
+
+    // 断言 4: 短词单独出现时应正确替换
+    for (const ss of shortSpans) {
+      // 检查这个短词 span 是否在长词 span 内部（已在断言 2 中检查，跳过）
+      const insideLong = longSpans.some(
+        (ls) => ss.start >= ls.start && ss.end <= ls.end
+      );
+      if (insideLong) continue; // 已在断言 2 中处理
+
+      if (shortHasValue) {
+        if (ss.replacement === ss.termKey) {
+          issues.push({
+            type: `conflict-type-${conflictType}`,
+            message: `短词 ${short.key} 有译文但未被替换（单独出现时）`,
+            detail: {
+              conflictType,
+              short: { key: short.key, value: short.value },
+              shortSpan: ss,
+              text,
+              spans,
+              fixedOutput: fixed.output,
+              naiveOutput: naive.output,
+            },
+          });
+        }
+      }
+    }
+
+    // 旧引擎专属切割证据（naive 引擎下才有意义：旧引擎的短词命中会落在长词出现区间内）
+    if (engine === "naive") {
+      const shortInsideLong = naive.spans.some(
+        (s) => s.termKey === short.key && spanInsideKey(text, s, long.key)
+      );
+      if (shortInsideLong) {
+        if (shortHasValue) {
+          // 类型 1/2：短词有译文 → 长词被切出 "短词译文 + 残段"（如 接口Key）
+          issues.push({
+            type: "naive-prefix-cut",
+            message: `长词 ${long.key} 被短词 ${short.key} 切割（检测到前缀误伤）`,
+            detail: {
+              conflictType,
+              short: { key: short.key, value: short.value },
+              long: { key: long.key, value: long.value },
+              text,
+              naiveSpans: naive.spans,
+              naiveOutput: naive.output,
+              fixedOutput: fixed.output,
+            },
+          });
+        } else if (!longHasValue) {
+          // 类型 4：都无译文 → 文本不变但长词被切出高亮残留（必须看 spans 才能发现）
+          issues.push({
+            type: "naive-cut-residue",
+            message: `不翻译长词 ${long.key} 被切割出高亮残留（短词 ${short.key} 内部命中）`,
+            detail: {
+              conflictType,
+              short: { key: short.key, value: short.value },
+              long: { key: long.key, value: long.value },
+              text,
+              naiveSpans: naive.spans,
+              naiveOutput: naive.output,
+              fixedOutput: fixed.output,
+            },
+          });
+        }
+        // 类型 3：短词无译文且长词有译文 → 断言 1（长词未被命中）已覆盖"短词抢占"
+      }
+    }
+
+    // 修复前/后差异对比（演示证据，不影响 ok；基于 spans 判断，
+    // 类型 4 的切割在文本层面不可见，必须看旧引擎的命中区间）
+    if (engine === "fixed") {
+      const cutEvidence = findNaiveCutEvidence({
+        naive,
+        text,
+        short,
+        long,
+        longHasValue,
+      });
+      if (cutEvidence) {
+        evidence.push({
+          type: "naive-vs-fixed-diff",
+          message: `修复前旧引擎 ${cutEvidence}，修复后已纠正`,
+          detail: {
+            conflictType,
+            short: { key: short.key, value: short.value },
+            long: { key: long.key, value: long.value },
+            text,
+            naiveOutput: naive.output,
+            fixedOutput: fixed.output,
+            naiveSpans: naive.spans,
+            fixedSpans: spans,
+          },
+        });
+      }
+    }
+
+    return { ok: issues.length === 0, issues, evidence };
+  }
+
+  // 未知类型
+  return {
+    ok: false,
+    issues: [
+      {
+        type: "unknown-testcase-type",
+        message: `未知的测试用例类型: ${testCase.type}`,
+        detail: { testCase },
+      },
+    ],
+    evidence,
+  };
+}
+
+/**
+ * 命中区间是否落在 key 文本的某个出现区间内
+ * @param {string} text - 完整文本
+ * @param {{ start: number, end: number }} span - 命中区间
+ * @param {string} key - 要检查的术语 key
+ */
+function spanInsideKey(text, span, key) {
+  let index = text.indexOf(key);
+  while (index !== -1) {
+    if (span.start >= index && span.end <= index + key.length) return true;
+    index = text.indexOf(key, index + 1);
+  }
+  return false;
+}
+
+/**
+ * 分析旧引擎（naive）输出中是否存在对长词的切割证据。
+ * 基于 spans 判断（类型 4 的切割在文本层面不可见，必须看命中区间）。
+ * @param {{
+ *   naive: { output: string, spans: Array<object> },
+ *   text: string,
+ *   short: object,
+ *   long: object,
+ *   longHasValue: boolean,
+ * }} params
+ * @returns {string|null} 描述证据的描述串，无问题返回 null
+ */
+function findNaiveCutEvidence({ naive, text, short, long, longHasValue }) {
+  const naiveLongHit = naive.spans.some((s) => s.termKey === long.key);
+  const shortInsideLong = naive.spans.some(
+    (s) => s.termKey === short.key && spanInsideKey(text, s, long.key)
+  );
+
+  // 旧引擎下短词命中落在长词区间内、且长词整体从未命中 → 存在切割
+  if (shortInsideLong && !naiveLongHit) {
+    if (short.value) {
+      // 类型 1/2：短词有译文 → 长词被切出 "短词译文 + 残段"（如 接口Key）
+      const residue =
+        long.key.slice(0, long.key.indexOf(short.key)) +
+        short.value +
+        long.key.slice(long.key.indexOf(short.key) + short.key.length);
+      return `将 ${long.key} 切割为 ${residue}`;
+    }
+    if (longHasValue) {
+      // 类型 3：短词无译文、长词有译文 → 长词永不触发（短词抢占）
+      return `长词 ${long.key} 未被触发（短词 ${short.key} 抢占）`;
+    }
+    // 类型 4：都无译文 → 文本不变但长词被切出高亮残留
+    return `长词 ${long.key} 被切割出高亮残留（短词 ${short.key} 内部命中）`;
+  }
+  return null;
+}
+
+// ─── 固定诊断样例 ────────────────────────────────────────────────────────────
+// 四组独立冲突对（8 个术语），分别对应四类冲突矩阵，不使用任意用户的术语数推导。
+// 冲突对数量 = 4（唯一冲突对数），冲突类别覆盖 = 4（四类各一），
+// 用例数量 = 8（每对两类方向 × 2）。
+//
+// 与任意用户输入的区别：用户输入中的冲突对数量由实际子串关系决定，
+// 四类矩阵覆盖由专门构造的 4 对 fixture 保证，不承诺对任意输入都有四类齐全。
+
+/**
+ * 返回四组独立冲突对（8 个术语）的术语字符串，覆盖全部 4 类冲突矩阵。
+ * 冲突对与类别覆盖一对一：类型 1 (API/APIKey)、类型 2 (UI/UIView)、
+ * 类型 3 (GPT/GPTs)、类型 4 (React/ReactNative)。
+ * @returns {string} 用 ; 连接的术语字符串，可直接传给 parseTerms。
+ */
+export function getDiagnosticSampleTerms() {
+  return DIAGNOSTIC_SAMPLE_TERMS;
+}
+
+// ─── 开发态故意失败样例 ──────────────────────────────────────────────────────
+// 旧引擎(naive)复现诊断 fixture。每项在 engine="naive" 下必然失败，
+// 用于验证"错误状态本身能被正确识别并呈现"。错误状态类型包括：
+// - 前缀误伤（naive-prefix-cut）：短词有译文把长词切成"短词译文+残段"
+// - 短词抢占（conflict-type-3）：短词无译文导致长词永不触发
+// - 高亮残留（naive-cut-residue）：都无译文但长词被切出高亮标记
+// 所有 fixture 都标注 engine="naive"，不得伪装成当前引擎失败。
+
+/**
+ * 返回确定性构造的旧引擎失败诊断 fixture。
+ * 每个 fixture 包含 parsedTerms、testCase、assertion(naive)、expectedIssueType
+ * 和 description 标签，供 UI 展示"旧引擎复现"诊断区域。
+ * @returns {Array<{
+ *   parsed: object,
+ *   testCase: object,
+ *   assertion: { ok: boolean, issues: Array, evidence: Array },
+ *   expectedIssueType: string,
+ *   description: string,
+ *   engine: "naive",
+ * }>}
+ */
+export function getDeliberateFailureFixtures() {
+  const fixtures = [];
+
+  const addFixture = (
+    termsString,
+    { conflictType, direction, expectedIssueType, description }
+  ) => {
+    const parsed = parseTerms(termsString);
+    const cases = generateTermTestText(parsed);
+    // 找到匹配方向与冲突类型的冲突用例
+    const testCase = cases.find(
+      (c) =>
+        c.type === "conflict" &&
+        c.direction === direction &&
+        c.conflictType === conflictType
+    );
+    if (!testCase) return;
+    const assertion = assertTermReplacements(parsed, testCase, {
+      engine: "naive",
+    });
+    fixtures.push({
+      parsed,
+      testCase,
+      assertion,
+      expectedIssueType,
+      description,
+      engine: "naive",
+    });
+  };
+
+  // 类型 2：短词有译文、长词无译文 → 旧引擎把 APIKey 切成 接口Key（前缀误伤）
+  addFixture("API,接口;APIKey", {
+    conflictType: 2,
+    direction: "short-first",
+    expectedIssueType: "naive-prefix-cut",
+    description: "前缀误伤复现：旧引擎把 APIKey 切成 接口Key（短词有译文）",
+  });
+
+  // 类型 3：短词无译文、长词有译文 → 旧引擎 GPTs 永不触发（短词抢占）
+  addFixture("GPT;GPTs,智能体集合", {
+    conflictType: 3,
+    direction: "short-first",
+    expectedIssueType: "conflict-type-3",
+    description: "短词抢占复现：旧引擎 GPTs 永不触发（短词无译文）",
+  });
+
+  // 类型 4：都无译文 → 旧引擎 ReactNative 切出高亮残留
+  addFixture("React;ReactNative", {
+    conflictType: 4,
+    direction: "short-first",
+    expectedIssueType: "naive-cut-residue",
+    description: "无译文长词高亮残留复现：旧引擎 ReactNative 被切割出高亮标记",
+  });
+
+  return fixtures;
+}
+
+// ─── UI 展示规模控制 ─────────────────────────────────────────────────────────
+// 完整计算结果与 UI 展示结果分离。完整结果用于统计和控制台诊断，
+// 但 UI 默认只展示有限数量（上限 4），筛选优先级：失败项优先。
+
+const DISPLAY_LIMIT_DEFAULT = 4;
+
+/**
+ * 从完整结果中筛选出 UI 展示条目，失败优先，数量不超过 limit。
+ * @param {Array<{ assertion: { ok: boolean } }>} results - 完整计算结果数组
+ * @param {{ limit?: number }} [options]
+ * @returns {{
+ *   displayed: Array,
+ *   hiddenFailCount: number,
+ *   hiddenPassCount: number,
+ * }}
+ */
+export function selectDisplayedResults(results, options = {}) {
+  const limit = options.limit ?? DISPLAY_LIMIT_DEFAULT;
+  if (!Array.isArray(results) || results.length === 0) {
+    return { displayed: [], hiddenFailCount: 0, hiddenPassCount: 0 };
+  }
+
+  // 分离失败与通过，各自保持原始顺序使确定性稳定
+  const failures = results.filter((r) => !r.assertion.ok);
+  const passes = results.filter((r) => r.assertion.ok);
+
+  // 先排失败（保持原始顺序），再排通过
+  const sorted = [...failures, ...passes];
+
+  // 取前 limit 条
+  const displayed = sorted.slice(0, limit);
+
+  // 计算隐藏数量
+  const totalFail = failures.length;
+  const totalPass = passes.length;
+  const displayedFail = displayed.filter((r) => !r.assertion.ok).length;
+  const displayedPass = displayed.filter((r) => r.assertion.ok).length;
+
+  return {
+    displayed,
+    hiddenFailCount: totalFail - displayedFail,
+    hiddenPassCount: totalPass - displayedPass,
+  };
+}

--- a/src/libs/termTestUtils.test.js
+++ b/src/libs/termTestUtils.test.js
@@ -1,0 +1,888 @@
+import { parseTerms } from "./terms";
+import {
+  hashKey,
+  detectTermConflicts,
+  generateTermTestText,
+  joinIntoParagraph,
+  assertTermReplacements,
+  getDiagnosticSampleTerms,
+  getDeliberateFailureFixtures,
+  selectDisplayedResults,
+} from "./termTestUtils";
+
+// ─── hashKey ─────────────────────────────────────────────────────────────────
+describe("termTestUtils hashKey", () => {
+  test("returns a deterministic number for the same key", () => {
+    expect(hashKey("API")).toBe(hashKey("API"));
+    expect(hashKey("APIKey")).toBe(hashKey("APIKey"));
+  });
+
+  test("returns different values for different keys", () => {
+    // 极低概率冲突，但不同 key 大概率不同
+    const api = hashKey("API");
+    const gpt = hashKey("GPT");
+    expect(api).not.toBe(gpt);
+  });
+
+  test("returns a non-negative integer", () => {
+    const h = hashKey("API");
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+  });
+
+  test("handles empty string", () => {
+    // djb2 初始值 5381，空字符串不进入循环，返回 5381
+    expect(hashKey("")).toBe(5381);
+  });
+
+  test("handles non-string input", () => {
+    expect(hashKey(null)).toBe(0);
+    expect(hashKey(undefined)).toBe(0);
+    expect(hashKey(123)).toBe(0);
+  });
+});
+
+// ─── detectTermConflicts ─────────────────────────────────────────────────────
+describe("termTestUtils detectTermConflicts", () => {
+  test("conflict type 1: short has value, long has value (API / APIKey)", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("API");
+    expect(conflicts[0].long.key).toBe("APIKey");
+    expect(conflicts[0].shortHasValue).toBe(true);
+    expect(conflicts[0].longHasValue).toBe(true);
+  });
+
+  test("conflict type 2: short has value, long has no value (API / APIKey)", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("API");
+    expect(conflicts[0].long.key).toBe("APIKey");
+    expect(conflicts[0].shortHasValue).toBe(true);
+    expect(conflicts[0].longHasValue).toBe(false);
+  });
+
+  test("conflict type 3: short has no value, long has value (GPT / GPTs)", () => {
+    const parsed = parseTerms("GPT;GPTs,智能体集合");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("GPT");
+    expect(conflicts[0].long.key).toBe("GPTs");
+    expect(conflicts[0].shortHasValue).toBe(false);
+    expect(conflicts[0].longHasValue).toBe(true);
+  });
+
+  test("conflict type 4: neither has value (React / ReactNative)", () => {
+    const parsed = parseTerms("React;ReactNative");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("React");
+    expect(conflicts[0].long.key).toBe("ReactNative");
+    expect(conflicts[0].shortHasValue).toBe(false);
+    expect(conflicts[0].longHasValue).toBe(false);
+  });
+
+  test("no conflicts between unrelated terms", () => {
+    const parsed = parseTerms("API,接口;GPT,生成式预训练;SQL,结构化查询");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test("multiple conflicts detected", () => {
+    const parsed = parseTerms(
+      "API,接口;APIKey,应用编程接口;GPT;GPTs,智能体集合"
+    );
+    const conflicts = detectTermConflicts(parsed);
+    // 预期：API↔APIKey, GPT↔GPTs
+    expect(conflicts.length).toBeGreaterThanOrEqual(2);
+    const pairKeys = conflicts.map((c) => `${c.short.key}:${c.long.key}`);
+    expect(pairKeys).toContain("API:APIKey");
+    expect(pairKeys).toContain("GPT:GPTs");
+  });
+
+  test("no conflicts with single term", () => {
+    const parsed = parseTerms("API,接口");
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  test("no conflicts with empty terms", () => {
+    expect(detectTermConflicts([])).toEqual([]);
+    expect(detectTermConflicts({ terms: [] })).toEqual([]);
+    expect(detectTermConflicts(null)).toEqual([]);
+    expect(detectTermConflicts(undefined)).toEqual([]);
+  });
+
+  test("detects conflicts with regex pattern terms", () => {
+    const parsed = parseTerms("API\\.\\d+,版本;API.42,具体版本");
+    const conflicts = detectTermConflicts(parsed);
+    // API\\.\\d+ 作为正则能匹配 API.42，应检测为冲突
+    expect(conflicts.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── generateTermTestText ────────────────────────────────────────────────────
+describe("termTestUtils generateTermTestText", () => {
+  test("generates conflict test cases for all 4 types with direction expansion", () => {
+    // 4 类冲突组合（8 个术语，4 个独立冲突对）
+    // 类型 1：API,接口;APIKey,应用编程接口
+    // 类型 2：UI,界面;UIView
+    // 类型 3：GPT;GPTs,智能体集合
+    // 类型 4：React;ReactNative
+    const parsed = parseTerms(
+      "API,接口;APIKey,应用编程接口;UI,界面;UIView;GPT;GPTs,智能体集合;React;ReactNative"
+    );
+    const cases = generateTermTestText(parsed);
+    const conflicts = cases.filter((c) => c.type === "conflict");
+    // 4 对冲突 × 2 个方向（short-first + long-first）= 8 个冲突用例
+    expect(conflicts.length).toBe(8);
+
+    // 验证冲突类型覆盖：每类至少出现一次
+    const typesPresent = new Set(conflicts.map((c) => c.conflictType));
+    expect(typesPresent.has(1)).toBe(true);
+    expect(typesPresent.has(2)).toBe(true);
+    expect(typesPresent.has(3)).toBe(true);
+    expect(typesPresent.has(4)).toBe(true);
+
+    // 验证方向覆盖：每个冲突对同时包含 short-first 和 long-first
+    const directionMap = {};
+    for (const c of conflicts) {
+      const key = `${c.short.key}:${c.long.key}`;
+      if (!directionMap[key]) directionMap[key] = new Set();
+      directionMap[key].add(c.direction);
+    }
+    for (const pairKey of Object.keys(directionMap)) {
+      expect(directionMap[pairKey].has("short-first")).toBe(true);
+      expect(directionMap[pairKey].has("long-first")).toBe(true);
+    }
+  });
+
+  test("generates single term test cases for non-conflict terms", () => {
+    const parsed = parseTerms("API,接口;GPT,生成式预训练");
+    const cases = generateTermTestText(parsed);
+    const singles = cases.filter((c) => c.type === "single");
+    expect(singles.length).toBe(2);
+    const termKeys = singles.map((c) => c.term.key);
+    expect(termKeys).toContain("API");
+    expect(termKeys).toContain("GPT");
+  });
+
+  test("generated text contains the term key", () => {
+    const parsed = parseTerms("API,接口");
+    const cases = generateTermTestText(parsed);
+    expect(cases.length).toBe(1);
+    expect(cases[0].text).toContain("API");
+  });
+
+  test("generated conflict text contains both short and long keys", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+    expect(conflictCase).toBeDefined();
+    expect(conflictCase.text).toContain("API");
+    expect(conflictCase.text).toContain("APIKey");
+  });
+
+  test("generated text is a complete natural sentence", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口;GPT,生成式预训练");
+    const cases = generateTermTestText(parsed);
+    for (const c of cases) {
+      // 句子应以大写字母开头
+      expect(c.text[0]).toBe(c.text[0].toUpperCase());
+      // 句子应以标点结尾
+      expect(c.text).toMatch(/[.?!]$/);
+      // 句子长度合理（完整自然句）
+      expect(c.text.length).toBeGreaterThan(20);
+    }
+  });
+
+  test("deterministic: same input produces same output", () => {
+    const input = "API,接口;APIKey,应用编程接口;GPT,生成式预训练";
+    const parsed1 = parseTerms(input);
+    const parsed2 = parseTerms(input);
+    const cases1 = generateTermTestText(parsed1);
+    const cases2 = generateTermTestText(parsed2);
+    expect(cases1.length).toBe(cases2.length);
+    for (let i = 0; i < cases1.length; i++) {
+      expect(cases1[i].text).toBe(cases2[i].text);
+    }
+  });
+
+  test("template selection is stable per term key", () => {
+    // 两次调用 hashKey 相同，所以模板选择相同
+    const parsed = parseTerms("API,接口;GPT,生成式预训练");
+    const cases = generateTermTestText(parsed);
+    // 再次生成
+    const cases2 = generateTermTestText(parsed);
+    expect(cases[0].text).toBe(cases2[0].text);
+    expect(cases[1].text).toBe(cases2[1].text);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(generateTermTestText([])).toEqual([]);
+    expect(generateTermTestText({ terms: [] })).toEqual([]);
+    expect(generateTermTestText(null)).toEqual([]);
+    expect(generateTermTestText(undefined)).toEqual([]);
+  });
+
+  test("direction field is present on all conflict cases", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const conflicts = cases.filter((c) => c.type === "conflict");
+    for (const c of conflicts) {
+      expect(c.direction).toBeDefined();
+      expect(["short-first", "long-first"]).toContain(c.direction);
+    }
+  });
+
+  test("long-first template places long key before short key in the sentence", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const longFirst = cases.find(
+      (c) => c.type === "conflict" && c.direction === "long-first"
+    );
+    expect(longFirst).toBeDefined();
+    // 长词在短词之前出现（long-first 模板中 {long} 在 {short} 前）。
+    // 注意：短词 key 可能作为长词 key 的子串（如 API 在 APIKey 中），
+    // 因此查找短词时要从长词之后开始搜索。
+    const longIdx = longFirst.text.indexOf(longFirst.long.key);
+    const shortIdx = longFirst.text.indexOf(
+      longFirst.short.key,
+      longIdx + longFirst.long.key.length
+    );
+    expect(shortIdx).toBeGreaterThan(longIdx);
+  });
+
+  test("short-first template places short key before long key in the sentence", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const shortFirst = cases.find(
+      (c) => c.type === "conflict" && c.direction === "short-first"
+    );
+    expect(shortFirst).toBeDefined();
+    const shortIdx = shortFirst.text.indexOf(shortFirst.short.key);
+    const longIdx = shortFirst.text.indexOf(shortFirst.long.key);
+    expect(shortIdx).toBeLessThan(longIdx);
+  });
+});
+
+// ─── generateTermTestText 显式 seed 轮换（Task 11） ──────────────────────────
+describe("termTestUtils generateTermTestText seed rotation", () => {
+  const parsed = parseTerms("API,接口;APIKey,应用编程接口;GPT,生成式预训练");
+
+  test("缺省 seed 与旧行为一致", () => {
+    const before = generateTermTestText(parsed);
+    expect(before.map((c) => c.text)).toEqual(
+      generateTermTestText(parsed, "").map((c) => c.text)
+    );
+    expect(before.map((c) => c.text)).toEqual(
+      generateTermTestText(parsed, undefined).map((c) => c.text)
+    );
+    expect(before.map((c) => c.text)).toEqual(
+      generateTermTestText(parsed, null).map((c) => c.text)
+    );
+    // 显式 seed "0" 是真实轮换种子（不同于缺省），应在有限模板内换句。
+    const seedZero = generateTermTestText(parsed, 0).map((c) => c.text);
+    expect(seedZero).toHaveLength(before.length);
+  });
+
+  test("同一输入 + 同一 seed 产生完全相同的例句", () => {
+    const a = generateTermTestText(parsed, "seed-7");
+    const b = generateTermTestText(parsed, "seed-7");
+    expect(a.map((c) => c.text)).toEqual(b.map((c) => c.text));
+    expect(a.map((c) => c.text)).toEqual(b.map((c) => c.text));
+  });
+
+  test("同一输入切换 seed 后，在有限模板集合内换出不同的自然例句", () => {
+    const base = generateTermTestText(parsed, "").map((c) => c.text);
+    // 轮换若干 seed，至少一个 seed 使某个用例的例句发生变化
+    let sawDifference = false;
+    for (let seed = 1; seed <= 16 && !sawDifference; seed++) {
+      const rotated = generateTermTestText(parsed, String(seed)).map(
+        (c) => c.text
+      );
+      sawDifference = rotated.some(
+        (text, index) => text !== base[index] && parsed.terms.length > 0
+      );
+    }
+    expect(sawDifference).toBe(true);
+  });
+
+  test("轮换后的例句仍是完整自然句（不破坏方向与结构）", () => {
+    for (const seed of ["1", "2", "3"]) {
+      const cases = generateTermTestText(parsed, seed);
+      for (const c of cases) {
+        expect(c.text[0]).toBe(c.text[0].toUpperCase());
+        expect(c.text).toMatch(/[.?!]$/);
+      }
+    }
+  });
+
+  test("连续重复生成不会因内部状态相互污染", () => {
+    const one = generateTermTestText(parsed, "rot");
+    const two = generateTermTestText(parsed, "rot");
+    const three = generateTermTestText(parsed, "");
+    expect(one).toEqual(two);
+    // 第三次（不同 seed）与首次结果不同集合大小一致、结构一致
+    expect(three).toHaveLength(one.length);
+  });
+});
+
+// ─── joinIntoParagraph ───────────────────────────────────────────────────────
+describe("termTestUtils joinIntoParagraph", () => {
+  test("joins texts in order with spaces", () => {
+    const cases = [
+      { text: "First sentence about API." },
+      { text: "Second sentence about GPT." },
+    ];
+    const paragraph = joinIntoParagraph(cases);
+    expect(paragraph).toBe(
+      "First sentence about API. Second sentence about GPT."
+    );
+  });
+
+  test("returns empty string for empty array", () => {
+    expect(joinIntoParagraph([])).toBe("");
+    expect(joinIntoParagraph(null)).toBe("");
+    expect(joinIntoParagraph(undefined)).toBe("");
+  });
+});
+
+// ─── assertTermReplacements ──────────────────────────────────────────────────
+describe("termTestUtils assertTermReplacements", () => {
+  // 标准替换器
+  const replacer = (t, m) => t.value || m;
+
+  // 冲突矩阵 4 类固定用例
+
+  test("类型 1: S有/L有 — API,接口;APIKey,应用编程接口 全部通过", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+    expect(conflictCase).toBeDefined();
+
+    const result = assertTermReplacements(parsed, conflictCase);
+    // 修复后应全部通过
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+    // 修复前后对比证据必须存活：旧引擎会产生 "接口 + 残段" 的切割
+    expect(result.evidence.length).toBeGreaterThan(0);
+    const diff = result.evidence.find((e) => e.type === "naive-vs-fixed-diff");
+    expect(diff).toBeDefined();
+    expect(diff.message).toContain("APIKey");
+  });
+
+  test("类型 2: S有/L无 — API,接口;APIKey 全部通过", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+    expect(conflictCase).toBeDefined();
+
+    const result = assertTermReplacements(parsed, conflictCase);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+    // 旧引擎会把 APIKey 切成 接口Key → 证据必须产出
+    expect(result.evidence.some((e) => e.type === "naive-vs-fixed-diff")).toBe(
+      true
+    );
+  });
+
+  test("类型 3: S无/L有 — GPT;GPTs,智能体集合 全部通过", () => {
+    const parsed = parseTerms("GPT;GPTs,智能体集合");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+    expect(conflictCase).toBeDefined();
+
+    const result = assertTermReplacements(parsed, conflictCase);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+    // 旧引擎中 GPTs 永远不会整体触发（GPT 抢占）→ 证据必须产出
+    expect(result.evidence.some((e) => e.type === "naive-vs-fixed-diff")).toBe(
+      true
+    );
+  });
+
+  test("类型 4: S无/L无 — React;ReactNative 全部通过", () => {
+    const parsed = parseTerms("React;ReactNative");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+    expect(conflictCase).toBeDefined();
+
+    const result = assertTermReplacements(parsed, conflictCase);
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+    // 类型 4 文本层面新旧引擎输出完全相同，证据必须基于 spans 产出（高亮残留）
+    expect(result.evidence.length).toBeGreaterThan(0);
+    const diff = result.evidence.find((e) => e.type === "naive-vs-fixed-diff");
+    expect(diff).toBeDefined();
+    expect(diff.message).toContain("高亮残留");
+  });
+
+  test("单术语用例全部通过", () => {
+    const parsed = parseTerms("API,接口;GPT,生成式预训练;SQL,结构化查询");
+    const cases = generateTermTestText(parsed);
+    const singles = cases.filter((c) => c.type === "single");
+    expect(singles.length).toBeGreaterThan(0);
+
+    for (const singleCase of singles) {
+      const result = assertTermReplacements(parsed, singleCase);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test("混合 4 类冲突 + 单术语全部通过", () => {
+    const parsed = parseTerms(
+      "API,接口;APIKey,应用编程接口;GPT;GPTs,智能体集合;React;ReactNative;SQL,结构化查询"
+    );
+    const cases = generateTermTestText(parsed);
+    expect(cases.length).toBeGreaterThan(0);
+
+    for (const testCase of cases) {
+      const result = assertTermReplacements(parsed, testCase);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  // ─── 构造错误场景：验证断言能正确检测问题 ─────────────────────────────
+
+  test("错误引擎输出会产出对应 issue：类型 1/2 前缀误伤（接口Key）", () => {
+    // 用 engine: "naive" 断言旧引擎输出 —— 旧引擎把 APIKey 切成 接口Key
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+
+    const result = assertTermReplacements(parsed, conflictCase, {
+      engine: "naive",
+    });
+    // 旧引擎输出确实错误 → ok=false 且产生对应 issue
+    expect(result.ok).toBe(false);
+    const prefixCut = result.issues.find((i) => i.type === "naive-prefix-cut");
+    expect(prefixCut).toBeDefined();
+    expect(prefixCut.message).toContain("前缀误伤");
+    // 长词整体未被命中（被短词抢占）也要报出
+    expect(result.issues.some((i) => i.type === "conflict-type-1")).toBe(true);
+  });
+
+  test("错误引擎输出会产出对应 issue：类型 2 长词被切出短词译文", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+
+    const result = assertTermReplacements(parsed, conflictCase, {
+      engine: "naive",
+    });
+    expect(result.ok).toBe(false);
+    // naive 输出中必然出现 接口Key 形态
+    const detail = result.issues[0]?.detail || {};
+    expect(detail.naiveOutput).toContain("接口Key");
+    expect(result.issues.some((i) => i.type === "naive-prefix-cut")).toBe(true);
+  });
+
+  test("错误引擎输出会产出对应 issue：类型 3 长词永不被触发（短词抢占）", () => {
+    const parsed = parseTerms("GPT;GPTs,智能体集合");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+
+    const result = assertTermReplacements(parsed, conflictCase, {
+      engine: "naive",
+    });
+    expect(result.ok).toBe(false);
+    const longNotHit = result.issues.find((i) => i.type === "conflict-type-3");
+    expect(longNotHit).toBeDefined();
+    expect(longNotHit.message).toContain("GPTs");
+  });
+
+  test("错误引擎输出会产出对应 issue：类型 4 不翻译长词被切割出高亮残留", () => {
+    const parsed = parseTerms("React;ReactNative");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+
+    const result = assertTermReplacements(parsed, conflictCase, {
+      engine: "naive",
+    });
+    expect(result.ok).toBe(false);
+    const residue = result.issues.find((i) => i.type === "naive-cut-residue");
+    expect(residue).toBeDefined();
+    expect(residue.message).toContain("高亮残留");
+    // 类型 4 文本层面新旧引擎输出相同（都是原文），切割只能从 spans 看出
+    const detail = residue.detail;
+    expect(detail.naiveOutput).toBe(conflictCase.text);
+    expect(detail.naiveSpans.some((s) => s.termKey === "React")).toBe(true);
+  });
+
+  test("修复后引擎对同一文本不会产生任何 issue（与旧引擎负向对照）", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    const conflictCase = cases.find((c) => c.type === "conflict");
+
+    const naiveResult = assertTermReplacements(parsed, conflictCase, {
+      engine: "naive",
+    });
+    const fixedResult = assertTermReplacements(parsed, conflictCase);
+    expect(naiveResult.ok).toBe(false);
+    expect(fixedResult.ok).toBe(true);
+  });
+
+  test("断言输出结构正确：{ ok, issues, evidence }，issue/evidence 有 type/message/detail", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+    // 用 naive 引擎保证 issues 真实非空
+    const result = assertTermReplacements(parsed, cases[0], {
+      engine: "naive",
+    });
+
+    // 结构验证
+    expect(result).toHaveProperty("ok");
+    expect(result).toHaveProperty("issues");
+    expect(result).toHaveProperty("evidence");
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(result.issues.length).toBeGreaterThan(0);
+
+    // 如果存在 issues，验证结构
+    for (const issue of result.issues) {
+      expect(issue).toHaveProperty("type");
+      expect(issue).toHaveProperty("message");
+      expect(issue).toHaveProperty("detail");
+      expect(typeof issue.type).toBe("string");
+      expect(typeof issue.message).toBe("string");
+      expect(typeof issue.detail).toBe("object");
+    }
+
+    // 修复后引擎的证据结构同样合规（evidence 非空才能真正演示修复前误伤）
+    const fixedResult = assertTermReplacements(parsed, cases[0]);
+    if (fixedResult.evidence.length > 0) {
+      for (const item of fixedResult.evidence) {
+        expect(item).toHaveProperty("type");
+        expect(item).toHaveProperty("message");
+        expect(item).toHaveProperty("detail");
+      }
+    }
+  });
+
+  test("message 为单行精简文案（在真实产生的 issues 上执行）", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const cases = generateTermTestText(parsed);
+
+    // 用 naive 引擎构造真实失败的用例，确保 issues 非空、断言真实执行
+    const naivelyFailed = assertTermReplacements(parsed, cases[0], {
+      engine: "naive",
+    });
+    const withEvidence = assertTermReplacements(parsed, cases[0]);
+    expect(naivelyFailed.issues.length).toBeGreaterThan(0);
+    expect(withEvidence.evidence.length).toBeGreaterThan(0);
+
+    const allMessages = [
+      ...naivelyFailed.issues,
+      ...naivelyFailed.evidence,
+      ...withEvidence.evidence,
+    ].map((i) => i.message);
+    for (const message of allMessages) {
+      // message 应为一行的长度（约 120 字符内）
+      expect(message.length).toBeLessThanOrEqual(120);
+      // 不应包含换行符
+      expect(message).not.toContain("\n");
+      // 不应为空文案
+      expect(String(message).trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("单术语用例：术语未被命中时产出 issue", () => {
+    const parsed = parseTerms("API,接口");
+    // 构造一个包含 API 但 API 在文本中不存在的 case
+    const singleCase = {
+      type: "single",
+      text: "Hello world, this is a test sentence.",
+      term: parsed.terms[0],
+    };
+
+    const result = assertTermReplacements(parsed, singleCase);
+    // 应能检测到术语未被命中并报告 issue
+    expect(result.ok).toBe(false);
+    const notFound = result.issues.find(
+      (i) => i.type === "single-term-not-found"
+    );
+    expect(notFound).toBeDefined();
+    expect(notFound.message).toContain("API");
+  });
+
+  test("空 parsedTerms 时产出 issue", () => {
+    const result = assertTermReplacements([], { type: "single", text: "test" });
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].type).toBe("no-terms");
+  });
+
+  test("空文本时产出 issue", () => {
+    const parsed = parseTerms("API,接口");
+    const result = assertTermReplacements(parsed, {
+      type: "single",
+      text: "",
+      term: parsed.terms[0],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].type).toBe("empty-text");
+  });
+});
+
+// ─── getDiagnosticSampleTerms ────────────────────────────────────────────────
+describe("termTestUtils getDiagnosticSampleTerms", () => {
+  test("returns 8 terms forming 4 independent conflict pairs covering all 4 types", () => {
+    const termsString = getDiagnosticSampleTerms();
+    const parsed = parseTerms(termsString);
+
+    // 8 个有效术语，无非法项
+    expect(parsed.invalid).toEqual([]);
+    expect(parsed.terms).toHaveLength(8);
+
+    // 4 个唯一冲突对
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(4);
+
+    // 每类冲突类型恰好出现一次（独立冲突对的"类别覆盖"不等于"用例条数"）
+    const typesCovered = conflicts.map(
+      (c) =>
+        (c.shortHasValue && c.longHasValue ? 1 : 0) +
+        (c.shortHasValue && !c.longHasValue ? 2 : 0) +
+        (!c.shortHasValue && c.longHasValue ? 3 : 0) +
+        (!c.shortHasValue && !c.longHasValue ? 4 : 0)
+    );
+    expect(new Set(typesCovered)).toEqual(new Set([1, 2, 3, 4]));
+
+    // 无冲突术语（所有术语都参与冲突）
+    const conflictKeys = new Set();
+    for (const c of conflicts) {
+      conflictKeys.add(c.short.key);
+      conflictKeys.add(c.long.key);
+    }
+    expect(conflictKeys.size).toBe(8);
+  });
+
+  test("generated cases from the diagnostic sample are deterministic and both directions per pair", () => {
+    const parsed = parseTerms(getDiagnosticSampleTerms());
+    const cases = generateTermTestText(parsed);
+    const conflicts = cases.filter((c) => c.type === "conflict");
+    // 4 对 × 2 方向 = 8 个冲突用例
+    expect(conflicts).toHaveLength(8);
+    // 每个方向都频率一致且模式稳定
+    const directions = conflicts.map((c) => c.direction).sort();
+    expect(directions.filter((d) => d === "short-first")).toHaveLength(4);
+    expect(directions.filter((d) => d === "long-first")).toHaveLength(4);
+
+    const again = generateTermTestText(parsed);
+    expect(again.map((c) => c.text)).toEqual(cases.map((c) => c.text));
+  });
+});
+
+// ─── getDeliberateFailureFixtures ────────────────────────────────────────────
+describe("termTestUtils getDeliberateFailureFixtures", () => {
+  test("returns naive-engine fixtures that reliably fail for old-stream bugs", () => {
+    const fixtures = getDeliberateFailureFixtures();
+    // 至少三个独立失败样式（前缀误伤、短词抢占、高亮残留）。
+    expect(fixtures.length).toBeGreaterThanOrEqual(3);
+
+    for (const fixture of fixtures) {
+      // 每个 fixture 是"旧引擎复现"诊断：engine 必须标注为 naive。
+      expect(fixture.engine).toBe("naive");
+      // 断言必须失败（故意展示错误，而非伪装当前引擎通过）。
+      expect(fixture.assertion.ok).toBe(false);
+      expect(fixture.assertion.issues.length).toBeGreaterThan(0);
+      // 每个 issue 带 message 且为单行。
+      for (const issue of fixture.assertion.issues) {
+        expect(issue.message).not.toContain("\n");
+        expect(issue.message.length).toBeGreaterThan(0);
+      }
+      // 附带说明性标签（否则用户无法区分"故意失败"与"当前引擎失败"）。
+      expect(typeof fixture.description).toBe("string");
+      expect(fixture.description.length).toBeGreaterThan(0);
+      // 汇总覆盖计划要求的三种旧引擎错误形态。
+      expect(fixture.description).toMatch(
+        /前缀误伤|短词抢占|高亮残留|切割|抢占/
+      );
+    }
+
+    // 三种旧引擎错误形态都被覆盖。
+    const joined = fixtures.map((f) => f.description).join(" ");
+    expect(joined).toMatch(/前缀误伤|切割/);
+    expect(joined).toMatch(/短词抢占|抢占/);
+    expect(joined).toMatch(/高亮残留/);
+  });
+
+  test("fixtures expose readable natural text and expected issue types", () => {
+    const fixtures = getDeliberateFailureFixtures();
+    for (const fixture of fixtures) {
+      expect(fixture.parsed.terms.length).toBeGreaterThan(0);
+      expect(typeof fixture.testCase.text).toBe("string");
+      expect(fixture.testCase.text.trim().length).toBeGreaterThan(0);
+      // 预期必读错误类型必须是单个字符串。
+      expect(typeof fixture.expectedIssueType).toBe("string");
+      expect(
+        fixture.assertion.issues.some(
+          (issue) => issue.type === fixture.expectedIssueType
+        )
+      ).toBe(true);
+    }
+  });
+});
+
+// ─── selectDisplayedResults ──────────────────────────────────────────────────
+describe("termTestUtils selectDisplayedResults", () => {
+  // 按注意：传入的 results 元素约定为 { assertion: { ok } }，displayed 复用同一数组元素。
+
+  function makeResults(okFlags) {
+    return okFlags.map((ok, index) => ({
+      index,
+      assertion: { ok },
+      testCase: { text: `case ${index}` },
+    }));
+  }
+
+  test("shows failures first, then passes up to the limit", () => {
+    const results = makeResults([true, false, true, false, true]);
+    const { displayed, hiddenFailCount, hiddenPassCount } =
+      selectDisplayedResults(results, { limit: 4 });
+
+    expect(displayed.map((r) => r.index)).toEqual([1, 3, 0, 2]);
+    // 失败 2 条全部展示、通过 2 条展示、1 条通过隐藏。
+    expect(hiddenFailCount).toBe(0);
+    expect(hiddenPassCount).toBe(1);
+  });
+
+  test("when failures exceed the limit, shows only failures and reports the rest", () => {
+    const results = makeResults([false, false, false, true, false]);
+    const { displayed, hiddenFailCount, hiddenPassCount } =
+      selectDisplayedResults(results, { limit: 3 });
+
+    // 3 个失败展示（取前 3 个失败），1 个失败隐藏、1 个通过隐藏。
+    expect(displayed.map((r) => r.index)).toEqual([0, 1, 2]);
+    expect(displayed.every((r) => !r.assertion.ok)).toBe(true);
+    expect(hiddenFailCount).toBe(1);
+    expect(hiddenPassCount).toBe(1);
+  });
+
+  test("when all pass, shows only the first limit items and counts the hidden passes", () => {
+    const results = makeResults([true, true, true, true, true, true]);
+    const { displayed, hiddenFailCount, hiddenPassCount } =
+      selectDisplayedResults(results, { limit: 4 });
+
+    expect(displayed.map((r) => r.index)).toEqual([0, 1, 2, 3]);
+    expect(hiddenFailCount).toBe(0);
+    expect(hiddenPassCount).toBe(2);
+  });
+
+  test("default limit is 4 and a larger limit can be requested", () => {
+    const results = makeResults([
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    const defaultSel = selectDisplayedResults(results);
+    expect(defaultSel.displayed).toHaveLength(4);
+    const larger = selectDisplayedResults(results, { limit: 40 });
+    expect(larger.displayed).toHaveLength(10);
+  });
+
+  test("empty results produce no displayed items and zero hidden counts", () => {
+    const { displayed, hiddenFailCount, hiddenPassCount } =
+      selectDisplayedResults([], { limit: 4 });
+    expect(displayed).toEqual([]);
+    expect(hiddenFailCount).toBe(0);
+    expect(hiddenPassCount).toBe(0);
+  });
+
+  test("stable deterministic order for ties within pass/fail groups", () => {
+    const results = makeResults([false, false, true, false, true]);
+    const a = selectDisplayedResults(results, { limit: 2 });
+    const b = selectDisplayedResults(results, { limit: 2 });
+    expect(a.displayed.map((r) => r.index)).toEqual([0, 1]);
+    expect(b.displayed.map((r) => r.index)).toEqual([0, 1]);
+  });
+});
+
+// ─── 冲突分析记忆化与 conflicts 复用（统一计划 20260829 Task 4）──────────────
+describe("termTestUtils 冲突分析记忆化（统一计划 20260829 Task 4）", () => {
+  function installCountingRegExp() {
+    const RealRegExp = RegExp;
+    let count = 0;
+    class CountingRegExp extends RealRegExp {
+      constructor(...args) {
+        super(...args);
+        count += 1;
+      }
+    }
+    global.RegExp = CountingRegExp;
+    return () => {
+      global.RegExp = RealRegExp;
+      return count;
+    };
+  }
+
+  test("同 parsed 两次 detectTermConflicts：第二次零编译且结果深相等", () => {
+    const keys = [];
+    for (let i = 0; i < 40; i++) keys.push(`TermNo${i}x,词${i}`);
+    const parsed = parseTerms(keys.join(";"));
+    const first = detectTermConflicts(parsed); // 预热并写入 WeakMap
+
+    const restore = installCountingRegExp();
+    let delta;
+    try {
+      var second = detectTermConflicts(parsed);
+    } finally {
+      delta = restore();
+    }
+    expect(second).toEqual(first);
+    // 加固前每次调用对 40×39 有序对各编译 2 次（3120）；记忆化后第二次为 0。
+    expect(delta).toBe(0);
+  });
+
+  test("detectTermConflicts 结果对正则术语保持既有语义（互不误伤）", () => {
+    const parsed = parseTerms("API\\d+,带编号;API,接口");
+    const conflicts = detectTermConflicts(parsed);
+    // API\d+ 与 API：API 是 API\d+ 的字面子串 → 检出长短词对
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("API");
+    expect(conflicts[0].long.key).toBe("API\\d+");
+  });
+
+  test("generateTermTestText 接受 { conflicts } 预计算结果并跳过内部自算", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    const synthetic = [
+      {
+        short: { key: "XX", value: "叉叉", isWord: true },
+        long: { key: "XXYY", value: "", isWord: false },
+        shortHasValue: true,
+        longHasValue: false,
+      },
+    ];
+    const cases = generateTermTestText(parsed, "", { conflicts: synthetic });
+    // 用例全部来自注入的 synthetic 冲突对，不含 API/APIKey 对
+    const conflictCases = cases.filter((c) => c.type === "conflict");
+    expect(conflictCases).toHaveLength(2); // short-first + long-first
+    for (const c of conflictCases) {
+      expect(c.short.key).toBe("XX");
+      expect(c.long.key).toBe("XXYY");
+    }
+    expect(
+      cases.some(
+        (c) => c.type === "conflict" && (c.short.key === "API" || c.long.key === "APIKey")
+      )
+    ).toBe(false);
+    // 无冲突术语走单术语用例
+    const singleCases = cases.filter((c) => c.type === "single");
+    expect(singleCases.map((c) => c.term.key).sort()).toEqual(["API", "APIKey"]);
+  });
+
+  test("generateTermTestText 不传 conflicts 时保持向后兼容（内部自算）", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    const cases = generateTermTestText(parsed);
+    const conflictCases = cases.filter((c) => c.type === "conflict");
+    expect(conflictCases).toHaveLength(2);
+  });
+});

--- a/src/libs/terms.js
+++ b/src/libs/terms.js
@@ -1,0 +1,888 @@
+// 专业术语（terms）解析与替换纯函数模块
+// 无 DOM、无日志依赖，供 translator / Playground / CLI / 单元测试四方复用。
+//
+// 已知边界（设计裁定留档，统一计划 20260829 Task 7）：
+// - 灾难性回溯无超时：ECMAScript 没有正则执行超时 API（语言级约束），用户自写的
+//   病态正则（如嵌套量词 + 交错字面量）在极端输入上可能阻塞主线程。该风险的前置
+//   条件是用户亲手书写恶意正则（自伤而非攻击面），parseTerms 已拦截非法正则、空
+//   匹配与纯零宽模式，触发边界显著收敛；metaWarnings 引导转义降低误写概率。
+//   Worker 化可以把执行移出主线程，但会引入通信/生命周期/跨环境（油猴、Web、扩展）
+//   三套适配与序列化成本，相对"用户自伤"的风险量级属过度工程，裁定不采用。
+//
+// 解析规格：
+// - 多条术语以换行或 ; 分隔；每条形如 key,value，key 与 value 用最后一个英文逗号分隔（key 本身允许含逗号）。
+// - key 按正则源码校验（new RegExp(key)），非法则跳过并收集进 invalid 数组（每项 { key, error }）。
+// - value 允许为空（= 不翻译，替换时保留原文并包裹标记）。"省略译文"的推荐写法是整段只写
+//   key（无逗号）；尾巴逗号 key, 同样按保留原文处理（兼容上游，非致命提醒，不阻断替换测试）。
+// - 相同 key 只保留首次出现；按 key.length 降序排序。
+// - 匹配语义：key 一律按正则源码包装为 (key) 参与 alternation，与上游一致、无单词边界，
+//   术语在原文任意位置（含其他字母内部，如 APIKeys/APIs/myAPI）都会命中。
+//   isWord（/^[A-Za-z0-9_]+$/ 判定）仅作诊断元数据保留，不再参与模式构建。
+// - 非法输入诊断：空源术语（,value）、非法正则、同源不同译文冲突（conflicting-mapping）与
+//   正则重叠冲突（conflicting-pattern）为致命诊断，hasErrors=true；尾巴逗号（key,）按保留原文
+//   处理（extra-comma 非致命提醒，仅提示更推荐只写 key）；重复映射（完全相同的 key,value）为
+//   非致命诊断；消费方在 hasErrors 时不得生成"替换测试成功"摘要。
+// - metaWarnings：有效术语的 key 中未转义正则元字符（如 .）的清单，供 UI 给出转义警告（非致命）。
+// - originalOrder 记录有效术语在原始输入中的出现顺序（供 applyNaiveReplace 复现旧引擎行为）。
+// - 非字符串输入统一视为空输入。
+
+const WORD_KEY_REGEX = /^[A-Za-z0-9_]+$/;
+
+// 未转义即按元字符处理的常见正则字符（提示用户转义用）
+const REGEX_META_CHARS = new Set([
+  ".",
+  "*",
+  "+",
+  "?",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "|",
+  "^",
+  "$",
+]);
+
+// 致命诊断类型：只要存在其一，整体输入不得视为"本地替换测试成功"
+// 导出供消费方（Playground 等）复用同一判定来源，避免硬编码列表漂移。
+// 注意：extra-comma 不在其中——`key,` 按保留原文处理，仅作非致命提醒。
+export const FATAL_DIAGNOSTIC_TYPES = new Set([
+  "empty-source-term",
+  "invalid-regex",
+  "empty-matching-pattern",
+  "zero-width-matching-pattern",
+  "conflicting-mapping",
+  "conflicting-pattern",
+]);
+
+/**
+ * 扫描 key 中未转义的正则元字符（反斜杠转义的字符跳过）。
+ * 仅用于 UI 提示（正则语义说明），不改变匹配行为。
+ * @param {string} key
+ * @returns {string[]} 去重后的元字符列表
+ */
+export function findUnescapedRegexMeta(key) {
+  if (typeof key !== "string") return [];
+  const found = new Set();
+  for (let i = 0; i < key.length; i++) {
+    const ch = key[i];
+    if (ch === "\\") {
+      i += 1; // 跳过被转义的字符
+      continue;
+    }
+    if (REGEX_META_CHARS.has(ch)) found.add(ch);
+  }
+  return [...found];
+}
+
+/** 预编译正则完整命中字面文本（m[0] === literalText）时返回 true。 */
+function regexFullyMatches(regex, literalText) {
+  if (!regex) return false;
+  try {
+    const match = regex.exec(literalText);
+    return Boolean(match && match[0] === literalText);
+  } catch (e) {
+    return false; // parseTerms 已校验过，正常不会走到这里
+  }
+}
+
+/**
+ * 跳过从 src[start]（'('）开始的平衡分组，返回 ')' 之后的位置。
+ * 内部的字符类与转义不参与配对计数。
+ */
+function skipBalancedGroup(src, start) {
+  let depth = 0;
+  let i = start;
+  let inClass = false;
+  while (i < src.length) {
+    const c = src[i];
+    if (inClass) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "]") inClass = false;
+      i += 1;
+      continue;
+    }
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === "[") {
+      inClass = true;
+      i += 1;
+      continue;
+    }
+    if (c === "(") {
+      depth += 1;
+      i += 1;
+      continue;
+    }
+    if (c === ")") {
+      depth -= 1;
+      i += 1;
+      if (depth === 0) return i;
+      continue;
+    }
+    i += 1;
+  }
+  return src.length; // 已通过 new RegExp 校验，理论不可达
+}
+
+/**
+ * 判定正则源码是否"整个 pattern 无任何可消费原子"（纯零宽/纯断言）。
+ * 此类模式（如 (?=x)、(?<=x)、\b）在空串上不匹配（先被 empty-matching 门闸
+ * 放行），但在非空文本上零宽命中并逐位置注入译文。
+ *
+ * 可消费原子 = 字面量字符 / . / [...] / 除 \b \B 外的一切转义序列。
+ * 不可确判一律按可消费处理（宁漏报交由 scanWithTerms 运行时守卫兜底，
+ * 不误报废合法术语，如 a|(?=x) 这类混合臂）。
+ *
+ * @param {string} key 已通过 new RegExp 校验的正则源码
+ * @returns {boolean} true = 纯零宽模式
+ */
+function isZeroWidthOnlyPattern(key) {
+  if (typeof key !== "string") return false;
+  const n = key.length;
+  let i = 0;
+  while (i < n) {
+    const ch = key[i];
+    if (ch === "\\") {
+      const next = key[i + 1];
+      if (next === "b" || next === "B") {
+        i += 2; // \b \B 是零宽断言，不消费字符
+        continue;
+      }
+      return false; // 其余转义一律按可消费（\d \s \\ \1 等）
+    }
+    if (ch === "[") {
+      // 字符类：整类按可消费处理（类内 \b 是退格字符，与断言语义无关）
+      i += 1;
+      while (i < n) {
+        if (key[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (key[i] === "]") break;
+        i += 1;
+      }
+      // 顶层字符类恒消费一个字符 = 可消费原子（计划 §2.2），判定为可消费。
+      // 越过 ] 后必须 return false 而非 continue：否则 [A-Z][a-z]+ / [0-9]+ / [^abc]
+      // 这类合法术语被误判纯零宽并从生产替换中静默丢弃（P1 回归锁定）。
+      // 环视组内的类不受影响：(?=[a-z]) 在上面的 lookaround 分支已整体跳过。
+      return false;
+    }
+    if (ch === "(") {
+      // 环视组 (?= (?! (?<= (?<! 本身零宽：内部原子不消费字符，整组跳过。
+      const isLookaround =
+        key[i + 1] === "?" &&
+        (key[i + 2] === "=" ||
+          key[i + 2] === "!" ||
+          (key[i + 2] === "<" &&
+            (key[i + 3] === "=" || key[i + 3] === "!")));
+      if (isLookaround) {
+        i = skipBalancedGroup(key, i);
+        continue;
+      }
+      i += 1;
+      // 命名组 (?<name> ：头部 "?<name>" 中的 ? < 与名字、> 均为语法字符
+      if (key[i] === "?") {
+        i += 1;
+        if (key[i] === "<" && key[i + 1] !== "=" && key[i + 1] !== "!") {
+          i += 1;
+          while (i < n && key[i] !== ">") i += 1;
+          i += 1; // 越过 >
+        }
+      }
+      continue;
+    }
+    if (ch === ".") return false; // 消费任意字符
+    if ("^$|?*+{})".includes(ch)) {
+      i += 1; // 语法字符，非原子
+      continue;
+    }
+    return false; // 其余字符 = 字面量，可消费
+  }
+  return true; // 全程未遇可消费原子 → 纯零宽
+}
+
+// 归一化入参：既接受 parsedTerms 数组，也接受 parseTerms 返回的 { terms, invalid, originalOrder } 对象
+function toTermList(parsedTerms) {
+  if (Array.isArray(parsedTerms)) return parsedTerms;
+  return parsedTerms?.terms || [];
+}
+
+/**
+ * 统计正则源码里的捕获组数量（普通捕获组与命名捕获组都会占用槽位）。
+ * 技巧：在源码末尾挂上一个恒为空的捕获组 `()`，再对一定能匹配上它的位置取的执行。
+ * 由于 match 数组长度恒等于「捕获组总数 + 1」（未参与的分组保持 undefined），
+ * 只要知道数组总长即可反推源码里的捕获组个数，无需手写括号计数解析器。
+ * @param {string} regexSrc
+ * @returns {number}
+ */
+function countCaptureGroupsInSource(regexSrc) {
+  try {
+    const probeMatch = new RegExp(`${regexSrc}|()`).exec("");
+    return probeMatch ? probeMatch.length - 2 : 0;
+  } catch {
+    // parseTerms 已校验过用户正则；此处命中只发生在手写非法 source 时，保守按 0。
+    return 0;
+  }
+}
+
+/**
+ * 手动 exec 循环扫描替换，配合「分支槽位」预扫描把每次命中反查回所属术语。
+ *
+ * 分支身份判定：
+ *   组合正则 = patterns.join("|")，其中每个分支基座恰好是 term.pattern 的外层捕获组，
+ *   因此在第 b 个分支上叠加 term 内部的捕获组后，分支 b 的基座槽位是一个确定数字。
+ *   「分支 b 命中  ⇔  token[基座槽位] !== undefined」（alternation 同一时刻只有
+ *   一个分支参与捕获）是稳定不变量，不依赖用户捕获组的数量、命名或排列。
+ *
+ *   判定过程在「完整原文」上重放一次同样的组合正则扫描（独立实例，lastIndex 互不干扰），
+ *   只命中到主扫描的当前 start 为止再取分支 —— 这保证了 lookbehind/lookahead 等依赖
+ *   上下文的正则拿到与主扫描完全一致的语义（旧实现只对孤立的 fullMatch 反查，会因
+ *   丢失前置/后置字符而失败）。
+ *
+ * 快路径：传入 buildTermsMatcher 物化的 matcher（其 termList 与本调用 termList
+ * 同一引用）时，槽位表与 phaseRegex 直接复用，热路径零编译（Translator 逐文本
+ * 节点扫描的关键性能保障）。matcher 为空或与 termList 不一致时走慢路径现场构建，
+ * 行为与旧实现完全一致。
+ *
+ * 兜底：无法映射到任何术语（手写外部正则与 termList 不一致等契约破坏）时，把本次
+ * 命中的完整原文区间写回，绝不推进 cursor 吞掉正文。
+ *
+ * @param {string} text
+ * @param {RegExp} regex 组合正则（g 标志）
+ * @param {Array} termList
+ * @param {(termEntry, fullMatch) => string} replacer
+ * @param {object} [matcher] buildTermsMatcher 物化的扫描上下文
+ * @returns {{ output: string, spans: Array }}
+ */
+function scanWithTerms(text, regex, termList, replacer, matcher) {
+  if (termList.length === 0) return { output: text, spans: [] };
+
+  let branchBaseGroups; // 分支 → 基座捕获组编号
+  let branchTermIndex; // 分支 → 术语下标
+  let mappingAligned;
+  let phaseRegex;
+
+  if (matcher && matcher.termList === termList && matcher.regex) {
+    // 快路径：全部扫描上下文来自 matcher，零编译
+    regex = matcher.regex;
+    branchBaseGroups = matcher.branchBaseGroups;
+    branchTermIndex = matcher.branchTermIndex;
+    mappingAligned = matcher.mappingAligned;
+    phaseRegex = matcher.phaseRegex;
+  } else {
+    // 慢路径：现场构建（兼容裸组合正则调用方）
+    // 非全局正则无法用 exec 循环（永远停在 index 0），统一补 g
+    if (!regex.global) {
+      regex = new RegExp(regex.source, `${regex.flags}g`);
+    }
+
+    // 分支基座槽位表：与 buildTermsRegex 采用相同的「只物化带 pattern 的术语」规则，
+    // 保证槽位计算与组合正则逐字对应。无 pattern 的术语不会进入 alternation，映射直接排除。
+    branchBaseGroups = [];
+    branchTermIndex = [];
+    let nextBaseGroup = 1;
+    for (let i = 0; i < termList.length; i++) {
+      const patternSrc = termList[i]?.pattern;
+      if (!patternSrc) continue;
+      branchBaseGroups.push(nextBaseGroup);
+      branchTermIndex.push(i);
+      nextBaseGroup += countCaptureGroupsInSource(patternSrc);
+    }
+
+    // 槽位映射与 termList 严格对齐（每个术语恰好贡献一个分支）时才启用预扫描判定；
+    // 否则无法可靠反查，直接走原文保留兜底。phaseRegex 必须继承原正则全部 flags
+    //（i/m/s 等），否则外部 /gi 场景下预扫描大小写不敏感语义丢失，术语被静默放弃。
+    mappingAligned = branchBaseGroups.length === termList.length;
+    phaseRegex = mappingAligned
+      ? new RegExp(regex.source, regex.flags)
+      : null;
+  }
+
+  // 复用共享正则/共享 matcher 时必须重置主扫描状态，保证跨调用幂等
+  regex.lastIndex = 0;
+  let phaseLastIndex = 0; // 预扫描已推进到的位置（与主扫描 z 状态无关）
+
+  const spans = [];
+  let result = "";
+  let cursor = 0;
+  let match;
+
+  // 预扫描：在完整原文上重放组合正则，直到到达主扫描命中的 start，
+  // 取该位置命中的分支基座槽位反查术语下标。
+  const resolvePhaseTermIndex = (start, fullMatch) => {
+    if (!phaseRegex) return -1;
+    for (;;) {
+      phaseRegex.lastIndex = phaseLastIndex;
+      const token = phaseRegex.exec(text);
+      if (!token) return -1;
+      const idx = token.index;
+      phaseLastIndex = idx + (token[0].length === 0 ? 1 : token[0].length);
+      if (idx > start) return -1;
+      if (idx === start) {
+        if (token[0] !== fullMatch) return -1;
+        for (let b = 0; b < branchBaseGroups.length; b++) {
+          if (token[branchBaseGroups[b]] !== undefined) {
+            return branchTermIndex[b];
+          }
+        }
+        return -1;
+      }
+    }
+  };
+
+  while ((match = regex.exec(text)) !== null) {
+    const fullMatch = match[0];
+    const start = match.index;
+
+    // 零宽命中守卫：静态层只拦"整个 pattern 纯零宽"，混合臂（如 a|(?=x)）的
+    // 零宽分支仍会在运行期命中。零宽命中不消费字符，照常 replacer+span 会在
+    // start===end 处凭空注入译文——直接跳过：不调 replacer、不产 span、
+    // 不推进 cursor，仅手动前进 lastIndex 防 exec 死循环。
+    // 已知边界（同位错过）：`(?=x)|x` on "x" 时，零宽臂赢得 alternation 优先级
+    // 后 lastIndex++，同位的消费分支不再被尝试，该处替换被错过。形态为
+    // "漏替换"而非"错误注入"，属"宁漏不误"设计取舍，不做代码级修复。
+    if (fullMatch.length === 0) {
+      regex.lastIndex++;
+      continue;
+    }
+
+    const termIndex = resolvePhaseTermIndex(start, fullMatch);
+
+    if (termIndex === -1) {
+      // 无法映射到任何术语条目（契约破坏等）：原样写回本次命中的完整原文区间并前进，
+      // 严禁只推进 cursor 把正文吞掉（P1 正文丢失根因）。
+      result += text.slice(cursor, start + fullMatch.length);
+      cursor = start + fullMatch.length;
+      continue;
+    }
+
+    const termEntry = termList[termIndex];
+    const replacement = replacer(termEntry, fullMatch);
+    spans.push({
+      start,
+      end: start + fullMatch.length,
+      termKey: termEntry.key,
+      value: termEntry.value,
+      replacement,
+    });
+    result += text.slice(cursor, start) + replacement;
+    cursor = start + fullMatch.length;
+  }
+
+  result += text.slice(cursor);
+  return { output: result, spans };
+}
+
+/**
+ * 为 CLI / 开发日志将结构化诊断对象格式化为人类可读的单行文本。
+ * 纯格式化函数，零 React 依赖。
+ * UI 层（Playground 等）应使用 i18n 键和结构化 detail 进行多语言渲染，不依赖此函数的硬编码中文。
+ * @param {{ type: string, segmentIndex?: number, segment?: string, key?: string, detail?: object }} diagnostic
+ * @returns {string}
+ */
+export function formatDiagnosticMessage(diagnostic) {
+  if (!diagnostic) return "";
+  const { type, segmentIndex, segment, key, detail } = diagnostic;
+  const seg = detail?.segment ?? segment ?? "";
+  const idx = detail?.segmentIndex ?? segmentIndex ?? "?";
+  switch (type) {
+    case "empty-source-term":
+      return `第 ${idx} 段「${seg}」的逗号前没有源术语（空源术语）`;
+    case "invalid-regex":
+      return `第 ${idx} 段「${seg}」无法作为正则解析：${detail?.error ?? ""}`;
+    case "empty-matching-pattern":
+      return `第 ${idx} 段「${seg}」的正则可匹配空字符串（${detail?.key ?? key ?? ""}），会在任意位置注入译文导致错乱，请改用非空匹配的正则`;
+    case "zero-width-matching-pattern":
+      return `第 ${idx} 段「${seg}」的正则不消费任何字符（${detail?.key ?? key ?? ""}），会在原文任意位置零宽注入译文导致错乱，请改用消费字符的正则`;
+    case "conflicting-mapping":
+      return `第 ${idx} 段「${seg}」与第 ${detail?.prevIndex ?? "?"} 段「${detail?.key ?? key ?? ""},${detail?.prevValue ?? ""}」同源但译文不同（冲突映射）`;
+    case "conflicting-pattern":
+      return `第 ${detail?.segmentIndexA ?? "?"} 段「${detail?.keyA ?? ""}」与第 ${detail?.segmentIndexB ?? "?"} 段「${detail?.keyB ?? ""}」的正则同时命中同一原文「${detail?.literal ?? ""}」（冲突映射），请转义或统一术语写法`;
+    case "extra-comma":
+      return `第 ${idx} 段「${seg}」逗号后没有译文（多余逗号）；已按保留原文处理，更推荐只写 key 不加尾巴逗号`;
+    case "duplicate-mapping":
+      return `第 ${idx} 段「${seg}」与第 ${detail?.prevIndex ?? "?"} 段重复（重复映射），已忽略`;
+    default:
+      return `第 ${idx} 段「${seg}」存在诊断（${type ?? ""}）`;
+  }
+}
+
+/**
+ * 严格字面量白名单文法：key 不含未转义正则元字符，且每个转义序列的被转义字符
+ * 本身 ∈ REGEX_META_CHARS（如 \. \+ \$）。
+ *
+ * 反例锁定：\d 的被转义字符 d 不是元字符 → 不算字面量（否则 \d × 5 的
+ * conflicting-pattern 检出会被漏掉）。\\（转义反斜杠）的被转义字符 \ 也不在
+ * 元字符集合内 → 保守不算字面量。
+ *
+ * 严格字面量模式作为正则只可能匹配其源码的去转义文本，两两冲突判定因此可
+ * 退化为纯子串比较，实现零正则编译的 O(n²) 短路。
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isStrictLiteralPattern(key) {
+  if (typeof key !== "string" || key === "") return false;
+  for (let i = 0; i < key.length; i++) {
+    const ch = key[i];
+    if (ch === "\\") {
+      if (!REGEX_META_CHARS.has(key[i + 1])) return false;
+      i += 1;
+      continue;
+    }
+    if (REGEX_META_CHARS.has(ch)) return false;
+  }
+  return true;
+}
+
+/**
+ * 跨术语正则重叠冲突分析（两两全量交叉校验，O(n²) 诊断逻辑）。
+ * 仅在 full 模式（Playground / CLI / 完整测试）下调用，避免阻塞生产 Translator 初始化。
+ *
+ * 性能加固（统一计划 20260829 Task 4）：
+ *   ① isStrictLiteralPattern 白名单短路——双方均为严格字面量时，字面量正则
+ *     只可能完整命中自身去转义文本，双 key 不同则必然无冲突，零编译跳过；
+ *   ② 按 key 预编译——非白名单对的正则每个 key 只编译一次（原实现对每个
+ *     有序对编译 2 次，40 条字面量术语即 3120 次编译）。
+ */
+function analyzeCrossTermPatternConflicts(terms, seenKeys, diagnostics) {
+  const patternConflictSeen = new Set();
+  const strictLiteralCache = new Map(); // key → boolean
+  const regexCache = new Map(); // key → RegExp | null
+
+  const isStrict = (key) => {
+    let v = strictLiteralCache.get(key);
+    if (v === undefined) {
+      v = isStrictLiteralPattern(key);
+      strictLiteralCache.set(key, v);
+    }
+    return v;
+  };
+  const getRegex = (key) => {
+    if (!regexCache.has(key)) {
+      let re = null;
+      try {
+        re = new RegExp(key); // 非全局：exec 不推进 lastIndex，可安全复用
+      } catch (e) {
+        re = null; // parseTerms 已校验过，正常不会走到这里
+      }
+      regexCache.set(key, re);
+    }
+    return regexCache.get(key);
+  };
+
+  for (let i = 0; i < terms.length; i++) {
+    for (let j = 0; j < terms.length; j++) {
+      if (i === j) continue;
+      const a = terms[i];
+      const b = terms[j];
+      if (a.key === b.key) continue;
+      const literalOverlap =
+        a.key.length <= b.key.length
+          ? b.key.includes(a.key)
+          : a.key.includes(b.key);
+      if (literalOverlap) continue;
+
+      // 白名单短路：双方均为严格字面量 → 字面量正则只匹配自身去转义文本，
+      // key 不同则不可能互相完整命中，无需编译任何正则。
+      if (isStrict(a.key) && isStrict(b.key)) continue;
+
+      // 任一方向的正则完整命中对方字面 key 即视为同一原文被两个术语同时认领
+      const reA = getRegex(a.key);
+      const hitB = regexFullyMatches(reA, b.key);
+      const reB = getRegex(b.key);
+      const hitA = regexFullyMatches(reB, a.key);
+      if (!hitB && !hitA) continue;
+
+      const signature = [a.key, b.key].sort().join("\u0000");
+      if (patternConflictSeen.has(signature)) continue;
+      patternConflictSeen.add(signature);
+
+      const literal = hitB ? b.key : a.key;
+      diagnostics.push({
+        type: "conflicting-pattern",
+        segmentIndex: seenKeys.get(a.key)?.index || i + 1,
+        segment: a.key,
+        key: a.key,
+        detail: {
+          keyA: a.key,
+          keyB: b.key,
+          literal,
+          segmentIndexA: seenKeys.get(a.key)?.index,
+          segmentIndexB: seenKeys.get(b.key)?.index,
+        },
+      });
+    }
+  }
+}
+
+/**
+ * 解析术语字符串
+ * @param {string} termsString
+ * @param {object} [options]
+ * @param {boolean} [options.fullDiagnostics=true] 是否执行跨术语 O(n²) 冲突分析（Playground / CLI / 完整测试传 true；生产 Translator 传 false）
+ * @returns {{
+ *   terms: Array<{ key: string, value: string, pattern: string, isWord: boolean }>,
+ *   invalid: Array<{ key: string, error: Error }>,
+ *   originalOrder: Array<{ key: string, value: string, pattern: string, isWord: boolean }>,
+ *   diagnostics: Array<{ type: string, segmentIndex: number, segment: string, key?: string, detail: object }>,
+ *   metaWarnings: Array<{ key: string, segmentIndex: number, metas: string[] }>,
+ *   hasErrors: boolean,
+ *   diagnosticsMode: "fast" | "full",
+ * }}
+ */
+export function parseTerms(termsString, options = {}) {
+  const fullDiagnostics = options?.fullDiagnostics !== false;
+  const diagnosticsMode = fullDiagnostics ? "full" : "fast";
+
+  const terms = [];
+  const invalid = [];
+  const originalOrder = [];
+  const diagnostics = [];
+  const metaWarnings = [];
+  const seenKeys = new Map(); // key -> { value, index }，记录首个出现的段
+
+  // 非字符串/空白串统一视为空输入
+  if (typeof termsString !== "string" || termsString.trim() === "") {
+    return {
+      terms,
+      invalid,
+      originalOrder,
+      diagnostics,
+      metaWarnings,
+      hasErrors: false,
+      diagnosticsMode,
+    };
+  }
+
+  const lines = termsString.split(/\n|;/); // 按换行或分号分割
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const trimmedLine = lines[lineIndex].trim();
+    const segmentIndex = lineIndex + 1; // 段号（1 起），与输入原文对应
+    if (!trimmedLine) continue; // 空段：静默跳过（空段不是非法段）
+
+    const lastCommaIndex = trimmedLine.lastIndexOf(",");
+    const hasComma = lastCommaIndex !== -1;
+    const key = hasComma
+      ? trimmedLine.substring(0, lastCommaIndex).trim()
+      : trimmedLine.trim();
+    const value = hasComma
+      ? trimmedLine.substring(lastCommaIndex + 1).trim()
+      : "";
+
+    // 空源术语：`,value`（逗号前没有源术语）
+    if (hasComma && !key) {
+      diagnostics.push({
+        type: "empty-source-term",
+        segmentIndex,
+        segment: trimmedLine,
+        detail: { segment: trimmedLine, segmentIndex },
+      });
+      continue;
+    }
+
+    // 多余逗号：`key,`（逗号后没有译文）。
+    // 兼容上游行为：`key,` 视为 value="" 的保留原文合法术语（替换时保留原文并 <i> 高亮），
+    // 仅作非致命提醒；不 continue，继续走后续校验并正常入表。更推荐的写法是只写 key 不加尾巴逗号。
+    if (hasComma && value === "") {
+      diagnostics.push({
+        type: "extra-comma",
+        segmentIndex,
+        segment: trimmedLine,
+        key,
+        detail: { segment: trimmedLine, segmentIndex, key },
+      });
+    }
+
+    // key 当作正则源码校验，非法则跳过并收集（保留 error 供日志/UI 提示）
+    let regexError = null;
+    let keyRegex = null;
+    try {
+      keyRegex = new RegExp(key);
+    } catch (error) {
+      regexError = error;
+    }
+    if (regexError) {
+      invalid.push({ key, error: regexError });
+      diagnostics.push({
+        type: "invalid-regex",
+        segmentIndex,
+        segment: trimmedLine,
+        key,
+        detail: {
+          segment: trimmedLine,
+          segmentIndex,
+          key,
+          error: regexError.message,
+        },
+      });
+      continue;
+    }
+
+    // 空匹配正则（如 a*、()、x?）：会在任意位置命中空串，替换时逐字注入译文导致文本错乱，
+    // 属于致命诊断，跳过该段（合法术语仍照常应用）。
+    if (keyRegex.test("")) {
+      diagnostics.push({
+        type: "empty-matching-pattern",
+        segmentIndex,
+        segment: trimmedLine,
+        key,
+        detail: { segment: trimmedLine, segmentIndex, key },
+      });
+      continue;
+    }
+
+    // 纯零宽正则（如 (?=x)、(?<=x)、\b）：整个 pattern 无任何可消费原子，在空串上
+    // 不匹配（躲过上面的 empty-matching 门闸），但在非空文本上逐位置零宽命中并注入
+    // 译文。属于致命诊断，跳过该段（混合臂如 a|(?=x) 含可消费原子，不在此列，
+    // 其运行期零宽分支由 scanWithTerms 守卫兜底）。
+    if (isZeroWidthOnlyPattern(key)) {
+      diagnostics.push({
+        type: "zero-width-matching-pattern",
+        segmentIndex,
+        segment: trimmedLine,
+        key,
+        detail: { segment: trimmedLine, segmentIndex, key },
+      });
+      continue;
+    }
+
+    // 同 key 去重与冲突映射：相同 key 只保留首次出现
+    if (seenKeys.has(key)) {
+      const prev = seenKeys.get(key);
+      if (prev.value === value) {
+        // 完全相同的映射 → 非致命重复映射
+        diagnostics.push({
+          type: "duplicate-mapping",
+          segmentIndex,
+          segment: trimmedLine,
+          key,
+          detail: {
+            segment: trimmedLine,
+            segmentIndex,
+            key,
+            prevIndex: prev.index,
+          },
+        });
+      } else {
+        // 同源不同译文 → 致命冲突映射
+        diagnostics.push({
+          type: "conflicting-mapping",
+          segmentIndex,
+          segment: trimmedLine,
+          key,
+          detail: {
+            segment: trimmedLine,
+            segmentIndex,
+            key,
+            prevIndex: prev.index,
+            prevValue: prev.value,
+          },
+        });
+      }
+      continue;
+    }
+
+    // isWord 仅作诊断元数据（Playground/测试引用），不参与模式构建：
+    // 生产匹配与上游一致，key 一律按正则源码包装为 (key)，无单词边界。
+    const isWord = WORD_KEY_REGEX.test(key);
+    const pattern = `(${key})`;
+    const entry = { key, value, pattern, isWord };
+    seenKeys.set(key, { value, index: segmentIndex });
+    terms.push(entry);
+    originalOrder.push(entry);
+
+    // 未转义正则元字符提示（非致命，仅 UI 警告）
+    const metas = findUnescapedRegexMeta(key);
+    if (metas.length > 0) {
+      metaWarnings.push({ key, segmentIndex, metas });
+    }
+  }
+
+  // 跨术语正则重叠冲突分析（O(n²)）：仅 full 模式执行。
+  // fast 模式下省略该诊断只表示"未执行完整冲突分析"，不宣称输入通过了完整校验。
+  if (fullDiagnostics) {
+    analyzeCrossTermPatternConflicts(terms, seenKeys, diagnostics);
+  }
+
+  // 按 key.length 降序排序（重叠 key 长词在前，避免短词抢占）
+  terms.sort((a, b) => b.key.length - a.key.length);
+
+  const hasErrors = diagnostics.some((d) => FATAL_DIAGNOSTIC_TYPES.has(d.type));
+
+  return {
+    terms,
+    invalid,
+    originalOrder,
+    diagnostics,
+    metaWarnings,
+    hasErrors,
+    diagnosticsMode,
+  };
+}
+
+/**
+ * 由解析后的术语构建组合正则（g 标志），无有效术语时返回 null
+ * @param {Array|object} parsedTerms
+ * @returns {RegExp|null}
+ */
+export function buildTermsRegex(parsedTerms) {
+  const terms = toTermList(parsedTerms);
+  if (terms.length === 0) return null;
+  const patterns = terms.map((t) => t.pattern).filter(Boolean);
+  if (patterns.length === 0) return null;
+  return new RegExp(patterns.join("|"), "g");
+}
+
+/**
+ * 一次物化术语扫描上下文（matcher），供热路径零编译复用。
+ *
+ * Translator 对每个文本节点调用一次 applyTermReplace；把组合正则、phase 预扫描
+ * 正则、分支槽位表在规则解析时一次性物化，避免逐节点重建（每术语 1 次 new RegExp
+ * 探针 + phaseRegex 编译）导致的页面级卡顿。
+ *
+ * 返回对象字段：
+ *   - termList: 术语数组（与传入 parsed.terms 同一引用）
+ *   - regex: 组合正则（g 标志）
+ *   - phaseRegex: 预扫描正则（继承 regex 全部 flags；不对齐时为 null）
+ *   - branchBaseGroups / branchTermIndex: 分支基座槽位表
+ *   - mappingAligned: 槽位映射是否与 termList 严格对齐
+ *   - flags: regex.flags
+ *
+ * 契约：物化后调用方不得就地变异 termList 条目的 key/pattern 字段；
+ * 跨调用复用同一 matcher 是安全的（lastIndex 由 scanWithTerms 每次重置）。
+ * 热更新时由调用方（Translator #parseTerms）整体重建 matcher 自然失效。
+ *
+ * @param {Array|object} parsedTerms
+ * @returns {object|null} 无有效术语时返回 null
+ */
+export function buildTermsMatcher(parsedTerms) {
+  const termList = toTermList(parsedTerms);
+  if (termList.length === 0) return null;
+  const regex = buildTermsRegex(termList);
+  if (!regex) return null;
+
+  // 分支基座槽位表：与组合正则逐字对应（只物化带 pattern 的术语）
+  const branchBaseGroups = [];
+  const branchTermIndex = [];
+  let nextBaseGroup = 1;
+  for (let i = 0; i < termList.length; i++) {
+    const patternSrc = termList[i]?.pattern;
+    if (!patternSrc) continue;
+    branchBaseGroups.push(nextBaseGroup);
+    branchTermIndex.push(i);
+    nextBaseGroup += countCaptureGroupsInSource(patternSrc);
+  }
+  const mappingAligned = branchBaseGroups.length === termList.length;
+
+  return {
+    termList,
+    regex,
+    phaseRegex: mappingAligned
+      ? new RegExp(regex.source, regex.flags)
+      : null,
+    branchBaseGroups,
+    branchTermIndex,
+    mappingAligned,
+    flags: regex.flags,
+  };
+}
+
+/**
+ * 单次 replace 扫描：命中区间记录 + 自定义替换回调。
+ * 第 4 参既接受裸组合正则（慢路径，现场构建槽位表，兼容既有调用方），
+ * 也接受 buildTermsMatcher 物化的 matcher（快路径，热路径零编译）。
+ * 对命名捕获组/嵌套捕获组 key 免疫：手动 exec 扫描 + 按术语 pattern 全量反查，
+ * 不依赖 String.replace 回调的捕获组参数位置。
+ * @param {string} text
+ * @param {Array|object} parsedTerms
+ * @param {(termEntry, fullMatch) => string} replacer
+ * @param {RegExp|object} [regex] 组合正则（g 标志）或 buildTermsMatcher 物化对象
+ * @returns {{ output: string, spans: Array<{ start: number, end: number, termKey: string, value: string, replacement: string }> }}
+ */
+export function applyTermReplace(text, parsedTerms, replacer, regex) {
+  // 非字符串统一视为空输入
+  if (typeof text !== "string") return { output: "", spans: [] };
+
+  const terms = toTermList(parsedTerms);
+
+  // matcher 快路径：termList 身份必须与本次传入 terms 一致；
+  // 不一致（契约破坏）时丢弃 matcher 按传入 terms 重建，保证输出自愈正确。
+  // 探测用鸭子类型（termList + exec），不用 instanceof——RegExp 子类与
+  // 跨 realm 场景下 instanceof 会误判。
+  if (
+    regex &&
+    typeof regex === "object" &&
+    regex.termList &&
+    regex.regex &&
+    typeof regex.regex.exec === "function"
+  ) {
+    if (regex.termList === terms) {
+      return scanWithTerms(
+        text,
+        regex.regex,
+        terms,
+        (termEntry, fullMatch) => replacer(termEntry, fullMatch),
+        regex
+      );
+    }
+    regex = undefined; // 丢弃不一致的 matcher，走下方重建
+  }
+
+  const combinedRegex = regex || buildTermsRegex(terms);
+  if (!combinedRegex) return { output: text, spans: [] };
+
+  combinedRegex.lastIndex = 0; // 内部重置 lastIndex，保证可复用
+
+  return scanWithTerms(text, combinedRegex, terms, (termEntry, fullMatch) =>
+    replacer(termEntry, fullMatch)
+  );
+}
+
+// naive 主正则缓存：按 originalOrder / 术语数组引用做 WeakMap 记忆化（GC 友好，
+// 无上限泄漏风险）。缓存的是 buildTermsMatcher 物化对象，与 applyTermReplace
+// 共用同一快路径。契约同 matcher：缓存命中期间不得就地变异术语条目 key 字段。
+const naiveMatcherCache = new WeakMap();
+
+/**
+ * 复现旧引擎行为：不按长度排序、无 \b 单词边界、保持用户输入原始顺序的 alternation。
+ * 优先使用 parseTerms 输出的 originalOrder 元数据，否则退化为 parsedTerms 的数组顺序。
+ * 主正则按术语数组引用缓存（同 parsed 第二次调用零编译）。
+ * 用于"修复前/后"对比演示。
+ * @param {string} text
+ * @param {Array|object} parsedTerms
+ * @returns {{ output: string, spans: Array<{ start: number, end: number, termKey: string, value: string, replacement: string }> }}
+ */
+export function applyNaiveReplace(text, parsedTerms) {
+  // 非字符串统一视为空输入
+  if (typeof text !== "string") return { output: "", spans: [] };
+
+  const orderedTerms = Array.isArray(parsedTerms?.originalOrder)
+    ? parsedTerms.originalOrder
+    : toTermList(parsedTerms);
+  if (orderedTerms.length === 0) return { output: text, spans: [] };
+
+  let matcher = naiveMatcherCache.get(orderedTerms);
+  if (!matcher) {
+    matcher = buildTermsMatcher(orderedTerms);
+    if (matcher) naiveMatcherCache.set(orderedTerms, matcher);
+  }
+  if (!matcher) return { output: text, spans: [] };
+
+  return scanWithTerms(
+    text,
+    matcher.regex,
+    orderedTerms,
+    (termEntry, fullMatch) => termEntry.value || fullMatch,
+    matcher
+  );
+}

--- a/src/libs/terms.test.js
+++ b/src/libs/terms.test.js
@@ -1,0 +1,1439 @@
+import {
+  parseTerms,
+  buildTermsRegex,
+  buildTermsMatcher,
+  applyTermReplace,
+  applyNaiveReplace,
+  findUnescapedRegexMeta,
+  formatDiagnosticMessage,
+  isStrictLiteralPattern,
+} from "./terms";
+import { detectTermConflicts } from "./termTestUtils";
+
+// 术语替换纯函数测试（Task 1）
+// 覆盖：解析规格、排序、去重、非法正则、无单词边界匹配（上游语义）、冲突矩阵 4 类、空译文语义、旧引擎复现
+describe("terms parseTerms", () => {
+  test("parses key,value pairs separated by newline or semicolon", () => {
+    const { terms, invalid, originalOrder } = parseTerms(
+      "API,接口\nGPTs,智能体集合;React,React Native"
+    );
+    expect(invalid).toEqual([]);
+    expect(terms.map((t) => t.key)).toEqual(["React", "GPTs", "API"]);
+    expect(terms.map((t) => t.value)).toEqual([
+      "React Native",
+      "智能体集合",
+      "接口",
+    ]);
+    // originalOrder 保持原始输入顺序，与排序后的 terms 独立
+    expect(originalOrder.map((t) => t.key)).toEqual(["API", "GPTs", "React"]);
+  });
+
+  test("sorts overlapping keys by key.length descending", () => {
+    const { terms } = parseTerms("API,接口;APIKey,应用编程接口");
+    expect(terms.map((t) => t.key)).toEqual(["APIKey", "API"]);
+    // 短词在前、长词在后时同样按长度降序
+    const reversed = parseTerms("APIKey,应用编程接口;API,接口").terms;
+    expect(reversed.map((t) => t.key)).toEqual(["APIKey", "API"]);
+  });
+
+  test("same key with a different value is a conflicting mapping (fatal), not silent override", () => {
+    const { terms, diagnostics, hasErrors } =
+      parseTerms("API,接口;API,另一个接口");
+    // 首段仍保留在 terms，但输入整体标记为非法（冲突映射）
+    expect(terms).toHaveLength(1);
+    expect(terms[0].value).toBe("接口");
+    expect(hasErrors).toBe(true);
+    expect(diagnostics.some((d) => d.type === "conflicting-mapping")).toBe(
+      true
+    );
+  });
+
+  test("identical repeated mapping is a non-fatal duplicate mapping diagnostic", () => {
+    const { terms, diagnostics, hasErrors } = parseTerms("API,接口;API,接口");
+    expect(terms).toHaveLength(1);
+    expect(hasErrors).toBe(false);
+    expect(diagnostics.some((d) => d.type === "duplicate-mapping")).toBe(true);
+    expect(diagnostics.some((d) => d.type === "conflicting-mapping")).toBe(
+      false
+    );
+  });
+
+  test("collects invalid regex keys into invalid array", () => {
+    const { terms, invalid } = parseTerms("API,接口;bad[re");
+    expect(terms.map((t) => t.key)).toEqual(["API"]);
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0].key).toBe("bad[re");
+    expect(invalid[0].error).toBeInstanceOf(Error);
+  });
+
+  test("marks isWord only for pure ASCII word keys", () => {
+    const { terms } = parseTerms("API,接口;手机,手机;API\\.\\d+,x");
+    const byKey = Object.fromEntries(terms.map((t) => [t.key, t]));
+    expect(byKey["API"].isWord).toBe(true);
+    expect(byKey["手机"].isWord).toBe(false);
+    expect(byKey["API\\.\\d+"].isWord).toBe(false);
+  });
+
+  test("wraps all keys as (key) with no word boundaries (上游语义)", () => {
+    const { terms } = parseTerms("API,接口;手机,手机;API\\.\\d+,x");
+    const byKey = Object.fromEntries(terms.map((t) => [t.key, t]));
+    expect(byKey["API"].pattern).toBe("(API)");
+    expect(byKey["手机"].pattern).toBe("(手机)");
+    expect(byKey["API\\.\\d+"].pattern).toBe("(API\\.\\d+)");
+  });
+
+  test("term entries expose exactly key, value, pattern, isWord", () => {
+    const { terms } = parseTerms("API,接口");
+    expect(Object.keys(terms[0]).sort()).toEqual([
+      "isWord",
+      "key",
+      "pattern",
+      "value",
+    ]);
+  });
+
+  test("splits key and value at the last comma", () => {
+    const { terms } = parseTerms("a,b,c");
+    expect(terms[0].key).toBe("a,b");
+    expect(terms[0].value).toBe("c");
+  });
+
+  test("line without comma yields an empty value", () => {
+    const { terms } = parseTerms("APIKey");
+    expect(terms[0].key).toBe("APIKey");
+    expect(terms[0].value).toBe("");
+  });
+
+  test("handles empty input", () => {
+    const empty = {
+      terms: [],
+      invalid: [],
+      originalOrder: [],
+      diagnostics: [],
+      metaWarnings: [],
+      hasErrors: false,
+      diagnosticsMode: "full",
+    };
+    expect(parseTerms("")).toEqual(empty);
+    expect(parseTerms(null)).toEqual(empty);
+    expect(parseTerms(undefined)).toEqual(empty);
+  });
+
+  test("treats whitespace-only and non-string input as empty", () => {
+    const empty = {
+      terms: [],
+      invalid: [],
+      originalOrder: [],
+      diagnostics: [],
+      metaWarnings: [],
+      hasErrors: false,
+      diagnosticsMode: "full",
+    };
+    expect(parseTerms("   ")).toEqual(empty);
+    expect(parseTerms(123)).toEqual(empty);
+  });
+
+  test("reports an empty source term for a comma at the start of a segment", () => {
+    const { terms, invalid, diagnostics, hasErrors } = parseTerms(",;API,接口");
+    expect(terms.map((t) => t.key)).toEqual(["API"]);
+    expect(invalid).toEqual([]);
+    // 「,」段：逗号前没有源术语 → 致命诊断
+    expect(hasErrors).toBe(true);
+    const emptySource = diagnostics.find((d) => d.type === "empty-source-term");
+    expect(emptySource).toBeDefined();
+    expect(emptySource.segmentIndex).toBe(1);
+    expect(emptySource.segment).toBe(",");
+  });
+});
+
+describe("terms buildTermsRegex", () => {
+  test("builds a global regex from sorted parsed terms", () => {
+    const { terms } = parseTerms("API,接口;APIKey,应用编程接口");
+    const regex = buildTermsRegex(terms);
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.flags).toContain("g");
+    expect(regex.source).toBe("(APIKey)|(API)");
+  });
+
+  test("returns null when there are no valid terms", () => {
+    expect(buildTermsRegex([])).toBeNull();
+    expect(buildTermsRegex(parseTerms("").terms)).toBeNull();
+    expect(buildTermsRegex(parseTerms("bad[re").terms)).toBeNull();
+    expect(buildTermsRegex(null)).toBeNull();
+  });
+
+  test("accepts the parseTerms result object as well", () => {
+    const regex = buildTermsRegex(parseTerms("API,接口"));
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex.source).toBe("(API)");
+  });
+});
+
+describe("terms applyTermReplace", () => {
+  const replacer = (term, fullMatch) => term.value || fullMatch;
+
+  test("replaces matches and records spans", () => {
+    const { terms } = parseTerms("API,接口;APIKey,应用编程接口");
+    const { output, spans } = applyTermReplace(
+      "APIKey and API",
+      terms,
+      replacer
+    );
+    expect(output).toBe("应用编程接口 and 接口");
+    expect(spans).toEqual([
+      {
+        start: 0,
+        end: 6,
+        termKey: "APIKey",
+        value: "应用编程接口",
+        replacement: "应用编程接口",
+      },
+      {
+        start: 11,
+        end: 14,
+        termKey: "API",
+        value: "接口",
+        replacement: "接口",
+      },
+    ]);
+  });
+
+  test("冲突矩阵 1：长短词均有译文时，长词整体替换、短词单独替换", () => {
+    const { terms } = parseTerms("API,接口;APIKey,应用编程接口");
+    const { output } = applyTermReplace("APIKey and API", terms, replacer);
+    expect(output).toBe("应用编程接口 and 接口");
+  });
+
+  test("冲突矩阵 2：短词有译文、长词无译文时，长词保持原文不被切割", () => {
+    const { terms } = parseTerms("API,接口;APIKey");
+    const { output, spans } = applyTermReplace(
+      "APIKey and API",
+      terms,
+      replacer
+    );
+    expect(output).toBe("APIKey and 接口");
+    expect(spans.map((s) => s.termKey)).toEqual(["APIKey", "API"]);
+    expect(output).not.toContain("接口Key");
+  });
+
+  test("冲突矩阵 3：短词无译文、长词有译文时，长词必须触发", () => {
+    const { terms } = parseTerms("GPT;GPTs,智能体集合");
+    const { output, spans } = applyTermReplace("GPTs and GPT", terms, replacer);
+    expect(output).toBe("智能体集合 and GPT");
+    expect(spans.map((s) => s.termKey)).toEqual(["GPTs", "GPT"]);
+  });
+
+  test("冲突矩阵 4：长短词均无译文时，长词整体保持原文、无切割残留", () => {
+    const { terms } = parseTerms("React;ReactNative");
+    const { output, spans } = applyTermReplace("ReactNative", terms, replacer);
+    expect(output).toBe("ReactNative");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].termKey).toBe("ReactNative");
+    expect(spans[0].start).toBe(0);
+    expect(spans[0].end).toBe(11);
+  });
+
+  test("keeps original text when the term has no translation (空译文语义)", () => {
+    const { terms } = parseTerms("APIKey");
+    const { output } = applyTermReplace("APIKey", terms, replacer);
+    expect(output).toBe("APIKey");
+  });
+
+  test("CJK keys match inside CJK strings (no word boundary)", () => {
+    const { terms } = parseTerms("手机,phone");
+    const { output } = applyTermReplace("新手机壳", terms, replacer);
+    expect(output).toBe("新phone壳");
+  });
+
+  test("keys match inside longer ASCII words (上游无单词边界)", () => {
+    const { terms } = parseTerms("API,接口");
+    const { output, spans } = applyTermReplace("myAPIkey", terms, replacer);
+    expect(output).toBe("my接口key");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].termKey).toBe("API");
+    expect(spans[0].start).toBe(2);
+    expect(spans[0].end).toBe(5);
+  });
+
+  test("regex terms work by regex semantics", () => {
+    const { terms } = parseTerms("API\\.\\d+,接口版本");
+    const { output } = applyTermReplace("version API.42 ok", terms, replacer);
+    expect(output).toBe("version 接口版本 ok");
+  });
+
+  test("resets lastIndex so the built regex stays reusable", () => {
+    const { terms } = parseTerms("API,接口");
+    applyTermReplace("API API", terms, replacer);
+    const { output } = applyTermReplace("API", terms, replacer);
+    expect(output).toBe("接口");
+  });
+
+  test("reuses a passed-in combined regex and resets its lastIndex", () => {
+    const { terms } = parseTerms("API,接口;APIKey,应用编程接口");
+    const regex = buildTermsRegex(terms);
+    const first = applyTermReplace("API API", terms, replacer, regex);
+    expect(first.output).toBe("接口 接口");
+    expect(regex.lastIndex).toBe(0); // 函数返回后已重置
+    const second = applyTermReplace("APIKey", terms, replacer, regex);
+    expect(second.output).toBe("应用编程接口");
+    expect(regex.lastIndex).toBe(0);
+  });
+
+  test("treats non-string text input as empty", () => {
+    const { terms } = parseTerms("API,接口");
+    expect(applyTermReplace(undefined, terms, replacer)).toEqual({
+      output: "",
+      spans: [],
+    });
+    expect(applyTermReplace(null, terms, replacer)).toEqual({
+      output: "",
+      spans: [],
+    });
+    expect(applyTermReplace(123, terms, replacer)).toEqual({
+      output: "",
+      spans: [],
+    });
+  });
+
+  test("passes the term entry and full match to the replacer", () => {
+    const { terms } = parseTerms("API,接口");
+    const seen = [];
+    applyTermReplace("API", terms, (term, fullMatch) => {
+      seen.push({ key: term.key, value: term.value, fullMatch });
+      return "X";
+    });
+    expect(seen).toEqual([{ key: "API", value: "接口", fullMatch: "API" }]);
+  });
+
+  test("returns text unchanged when there are no valid terms", () => {
+    expect(applyTermReplace("API", [], replacer)).toEqual({
+      output: "API",
+      spans: [],
+    });
+    expect(
+      applyTermReplace("API", parseTerms("bad[re").terms, replacer)
+    ).toEqual({ output: "API", spans: [] });
+  });
+});
+
+describe("terms applyNaiveReplace", () => {
+  test("reproduces the old engine: input order, no boundaries, prefix-cut", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    // 原始顺序：API 在前，APIKey 在后 → alternation `(API)|(APIKey)` → API 抢占
+    const naive = applyNaiveReplace("APIKey and API", parsed);
+    expect(naive.output).toBe("接口Key and 接口");
+    expect(naive.spans.map((s) => s.termKey)).toEqual(["API", "API"]);
+    // 与修复后行为对比
+    expect(
+      applyTermReplace("APIKey and API", parsed.terms, (t, m) => t.value || m)
+        .output
+    ).toBe("应用编程接口 and 接口");
+  });
+
+  test("reproduces the prefix-cut bug for conflict case 2", () => {
+    const parsed = parseTerms("API,接口;APIKey");
+    expect(applyNaiveReplace("APIKey", parsed).output).toBe("接口Key");
+    expect(
+      applyTermReplace("APIKey", parsed.terms, (t, m) => t.value || m).output
+    ).toBe("APIKey");
+  });
+
+  test("uses originalOrder metadata over sorted array order", () => {
+    // 输入顺序：长词在前 → 无前缀切割
+    const parsed = parseTerms("APIKey,应用编程接口;API,接口");
+    expect(parsed.originalOrder.map((t) => t.key)).toEqual(["APIKey", "API"]);
+    // 原始顺序：APIKey 先 → (APIKey)|(API) → APIKey 整体命中
+    expect(applyNaiveReplace("APIKey", parsed).output).toBe("应用编程接口");
+    // 若退化为数组（已排序短在前），效果相同（排序后 APIKey 仍在 API 前）
+    expect(applyNaiveReplace("APIKey", parsed.terms).output).toBe(
+      "应用编程接口"
+    );
+  });
+
+  test("treats non-string text input as empty and returns spans shape", () => {
+    expect(applyNaiveReplace(undefined, parseTerms("API,接口"))).toEqual({
+      output: "",
+      spans: [],
+    });
+    expect(applyNaiveReplace(null, parseTerms("API,接口"))).toEqual({
+      output: "",
+      spans: [],
+    });
+    expect(applyNaiveReplace(123, parseTerms("API,接口"))).toEqual({
+      output: "",
+      spans: [],
+    });
+  });
+});
+
+describe("terms applyTermReplace with capture groups in keys (分支映射)", () => {
+  const replacer = (t, m) => t.value || m;
+
+  test("嵌套捕获组 key 不破坏分支映射（后置术语仍能命中）", () => {
+    const { terms } = parseTerms("(Foo|Bar),替换;Baz,巴兹");
+    const { output, spans } = applyTermReplace("Baz and Foo", terms, replacer);
+    expect(output).toBe("巴兹 and 替换");
+    expect(spans.map((s) => s.termKey)).toEqual(["Baz", "(Foo|Bar)"]);
+    expect(spans[0].start).toBe(0);
+    expect(spans[0].end).toBe(3);
+    expect(spans[1].start).toBe(8);
+    expect(spans[1].end).toBe(11);
+  });
+
+  test("命名捕获组 key 不破坏分支映射与 span 偏移量", () => {
+    const { terms } = parseTerms("(?<code>API)\\d+,带编号接口;API,接口");
+    const { output, spans } = applyTermReplace(
+      "API42 and API",
+      terms,
+      replacer
+    );
+    expect(output).toBe("带编号接口 and 接口");
+    expect(spans.map((s) => s.termKey)).toEqual(["(?<code>API)\\d+", "API"]);
+    expect(spans[0].start).toBe(0);
+    expect(spans[0].end).toBe(5);
+    expect(spans[1].start).toBe(10);
+    expect(spans[1].end).toBe(13);
+  });
+
+  test("applyNaiveReplace 对命名捕获组 key 同样不崩溃且返回 spans", () => {
+    const parsed = parseTerms("(?<code>API)\\d+,带编号接口;API,接口");
+    const naive = applyNaiveReplace("API42 and API", parsed);
+    expect(naive.output).toBe("带编号接口 and 接口");
+    expect(naive.spans).toHaveLength(2);
+    expect(naive.spans[1].termKey).toBe("API");
+    expect(naive.spans[1].start).toBe(10);
+  });
+});
+
+// ─── Task 14：点号字面量与正则语义 ──────────────────────────────────────────
+// 术语 key 默认按正则源码处理（与既有规则语义一致，不改为字面量以免破坏已有正则规则）。
+// 点号术语（如 Dr.whob）与其他 key 一样一律按 (key) 语义匹配（无单词边界）；
+// 未转义的点号按正则通配符工作，界面需给出转义警告。
+describe("terms 点号字面量与正则语义（Task 14）", () => {
+  test("Dr.whob 按正则语义解析（isWord 仅诊断元数据）", () => {
+    const parsed = parseTerms("Dr.whob,神经病");
+    const entry = parsed.terms[0];
+    expect(entry.isWord).toBe(false);
+    expect(entry.pattern).toBe("(Dr.whob)");
+    expect(entry.pattern).not.toMatch(/^\\b/);
+    // 点号未转义 → 产生元字符警告（非致命）
+    expect(parsed.hasErrors).toBe(false);
+    expect(parsed.metaWarnings).toHaveLength(1);
+    expect(parsed.metaWarnings[0].key).toBe("Dr.whob");
+    expect(parsed.metaWarnings[0].metas).toContain(".");
+  });
+
+  test("Dr\\.whob 字面点号不产生元字符警告", () => {
+    const parsed = parseTerms("Dr\\.whob,神经病");
+    expect(parsed.terms[0].pattern).toBe("(Dr\\.whob)");
+    expect(parsed.terms[0].isWord).toBe(false);
+    expect(parsed.metaWarnings).toEqual([]);
+  });
+
+  test("foo.bar（未转义点号）按通配符匹配 fooXbar", () => {
+    const { terms } = parseTerms("foo.bar,甲");
+    const { output, spans } = applyTermReplace(
+      "fooXbar",
+      terms,
+      (t, m) => t.value || m
+    );
+    expect(output).toBe("甲");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].termKey).toBe("foo.bar");
+  });
+
+  test("foo\\.bar（转义点号）不匹配 fooXbar", () => {
+    const { terms } = parseTerms("foo\\.bar,甲");
+    const { output } = applyTermReplace(
+      "fooXbar",
+      terms,
+      (t, m) => t.value || m
+    );
+    expect(output).toBe("fooXbar");
+    // 字面点号文本仍能精确命中
+    const literal = applyTermReplace("foo.bar", terms, (t, m) => t.value || m);
+    expect(literal.output).toBe("甲");
+  });
+
+  test("API\\.\\d+ 按正则语义工作", () => {
+    const { terms } = parseTerms("API\\.\\d+,接口版本");
+    const { output } = applyTermReplace(
+      "version API.42 ok",
+      terms,
+      (t, m) => t.value || m
+    );
+    expect(output).toBe("version 接口版本 ok");
+  });
+
+  test("含点号术语的索引与译文映射不错位（Dr.whob 在自然句中整体命中）", () => {
+    const parsed = parseTerms("Dr.whob,神经病");
+    const { output, spans } = applyTermReplace(
+      "The Dr.whob feature will ship in the next release.",
+      parsed.terms,
+      (t, m) => t.value || m
+    );
+    expect(output).toContain("神经病");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].termKey).toBe("Dr.whob");
+    expect(spans[0].value).toBe("神经病");
+    expect(spans[0].replacement).toBe("神经病");
+    expect(output).not.toContain("Dr.whob");
+  });
+
+  test("findUnescapedRegexMeta 仅收集未转义元字符", () => {
+    expect(findUnescapedRegexMeta("Dr.whob")).toEqual(["."]);
+    expect(findUnescapedRegexMeta("Dr\\.whob")).toEqual([]);
+    expect(findUnescapedRegexMeta("API\\.\\d+")).toEqual(["+"]);
+    expect(findUnescapedRegexMeta("API")).toEqual([]);
+    expect(findUnescapedRegexMeta(null)).toEqual([]);
+  });
+});
+
+// ─── P1：分支识别上下文丢失导致的正文丢失 ────────────────────────────────────
+// 术语 key 可含 lookbehind/lookahead（依赖匹配位置之前的上下文），且第一个术语的
+// 嵌套捕获组会把组合正则的捕获槽位往后推。旧实现先对孤立 fullMatch 单独执行用户正则
+// （丢上下文），再按捕获组下标兜底（槽位偏移），两者叠加返回 -1，只推进 cursor 不写回
+// 正文，最终整个文本被吞掉。修复必须：
+//   1. 分支身份不依赖"对孤立 fullMatch 重新执行用户正则"，也不依赖用户捕获组数量；
+//   2. 无法映射时保留原文区间，绝不吞正文。
+describe("terms P1 分支识别修复（lookbehind / 嵌套捕获组 / 零宽边界）", () => {
+  const replacer = (t, m) => t.value || m;
+
+  test("P1 最小复现：嵌套捕获组 + lookbehind 术语在原文上下文命中后不再吞文本", () => {
+    // 真实生产链路：parseTerms -> buildTermsRegex -> applyTermReplace
+    const parsed = parseTerms("((ABCDEFG)),long;(?<=x)y,look");
+    const regex = buildTermsRegex(parsed);
+    expect(regex).toBeInstanceOf(RegExp);
+
+    // 组合正则在原始正文 "xy" 中命中 "y"（lookbehind 上下文在前置 x）。
+    const mainMatch = regex.exec("xy");
+    expect(mainMatch[0]).toBe("y");
+    expect(mainMatch.index).toBe(1);
+    // 但独立的 (?<=x)y 在孤立的 "y" 上无法反查（丢前置 x）——旧 resolveTermIndex 返回 -1。
+    const isolated = new RegExp("(?<=x)y").exec("y");
+    expect(isolated).toBeNull();
+
+    const { output, spans } = applyTermReplace("xy", parsed, replacer, regex);
+    expect(output).toBe("xlook");
+    expect(spans).toEqual([
+      {
+        start: 1,
+        end: 2,
+        termKey: "(?<=x)y",
+        value: "look",
+        replacement: "look",
+      },
+    ]);
+  });
+
+  test("P1 兜底守卫：无法映射分支身份时必须保留区间，绝不吞正文", () => {
+    // 用与 parsed terms 不一致的手工正则（组合正则里多出一个用户分支），
+    // 该分支在 termList 中不存在——映射必然失败，必须走原文保留兜底。
+    const parsed = parseTerms("API,接口;Baz,巴兹");
+    const regex = new RegExp("(API)|(Baz)|(ghost)", "g");
+    const { output, spans } = applyTermReplace("API Baz", parsed, replacer, regex);
+    // 能映射的 API/Baz 正常替换；ghost 不会命中文本；不得丢任何字符。
+    expect(output).toBe("接口 巴兹");
+    expect(spans.map((s) => s.termKey)).toEqual(["API", "Baz"]);
+  });
+
+  test("捕获组回归矩阵：普通嵌套、命名、非捕获、lookahead/lookbehind、多个命名组共存", () => {
+    // 普通嵌套捕获组（既有回归）。
+    expect(
+      applyTermReplace("Baz and Foo", parseTerms("(Foo|Bar),替换;Baz,巴兹").terms, replacer).output
+    ).toBe("巴兹 and 替换");
+
+    // 命名捕获组（既有回归）。
+    expect(
+      applyTermReplace(
+        "API42 and API",
+        parseTerms("(?<code>API)\\d+,带编号接口;API,接口").terms,
+        replacer
+      ).output
+    ).toBe("带编号接口 and 接口");
+
+    // 非捕获组 + lookbehind 组合：非捕获组不占槽位，前后术语都不错位。
+    const noncap = parseTerms("(?:Foo)bar,组合;Api,甲;(?<=x)y,乙");
+    const noncapOut = applyTermReplace("xy and Foobar and Api", noncap, replacer);
+    expect(noncapOut.output).toBe("x乙 and 组合 and 甲");
+
+    // lookahead 术语与其后置术语：lookahead 不消费字符，槽位照常映射。
+    const lookahead = parseTerms("Foo(?=Bar),先;Baz,后");
+    const lookaheadOut = applyTermReplace("FooBar Baz", lookahead, replacer);
+    expect(lookaheadOut.output).toBe("先Bar 后");
+
+    // 多个用户命名组 + 普通组混合：所有分支都保持正确映射。
+    const multiNamed = parseTerms(
+      "(?<a>X)(?<b>Y)\\d+,xy编号;(?<c>Q)R,qr"
+    );
+    const multiNamedOut = applyTermReplace("XY42 and QR", multiNamed, replacer);
+    expect(multiNamedOut.output).toBe("xy编号 and qr");
+
+    // 消费型上下文环视：lookbehind 命中消费真实字符 y，命名组消费 n——
+    // 二者均非纯零宽模式。纯/混合零宽的防护由下方「零宽防护与 flags 继承」用例组覆盖。
+    const boundary = parseTerms("(?<=x)y,已选;(?<n>n),字母n");
+    const boundaryOut = applyTermReplace("xy n", boundary, replacer);
+    expect(boundaryOut.output).toBe("x已选 字母n");
+  });
+
+  test("P1 修复作用于 applyNaiveReplace 同一条扫描链路", () => {
+    const parsed = parseTerms("((ABCDEFG)),long;(?<=x)y,look");
+    const naive = applyNaiveReplace("xy", parsed);
+    expect(naive.output).toBe("xlook");
+    expect(naive.spans).toHaveLength(1);
+    expect(naive.spans[0].termKey).toBe("(?<=x)y");
+  });
+});
+
+// ─── 零宽防护与 flags 继承（统一计划 20260829 Task 2）────────────────────────
+// 纯零宽模式（整个 pattern 无任何可消费原子，如 (?=x)、(?<=x)、\b）在非空文本上
+// 也能零宽命中并逐位置注入译文（"xx" → "YxYx"）。防护分两层：
+//   静态层：isZeroWidthOnlyPattern 在 parseTerms 中判定，产出致命诊断
+//           zero-width-matching-pattern（置于既有 empty-matching 门闸之后，
+//           a*/x?/^ 等空匹配模式仍归 empty-matching，不重复归类）；
+//   运行时层：混合臂（如 a|(?=x)）合法保留，scanWithTerms 对零宽命中跳过
+//           replacer 与 span，仅手动前进，杜绝 start===end 的 span。
+// flags 继承（F6）：phaseRegex 必须继承外部组合正则的全部 flags（i/m/s），
+//   否则大小写不敏感等场景下分支反查失败，术语被兜底路径静默放弃。
+describe("terms 零宽防护与 flags 继承（统一计划 20260829 Task 2）", () => {
+  const replacer = (t, m) => t.value || m;
+
+  test("混合臂运行时零宽守卫：a|(?=x) 消费臂照常替换，零宽臂不产 span 不调 replacer", () => {
+    const parsed = parseTerms("a|(?=x),Y");
+    let replacerCalls = 0;
+    const countingReplacer = (t, m) => {
+      replacerCalls += 1;
+      return t.value || m;
+    };
+    const out = applyTermReplace("ax", parsed.terms, countingReplacer);
+    expect(out.output).toBe("Yx");
+    expect(out.spans).toHaveLength(1);
+    expect(out.spans[0]).toMatchObject({
+      start: 0,
+      end: 1,
+      termKey: "a|(?=x)",
+    });
+    expect(replacerCalls).toBe(1);
+  });
+
+  test("混合臂 (?=x)|b：零宽臂跳过后消费臂仍命中", () => {
+    const out = applyTermReplace("xb", parseTerms("(?=x)|b,Y").terms, replacer);
+    expect(out.output).toBe("xY");
+    expect(out.spans).toHaveLength(1);
+    expect(out.spans[0].start).toBe(1);
+  });
+
+  test("零宽守卫作用于 applyNaiveReplace 同一条扫描链路", () => {
+    // 纯零宽术语在静态层即被排除，naive 无术语可用，输出原样。
+    const pure = parseTerms("(?=x),Y");
+    expect(pure.terms).toHaveLength(0);
+    const pureOut = applyNaiveReplace("xx", pure);
+    expect(pureOut.output).toBe("xx");
+    expect(pureOut.spans).toHaveLength(0);
+
+    // 混合臂：naive 下零宽臂同样不产 span。
+    const mixed = parseTerms("a|(?=x),Y");
+    const mixedOut = applyNaiveReplace("ax", mixed);
+    expect(mixedOut.output).toBe("Yx");
+    expect(mixedOut.spans).toHaveLength(1);
+  });
+
+  test("静态矩阵：纯零宽模式 fatal 且不进 terms，合法术语仍保留", () => {
+    for (const key of ["(?=x)", "(?<=x)", "\\b"]) {
+      const parsed = parseTerms(`${key},Y;API,接口`);
+      expect(parsed.hasErrors).toBe(true);
+      const d = parsed.diagnostics.find(
+        (diag) => diag.type === "zero-width-matching-pattern"
+      );
+      expect(d).toBeDefined();
+      expect(d.key).toBe(key);
+      expect(parsed.terms.map((t) => t.key)).toEqual(["API"]);
+    }
+  });
+
+  test("负向环视与 \\B 在空串上匹配空串，先被既有 empty-matching 门闸拦截", () => {
+    // 计划预测修订（Task 1 取证实测）：(?<!y)/(?!x)/\B 的 test("") 为 true，
+    // 先被既有 empty-matching 门闸拒绝（类型为 empty-matching-pattern 而非新
+    // 类型），零宽防护目标一致。
+    for (const key of ["(?<!y)", "(?!x)", "\\B"]) {
+      const parsed = parseTerms(`${key},Y`);
+      expect(parsed.hasErrors).toBe(true);
+      expect(parsed.terms).toHaveLength(0);
+    }
+  });
+
+  test("静态矩阵不误报：消费型 lookaround 与混合臂合法保留", () => {
+    for (const key of ["(?<=x)y", "a(?=x)", "x\\b", "a|(?=x)"]) {
+      const parsed = parseTerms(`${key},Y`);
+      expect(parsed.hasErrors).toBe(false);
+      expect(parsed.terms).toHaveLength(1);
+      expect(parsed.terms[0].key).toBe(key);
+    }
+  });
+
+  test("静态矩阵不误报：字符类为可消费原子，纯类术语不得判零宽（P1 回归锁定）", () => {
+    // isZeroWidthOnlyPattern 的 [ 分支越过 ] 后必须判定可消费；
+    // [A-Z][a-z]+ / [0-9]+ / [^abc] 是术语库常规写法，误判 fatal 会被生产路径静默丢弃。
+    for (const key of [
+      "[A-Z][a-z]+",
+      "[0-9]+",
+      "[^abc]",
+      "[a-z]",
+      "[abc]+",
+      "\\b[0-9]+\\b",
+      "(?<=[a-z])x",
+    ]) {
+      const parsed = parseTerms(`${key},Y`);
+      expect(parsed.hasErrors).toBe(false);
+      expect(parsed.terms).toHaveLength(1);
+      expect(parsed.terms[0].key).toBe(key);
+    }
+  });
+
+  test("字符类术语真实应用闭环：[A-Z][a-z]+ 命中专名并完成替换（防平凡通过）", () => {
+    const parsed = parseTerms("[A-Z][a-z]+,人名");
+    expect(parsed.terms).toHaveLength(1);
+    const out = applyTermReplace("John met Mary", parsed.terms, replacer);
+    expect(out.output).toBe("人名 met 人名");
+    expect(out.spans).toHaveLength(2);
+    expect(out.spans[0]).toMatchObject({ start: 0, end: 4, termKey: "[A-Z][a-z]+" });
+  });
+
+  test("静态矩阵不重复归类：a*/x?/^ 仍由 empty-matching 门闸负责", () => {
+    for (const key of ["a*", "x?", "^"]) {
+      const parsed = parseTerms(`${key},Y`);
+      expect(parsed.hasErrors).toBe(true);
+      expect(
+        parsed.diagnostics.some((d) => d.type === "empty-matching-pattern")
+      ).toBe(true);
+      expect(
+        parsed.diagnostics.some(
+          (d) => d.type === "zero-width-matching-pattern"
+        )
+      ).toBe(false);
+    }
+  });
+
+  test("flags 继承（F6）：外部 /gi 组合正则下 phaseRegex 不丢 i，术语照常替换", () => {
+    const parsed = parseTerms("abc,译");
+    // 外部组合正则必须与 buildTermsRegex 同 source（分支基座包裹由 pattern 提供，
+    // 槽位反查契约），此处仅附加 i 标志模拟调用方扩展 flags 的场景。
+    const external = new RegExp(buildTermsRegex(parsed).source, "gi");
+    const out = applyTermReplace("xABCx", parsed.terms, replacer, external);
+    expect(out.output).toBe("x译x");
+    expect(out.spans).toHaveLength(1);
+    expect(out.spans[0]).toMatchObject({
+      start: 1,
+      end: 4,
+      termKey: "abc",
+      value: "译",
+    });
+  });
+});
+
+// ─── matcher 缓存与 naive 缓存（统一计划 20260829 Task 3）────────────────────
+// 生产 Translator 对每个文本节点调用一次 applyTermReplace；逐节点重建分支槽位表
+// （每术语 1 次 new RegExp 探针）与 phaseRegex 是页面级卡顿根因。matcher 把
+// 组合正则、phaseRegex、槽位表一次物化，热路径零编译。naive 引擎同链路，
+// 按 originalOrder 引用做 WeakMap 记忆化。
+// 计数手段：临时把 global.RegExp 替换为计数子类（finally 还原），断言增量编译数。
+describe("terms matcher 缓存与 naive 缓存（统一计划 20260829 Task 3）", () => {
+  const replacer = (t, m) => t.value || m;
+
+  /** 临时替换 global.RegExp 为计数子类；返回还原函数，调用后取回计数。 */
+  function installCountingRegExp() {
+    const RealRegExp = RegExp;
+    let count = 0;
+    class CountingRegExp extends RealRegExp {
+      constructor(...args) {
+        super(...args);
+        count += 1;
+      }
+    }
+    global.RegExp = CountingRegExp;
+    return () => {
+      global.RegExp = RealRegExp;
+      return count;
+    };
+  }
+
+  test("matcher 快路径：物化后连续两次 applyTermReplace 增量编译均为 0", () => {
+    const parsed = parseTerms(
+      "API,接口;APIKey,应用编程接口;GPTs,智能体集合"
+    );
+    const matcher = buildTermsMatcher(parsed);
+    expect(matcher).not.toBeNull();
+    const text = "The APIKey and GPTs and API here";
+
+    const restore1 = installCountingRegExp();
+    try {
+      applyTermReplace(text, parsed.terms, replacer, matcher);
+    } finally {
+      expect(restore1()).toBe(0);
+    }
+    const restore2 = installCountingRegExp();
+    try {
+      const out = applyTermReplace(text, parsed.terms, replacer, matcher);
+      expect(out.output).toBe("The 应用编程接口 and 智能体集合 and 接口 here");
+    } finally {
+      expect(restore2()).toBe(0);
+    }
+  });
+
+  test("matcher 物化形状：regex/phaseRegex/槽位表/flags 齐备且与 buildTermsRegex 同 source", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const matcher = buildTermsMatcher(parsed);
+    expect(matcher.regex).toBeInstanceOf(RegExp);
+    expect(matcher.regex.global).toBe(true);
+    expect(matcher.regex.source).toBe(buildTermsRegex(parsed).source);
+    expect(matcher.phaseRegex).toBeInstanceOf(RegExp);
+    expect(matcher.phaseRegex.flags).toBe(matcher.regex.flags);
+    expect(matcher.termList).toBe(parsed.terms);
+    expect(matcher.mappingAligned).toBe(true);
+    expect(matcher.branchBaseGroups).toEqual([1, 2]);
+    expect(matcher.branchTermIndex).toEqual([0, 1]);
+  });
+
+  test("空术语与全非法输入下 buildTermsMatcher 返回 null", () => {
+    expect(buildTermsMatcher(parseTerms(""))).toBeNull();
+    expect(buildTermsMatcher(parseTerms("a*,x"))).toBeNull();
+    expect(buildTermsMatcher([])).toBeNull();
+    expect(buildTermsMatcher(null)).toBeNull();
+  });
+
+  test("A/B matcher 交错扫描与单用结果一致（lastIndex 与 phase 状态互不污染）", () => {
+    const parsedA = parseTerms("API,接口;APIKey,应用编程接口");
+    const parsedB = parseTerms("GPT;GPTs,智能体集合");
+    const matcherA = buildTermsMatcher(parsedA);
+    const matcherB = buildTermsMatcher(parsedB);
+    const textA = "Use APIKey and API today";
+    const textB = "GPTs and GPT differ";
+    const textB2 = "GPTs and GPT differ";
+
+    const soloA = applyTermReplace(textA, parsedA.terms, replacer, matcherA).output;
+    const soloB = applyTermReplace(textB, parsedB.terms, replacer, matcherB).output;
+    const soloB2 = applyNaiveReplace(textB2, parsedB).output;
+
+    // 交错：A → B → A → naive(B)，各自结果必须与单用完全一致
+    const i1 = applyTermReplace(textA, parsedA.terms, replacer, matcherA).output;
+    const i2 = applyTermReplace(textB, parsedB.terms, replacer, matcherB).output;
+    const i3 = applyTermReplace(textA, parsedA.terms, replacer, matcherA).output;
+    const i4 = applyNaiveReplace(textB2, parsedB).output;
+    expect(i1).toBe(soloA);
+    expect(i2).toBe(soloB);
+    expect(i3).toBe(soloA);
+    expect(i4).toBe(soloB2);
+  });
+
+  test("matcher 与传入 terms 不一致时丢弃 matcher 重建，输出仍正确", () => {
+    const parsedA = parseTerms("API,接口");
+    const parsedB = parseTerms("GPTs,智能体集合");
+    const matcherA = buildTermsMatcher(parsedA);
+    // 用 A 的 matcher 配 B 的 terms：身份校验不通过，必须丢弃 matcher 按 B 重建，
+    // 保证任意契约破坏下输出仍正确（自愈）。
+    const out = applyTermReplace("Talk to GPTs", parsedB.terms, replacer, matcherA);
+    expect(out.output).toBe("Talk to 智能体集合");
+    expect(out.spans).toHaveLength(1);
+  });
+
+  test("naive 缓存：同 parsed 第二次 applyNaiveReplace 增量编译 0", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    const text = "APIKey and API";
+    applyNaiveReplace(text, parsed); // 预热并写入 WeakMap 缓存
+
+    const restore = installCountingRegExp();
+    let delta;
+    try {
+      const out = applyNaiveReplace(text, parsed);
+      // naive 引擎按 originalOrder（API 在前）复现旧引擎前缀切割：接口Key
+      expect(out.output).toBe("接口Key and 接口");
+    } finally {
+      delta = restore();
+    }
+    expect(delta).toBe(0);
+  });
+
+  test("2000 字面量术语 × 单文本：matcher 路径零编译，慢路径不异常", () => {
+    const keys = [];
+    for (let i = 0; i < 2000; i++) keys.push(`TermNo${i}x,词${i}`);
+    const parsed = parseTerms(keys.join(";"));
+    const matcher = buildTermsMatcher(parsed);
+    const text = "plain text without any term here";
+
+    const restore = installCountingRegExp();
+    let delta;
+    try {
+      const out = applyTermReplace(text, parsed.terms, replacer, matcher);
+      expect(out.output).toBe(text);
+      expect(out.spans).toHaveLength(0);
+    } finally {
+      delta = restore();
+    }
+    expect(delta).toBe(0);
+  });
+
+  test("多术语 × 多文本节点无命中：matcher 快路径零编译、输出恒等（审查者第二轮显式回归锁定）", () => {
+    const keys = [];
+    for (let i = 0; i < 100; i++) keys.push(`TermNo${i}x,词${i}`);
+    const parsed = parseTerms(keys.join(";"));
+    const matcher = buildTermsMatcher(parsed);
+    expect(matcher).not.toBeNull();
+
+    const restore = installCountingRegExp();
+    let delta;
+    try {
+      for (let j = 0; j < 50; j++) {
+        const text = `plain text node ${j} without any matching term`;
+        const out = applyTermReplace(text, parsed.terms, replacer, matcher);
+        expect(out.output).toBe(text);
+        expect(out.spans).toHaveLength(0);
+      }
+    } finally {
+      delta = restore();
+    }
+    expect(delta).toBe(0);
+  });
+});
+
+// ─── Task 2：fast/full 解析契约与生产热路径性能解耦 ──────────────────────────
+// parseTerms 默认（full）保留跨术语 conflicting-pattern 两两分析，用于 Playground / CLI
+// 诊断；生产 Translator 用 fast 模式省略该 O(n²) 分析。两种模式必须共享同一套基础解析
+// 结果，仅 full 额外产生 conflicting-pattern 及派生诊断状态。
+describe("terms fast/full 解析契约（Task 2）", () => {
+  test("fast 模式产出 diagnosticsMode=fast，且不含 conflicting-pattern 完整分析", () => {
+    const input = "Dr\\.who;Dr.who,神经病患者";
+    const full = parseTerms(input); // 默认 full
+    expect(full.diagnosticsMode).toBe("full");
+    expect(full.hasErrors).toBe(true);
+    expect(
+      full.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(true);
+
+    const fast = parseTerms(input, { fullDiagnostics: false });
+    expect(fast.diagnosticsMode).toBe("fast");
+    // fast 跳过跨术语重叠分析：同一输入不产生 conflicting-pattern（不等于通过完整校验）。
+    expect(
+      fast.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(false);
+  });
+
+  test("同一输入 fast/full 除 conflicting-pattern 外基础契约完全一致", () => {
+    const inputs = [
+      "API,接口;APIKey,应用编程接口",
+      "Dr\\.who;Dr.who,神经病患者;API,接口",
+      "a*,x;([,坏规则;Dr.who,;API,接口;API,接口;手机,phone",
+      "",
+    ];
+    for (const input of inputs) {
+      const fast = parseTerms(input, { fullDiagnostics: false });
+      const full = parseTerms(input, { fullDiagnostics: true });
+      // 基础解析结果必须一致：terms（排序）、invalid、originalOrder、metaWarnings。
+      expect(fast.terms).toEqual(full.terms);
+      expect(fast.invalid).toEqual(full.invalid);
+      expect(fast.originalOrder).toEqual(full.originalOrder);
+      expect(fast.metaWarnings).toEqual(full.metaWarnings);
+      // 基础诊断一致；full 可能比 fast 多出 conflicting-pattern（及其派生的 hasErrors=true）。
+      const fastBase = fast.diagnostics.filter(
+        (d) => d.type !== "conflicting-pattern"
+      );
+      const fullBase = full.diagnostics.filter(
+        (d) => d.type !== "conflicting-pattern"
+      );
+      expect(fullBase).toEqual(fastBase);
+      for (const d of fast.diagnostics) {
+        expect(d.type).not.toBe("conflicting-pattern");
+      }
+      // conflicting-pattern 在 full 模式继续是致命诊断；fast 省略它不代表少报故障。
+      if (fast.hasErrors) expect(full.hasErrors).toBe(true);
+      if (full.hasErrors && !fast.hasErrors) {
+        expect(
+          full.diagnostics.some((d) => d.type === "conflicting-pattern")
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("fast 模式不调用 O(n²) 跨术语冲突分析（结构证据 + 宽松耗时对比）", () => {
+    const N = 300;
+    const keys = [];
+    for (let i = 0; i < N; i++) keys.push(`A\\d\\dK${i}`);
+    // 锚点字面量与 A\ d\dK0 类正则互相完整命中 → full 模式必然产生大量 conflicting-pattern。
+    const input = [...keys, "A09K0,锚点"].join(";");
+
+    const fastStart = Date.now();
+    const fast = parseTerms(input, { fullDiagnostics: false });
+    const fastElapsed = Date.now() - fastStart;
+
+    const fullStart = Date.now();
+    const full = parseTerms(input, { fullDiagnostics: true });
+    const fullElapsed = Date.now() - fullStart;
+
+    // 结构断言是主证据：fast 结果中不存在任何 overlapping 诊断，full 存在。
+    expect(
+      fast.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(false);
+    expect(
+      full.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(true);
+    // 术语列表一致，证明 fast 只是跳过诊断分析、不是丢了合法条目。
+    expect(fast.terms).toEqual(full.terms);
+    // 宽松耗时对比，不锁窄毫秒阈值（CI 抖动免疫）。
+    expect(fastElapsed).toBeLessThan(Math.max(100, fullElapsed));
+  });
+});
+
+// ─── Task 10：严格非法输入诊断 ──────────────────────────────────────────────
+// 解析结果区分：有效映射 / 有效保留规则 / 空源术语 / 空译文(多余逗号) /
+// 重复映射 / 冲突映射（同源不同译文）/ 冲突映射（正则重叠）。
+// 只要存在致命非法段，hasErrors=true，消费方不得生成"替换测试成功"摘要。
+describe("terms 严格非法输入诊断（Task 10）", () => {
+  test("固定输入 1：Dr.who, 尾巴逗号按保留原文处理（非致命提醒）", () => {
+    const parsed = parseTerms("Dr.who,");
+    expect(parsed.hasErrors).toBe(false);
+    const extra = parsed.diagnostics.find((d) => d.type === "extra-comma");
+    expect(extra).toBeDefined();
+    // 对提醒给出段号与原始内容
+    expect(extra.segmentIndex).toBe(1);
+    expect(extra.segment).toBe("Dr.who,");
+    // UI 不再直出 message（i18n 归属 UI）；格式化函数为 CLI/测试提供可读文本
+    expect(extra.message).toBeUndefined();
+    const formatted = formatDiagnosticMessage(extra);
+    expect(formatted).toContain("第 1 段");
+    expect(formatted).toContain("Dr.who,");
+    // 产生一个保留原文的可执行术语（value 为空）
+    expect(parsed.terms).toHaveLength(1);
+    expect(parsed.terms[0].key).toBe("Dr.who");
+    expect(parsed.terms[0].value).toBe("");
+  });
+
+  test("尾巴逗号 API, 应用为保留原文 + <i> 高亮，hasErrors=false", () => {
+    const parsed = parseTerms("API,");
+    expect(parsed.hasErrors).toBe(false);
+    const term = parsed.terms.find((t) => t.key === "API");
+    expect(term).toBeDefined();
+    expect(term.value).toBe("");
+    // 运行时按上游 value || fullMatch 保留原文并包裹 <i> 高亮
+    const { output } = applyTermReplace(
+      "call the API now",
+      parsed,
+      (termEntry, fullMatch) => `<i>${termEntry.value || fullMatch}</i>`
+    );
+    expect(output).toContain("<i>API</i>");
+  });
+
+  test("固定输入 2：Dr\\.who;Dr.who,神经病患者 被拒绝（正则重叠冲突映射）", () => {
+    const parsed = parseTerms("Dr\\.who;Dr.who,神经病患者");
+    expect(parsed.hasErrors).toBe(true);
+    const conflict = parsed.diagnostics.find(
+      (d) => d.type === "conflicting-pattern"
+    );
+    expect(conflict).toBeDefined();
+    // 诊断同时指出两个 key 与同一原文（detail 结构化字段；可读文本由格式化函数产生）
+    expect(conflict.message).toBeUndefined();
+    expect(formatDiagnosticMessage(conflict)).toContain("Dr\\.who");
+    expect(formatDiagnosticMessage(conflict)).toContain("Dr.who");
+    expect(conflict.detail.literal).toBe("Dr.who");
+  });
+
+  test("固定输入 3：Dr.who;,abc;入门, （空源术语致命 + 尾巴逗号保留）", () => {
+    // 分割后各段：Dr.who（合法保留规则）、,abc（逗号前无源术语，致命）、入门,（尾巴逗号，保留原文）
+    const parsed = parseTerms("Dr.who;,abc;入门,");
+    expect(parsed.hasErrors).toBe(true);
+    const extras = parsed.diagnostics.filter((d) => d.type === "extra-comma");
+    expect(extras).toHaveLength(1);
+    expect(extras[0].segment).toBe("入门,");
+    expect(parsed.diagnostics.some((d) => d.type === "empty-source-term")).toBe(
+      true
+    );
+    // 合法 keep rule（Dr.who）与尾巴逗号保留规则（入门）都被解析出来；空源（abc）被跳过
+    expect(parsed.terms.some((t) => t.key === "Dr.who")).toBe(true);
+    expect(parsed.terms.some((t) => t.key === "入门")).toBe(true);
+    expect(parsed.terms.some((t) => t.key === "abc")).toBe(false);
+  });
+
+  test("空源术语（逗号前无 key）是致命错误", () => {
+    const parsed = parseTerms(",接口;API,接口");
+    expect(parsed.hasErrors).toBe(true);
+    expect(parsed.diagnostics.some((d) => d.type === "empty-source-term")).toBe(
+      true
+    );
+  });
+
+  test("非法正则是致命错误且仍收集进 invalid（向后兼容）", () => {
+    const parsed = parseTerms("API,接口;bad[re");
+    expect(parsed.hasErrors).toBe(true);
+    expect(parsed.invalid).toHaveLength(1);
+    expect(parsed.invalid[0].key).toBe("bad[re");
+    expect(parsed.diagnostics.some((d) => d.type === "invalid-regex")).toBe(
+      true
+    );
+    // 合法术语仍被解析并保留在 terms 中，供消费方继续应用
+    expect(parsed.terms.map((t) => t.key)).toEqual(["API"]);
+  });
+
+  test("重复术语/重复映射/同源不同译文产生三种不同诊断", () => {
+    const dupKey = parseTerms("API;API");
+    expect(dupKey.diagnostics.some((d) => d.type === "duplicate-mapping")).toBe(
+      true
+    );
+    expect(dupKey.hasErrors).toBe(false);
+
+    const dupMap = parseTerms("API,接口;API,接口");
+    expect(dupMap.diagnostics.some((d) => d.type === "duplicate-mapping")).toBe(
+      true
+    );
+    expect(dupMap.hasErrors).toBe(false);
+
+    const conflictMap = parseTerms("API,接口;API,应用编程接口");
+    expect(
+      conflictMap.diagnostics.some((d) => d.type === "conflicting-mapping")
+    ).toBe(true);
+    expect(conflictMap.hasErrors).toBe(true);
+  });
+
+  test("合法长短词冲突（API/APIKey）不产生冲突映射诊断", () => {
+    const parsed = parseTerms("API,接口;APIKey,应用编程接口");
+    expect(parsed.hasErrors).toBe(false);
+    expect(
+      parsed.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(false);
+    expect(
+      parsed.diagnostics.some((d) => d.type === "conflicting-mapping")
+    ).toBe(false);
+  });
+
+  test("空匹配正则（a*、()）是致命诊断且被跳过，合法术语仍生效", () => {
+    const parsed = parseTerms("a*,x;API,接口");
+    expect(parsed.hasErrors).toBe(true);
+    expect(
+      parsed.diagnostics.some((d) => d.type === "empty-matching-pattern")
+    ).toBe(true);
+    // 空匹配段被跳过，合法术语仍保留
+    expect(parsed.terms.map((t) => t.key)).toEqual(["API"]);
+    // 空匹配正则不再注入译文破坏文本
+    expect(
+      applyTermReplace("hello", parsed.terms, (t, m) => t.value || m).output
+    ).toBe("hello");
+  });
+
+  test("空匹配正则 () 与 x? 同样被拒绝", () => {
+    for (const key of ["()", "x?", "a*"]) {
+      const parsed = parseTerms(`${key},v`);
+      expect(parsed.hasErrors).toBe(true);
+      const d = parsed.diagnostics.find(
+        (diag) => diag.type === "empty-matching-pattern"
+      );
+      expect(d).toBeDefined();
+      expect(d.key).toBe(key);
+      expect(parsed.terms).toHaveLength(0);
+    }
+  });
+
+  test("每条诊断携带结构化 type/segmentIndex/segment/detail；格式化函数产物为单行", () => {
+    const parsed = parseTerms("Dr.who,;Dr\\.who;Dr.who,神经病患者");
+    expect(parsed.diagnostics.length).toBeGreaterThan(0);
+    for (const d of parsed.diagnostics) {
+      expect(typeof d.type).toBe("string");
+      expect(typeof d.segmentIndex).toBe("number");
+      expect(typeof d.segment).toBe("string");
+      // 用户可见文案归属 UI（i18n）/ CLI（格式化函数），核心不输出硬编码中文 message
+      expect(d.message).toBeUndefined();
+      expect(d).toHaveProperty("detail");
+      // CLI 格式化函数产物保持单行上限，与旧 message 契约一致
+      const formatted = formatDiagnosticMessage(d);
+      expect(typeof formatted).toBe("string");
+      expect(formatted).not.toContain("\n");
+      expect(formatted.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  // ─── v4：hasErrors 不等于 terms 为空，合法条目逐条保留 ─────────────────────
+  test("hasErrors === true 时合法条目仍保留在 terms 中（不因单条坏数据清空整份）", () => {
+    const parsed = parseTerms("API,接口;([,坏规则");
+    expect(parsed.hasErrors).toBe(true);
+    expect(parsed.invalid.map((i) => i.key)).toEqual(["(["]);
+    expect(parsed.diagnostics.some((d) => d.type === "invalid-regex")).toBe(
+      true
+    );
+    // 合法条目未被非法段牵连：仍可应用
+    expect(parsed.terms.map((t) => t.key)).toEqual(["API"]);
+    expect(parsed.terms[0].value).toBe("接口");
+  });
+
+  test("合法条目与空 source、多余逗号、重复/冲突条目共存时仍逐条保留", () => {
+    // 段 1 合法映射；段 2 空源；段 3 多余逗号（保留原文）；段 4 重复映射；段 5 合法；段 6 冲突映射
+    const parsed = parseTerms("API,接口;,empty;Key,;API,接口;X,接口;X,另一个");
+    expect(parsed.hasErrors).toBe(true);
+    const types = new Set(parsed.diagnostics.map((d) => d.type));
+    expect(types.has("empty-source-term")).toBe(true);
+    expect(types.has("extra-comma")).toBe(true);
+    expect(types.has("duplicate-mapping")).toBe(true);
+    expect(types.has("conflicting-mapping")).toBe(true);
+    // 合法条目（API、X 的首个映射）与尾巴逗号保留条目（Key）仍在 terms 中
+    expect(parsed.terms.some((t) => t.key === "API")).toBe(true);
+    expect(parsed.terms.some((t) => t.key === "X" && t.value === "接口")).toBe(
+      true
+    );
+    expect(parsed.terms.some((t) => t.key === "Key" && t.value === "")).toBe(
+      true
+    );
+    // 空源段被跳过，未进入 terms
+    expect(parsed.terms.some((t) => t.key === "empty")).toBe(false);
+  });
+
+  test("diagnostics 精确指向被拒绝条目，合法条目不产生任何诊断", () => {
+    const parsed = parseTerms("API,接口;bad[re");
+    // 唯一诊断指向非法段 bad[re
+    expect(parsed.diagnostics).toHaveLength(1);
+    expect(parsed.diagnostics[0].type).toBe("invalid-regex");
+    expect(parsed.diagnostics[0].key).toBe("bad[re");
+    // 合法条目 API 未被标记为失败
+    expect(parsed.invalid.some((i) => i.key === "API")).toBe(false);
+    const apiDiag = parsed.diagnostics.filter((d) => d.key === "API");
+    expect(apiDiag).toHaveLength(0);
+  });
+});
+
+// ─── 术语冲突分析引擎加固（统一计划 20260829 Task 4）─────────────────────────
+// analyzeCrossTermPatternConflicts 是 O(n²) 两两交叉分析：原实现对每个有序对
+// 编译 2 次正则（fullRegexMatches），40 条术语即 3120 次编译。加固手段：
+//   ① isStrictLiteralPattern 白名单短路：双方均为严格字面量（未转义元字符为空，
+//     且每个转义序列的被转义字符 ∈ REGEX_META_CHARS）时，字面量正则只可能完整
+//     命中自身去转义文本，双 key 不同则必然无冲突——零编译跳过；
+//   ② 按 key 预编译：非白名单对的正则每个 key 只编译一次。
+// 白名单文法反例锁定：\d 的被转义字符 d 不是元字符，不得判为字面量，
+// 否则 \d × 5 的 conflicting-pattern 检出会被漏掉（B3）。
+describe("terms 冲突分析引擎加固（统一计划 20260829 Task 4）", () => {
+  function installCountingRegExp() {
+    const RealRegExp = RegExp;
+    let count = 0;
+    class CountingRegExp extends RealRegExp {
+      constructor(...args) {
+        super(...args);
+        count += 1;
+      }
+    }
+    global.RegExp = CountingRegExp;
+    return () => {
+      global.RegExp = RealRegExp;
+      return count;
+    };
+  }
+
+  test("isStrictLiteralPattern 白名单文法：\\d 不得判为字面量，转义元字符序列可以", () => {
+    // 纯字面量
+    expect(isStrictLiteralPattern("API")).toBe(true);
+    expect(isStrictLiteralPattern("TermNo0x")).toBe(true);
+    // 转义元字符序列（被转义字符 ∈ REGEX_META_CHARS）
+    expect(isStrictLiteralPattern("Dr\\.whob")).toBe(true);
+    expect(isStrictLiteralPattern("a\\.b\\+c")).toBe(true);
+    expect(isStrictLiteralPattern("\\$\\^")).toBe(true);
+    // 反例：被转义字符不是元字符（\d \w \s 等）→ 不算字面量
+    expect(isStrictLiteralPattern("\\d")).toBe(false);
+    expect(isStrictLiteralPattern("\\w")).toBe(false);
+    // 反例：存在未转义元字符
+    expect(isStrictLiteralPattern("a.b")).toBe(false);
+    expect(isStrictLiteralPattern("(unclosed")).toBe(false);
+    expect(isStrictLiteralPattern("")).toBe(false);
+  });
+
+  test("40 条互不为子串的严格字面量术语：跨术语冲突分析零编译（full − fast 差值）", () => {
+    const keys = [];
+    for (let i = 0; i < 40; i++) keys.push(`TermNo${i}x,词${i}`);
+    const input = keys.join(";");
+    // fast 模式跳过冲突分析：其编译数 = 逐段 keyRegex 校验的基线
+    const restoreFast = installCountingRegExp();
+    let fastDelta;
+    try {
+      parseTerms(input, { fullDiagnostics: false });
+    } finally {
+      fastDelta = restoreFast();
+    }
+    const restoreFull = installCountingRegExp();
+    let fullDelta;
+    try {
+      parseTerms(input);
+    } finally {
+      fullDelta = restoreFull();
+    }
+    // full 与 fast 的编译差值应恰为 0（冲突分析贡献零编译）；加固前为 3120。
+    expect(fullDelta - fastDelta).toBe(0);
+  });
+
+  test("B3 锁定：\\d × 5 与 \\w × A 的 conflicting-pattern 必须检出", () => {
+    for (const input of ["\\d,数字;5,five", "\\w,词;A,甲"]) {
+      const parsed = parseTerms(input);
+      expect(parsed.hasErrors).toBe(true);
+      const d = parsed.diagnostics.find(
+        (diag) => diag.type === "conflicting-pattern"
+      );
+      expect(d).toBeDefined();
+      expect(parsed.terms).toHaveLength(2);
+    }
+  });
+
+  test("字面量子串对走 literalOverlap 路径：parseTerms 不报 conflicting-pattern，detectTermConflicts 检出", () => {
+    const parsed = parseTerms("abc,甲;abcde,乙");
+    expect(
+      parsed.diagnostics.some((d) => d.type === "conflicting-pattern")
+    ).toBe(false);
+    expect(parsed.terms).toHaveLength(2);
+    const conflicts = detectTermConflicts(parsed);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].short.key).toBe("abc");
+    expect(conflicts[0].long.key).toBe("abcde");
+  });
+});
+
+// ─── 字符级不变量对抗矩阵（统一计划 20260829 Task 1 语料裁剪落库，Task 6）────
+// 「无新问题」的字符级不变量：每个字符要么原样保留，要么在真实命中的 span 内被
+// 显式替换（output 可由 text + spans 精确重建）。四道防线对应四不变量：
+//   ① spans 重建 === output；
+//   ② span start<end 有序不重叠（零宽 span 是注入事故的直接证据）；
+//   ③ 同输入两次调用全等（lastIndex 卫生 / 幂等）；
+//   ④ 非法正则语料不抛异常。
+// Task 1 取证阶段的对抗扫描（54 组 × 21 文本）在修复前恰好产生 80 项零宽 span
+// 违例、其余不变量全绿；此处以确定性固定语料把"修复后行为"永久落库。
+describe("terms 字符级不变量对抗矩阵（统一计划 20260829 Task 6）", () => {
+  const MATRIX_TERMS = [
+    // 常规字面量 / 正则 / 捕获组 / 消费型环视
+    "API,接口", "APIKey,应用编程接口", "UI,界面", "UIView", "GPT;GPTs,智能体集合",
+    "foo.bar,点", "Dr\\.whob,医生", "API\\d+,编号", "colou?r,颜色", "[abc]+,集合", "[A-Z][a-z]+,专名",
+    "(?:ab)+,重复", "a|b,或者", "\\w+,词", "x", "xx,双x", "Foo(?=Bar),先;Baz,后",
+    "(?<=x)y,已选", "(?<!y)x,非y前x", "x\\b,词尾x", "(?<a>X)(?<b>Y)\\d+,xy编号",
+    "(?<c>Q)R,qr", "((ABCDEFG)),long", "手机,phone",
+    // 混合零宽臂（合法保留，运行期守卫兜底）
+    "a|(?=x),Y", "zz|(?=x),Y", "(?=x)y,z",
+    // 非法正则语料（⑤不抛异常覆盖）
+    "bad[re,坏", "(unclosed,括", "*x,星", "[z,方括", "?y,问号",
+    // 空匹配 / 纯零宽（现状即被门闸 fatal 排除，不进 terms）
+    "a*,星", "(),空组", "^,尖", "(?=x),Y", "(?<=x),Y", "\\b,Y", "(?!x),Y", "\\B,Z",
+  ];
+
+  const MATRIX_TEXTS = [
+    "xx", "ab", "x", "ax", "xb", "FooBar Baz", "xy n", "APIKeys and APIs",
+    "myAPI", "The ReactNative app", "GPTs 与 GPT", "colours and color",
+    "XY42 and QR", "Dr.whob here", "API123编号", "中文与English混排",
+    "QR code for QR", "aXbXc", "  ",
+  ];
+
+  // 防平凡通过（greenwash）守卫：以下组必须物化为合法术语并在矩阵文本上至少命中一次。
+  // 字符类术语曾被 isZeroWidthOnlyPattern 误判 fatal → terms=[] → 四不变量在空数组上
+  // "平凡全绿"，正是该守卫要堵死的盲区；术语若再被静默丢弃，本断言必红。
+  const assertConsumingTerms = new Map([
+    ["[abc]+,集合", { terms: 1, minHits: 1 }],
+    ["[A-Z][a-z]+,专名", { terms: 1, minHits: 1 }],
+  ]);
+
+  const matrixReplacer = (t, m) => t.value || m;
+
+  function rebuildFromSpans(text, spans) {
+    const sorted = [...spans].sort((a, b) => a.start - b.start || a.end - b.end);
+    let out = "";
+    let cursor = 0;
+    for (const s of sorted) {
+      out += text.slice(cursor, s.start) + s.replacement;
+      cursor = s.end;
+    }
+    return out + text.slice(cursor);
+  }
+
+  for (const engine of ["fixed", "naive"]) {
+    test(`不变量矩阵：${engine} 引擎在 ${MATRIX_TERMS.length} 组 × ${MATRIX_TEXTS.length} 文本上四不变量全绿`, () => {
+      const violations = [];
+      for (const termsString of MATRIX_TERMS) {
+        const parsed = parseTerms(termsString);
+        for (const text of MATRIX_TEXTS) {
+          const run = () =>
+            engine === "fixed"
+              ? applyTermReplace(text, parsed.terms, matrixReplacer)
+              : applyNaiveReplace(text, parsed);
+          let result;
+          try {
+            result = run();
+          } catch (e) {
+            violations.push({ termsString, text, inv: "no-throw", error: String(e) });
+            continue;
+          }
+          // ① spans 重建 === output
+          const rebuilt = rebuildFromSpans(text, result.spans);
+          if (rebuilt !== result.output) {
+            violations.push({ termsString, text, inv: "rebuild", rebuilt, output: result.output });
+          }
+          // ② span start<end 有序不重叠（零宽 span = 修复前事故形态，修复后必须绝迹）
+          const sorted = [...result.spans].sort(
+            (a, b) => a.start - b.start || a.end - b.end
+          );
+          for (const s of sorted) {
+            if (!(s.start < s.end)) {
+              violations.push({ termsString, text, inv: "non-zero-width", span: s });
+              break;
+            }
+          }
+          for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i].start < sorted[i - 1].end) {
+              violations.push({ termsString, text, inv: "non-overlap", a: sorted[i - 1], b: sorted[i] });
+              break;
+            }
+          }
+          // ③ 同输入两次调用全等
+          const second = run();
+          if (JSON.stringify(result) !== JSON.stringify(second)) {
+            violations.push({ termsString, text, inv: "idempotent" });
+          }
+        }
+      }
+      expect(violations).toEqual([]);
+    });
+  }
+
+  test("防平凡通过守卫：字符类术语必须物化合法术语并在矩阵文本上真实命中", () => {
+    // 曾经的 P1 回归形态：isZeroWidthOnlyPattern 把顶层字符类当零宽 → parseTerms
+    // 判 fatal → terms=[] → 四不变量在空术语集上平凡全绿，缺陷被矩阵掩盖。
+    // 本守卫直接要求：术语数符合预期 + 在固定语料上至少产生 minHits 个 span。
+    for (const [termsString, expected] of assertConsumingTerms) {
+      const parsed = parseTerms(termsString);
+      expect({ termsString, termCount: parsed.terms.length }).toEqual({
+        termsString,
+        termCount: expected.terms,
+      });
+      let hits = 0;
+      for (const text of MATRIX_TEXTS) {
+        hits += applyTermReplace(text, parsed.terms, matrixReplacer).spans.length;
+      }
+      // 术语被误杀时 terms=[] → hits 恒为 0，本断言立即转红。
+      expect(hits).toBeGreaterThanOrEqual(expected.minHits);
+    }
+  });
+
+  test("不变量矩阵：fast/full 基础解析逐字段一致（除 conflicting-pattern）", () => {
+    for (const termsString of MATRIX_TERMS) {
+      const fast = parseTerms(termsString, { fullDiagnostics: false });
+      const full = parseTerms(termsString);
+      const fields = (p) => ({
+        terms: p.terms,
+        invalid: p.invalid,
+        originalOrder: p.originalOrder,
+        metaWarnings: p.metaWarnings,
+        baseDiags: p.diagnostics.filter((d) => d.type !== "conflicting-pattern"),
+      });
+      expect(JSON.stringify(fields(fast))).toBe(JSON.stringify(fields(full)));
+    }
+  });
+
+  test("不变量矩阵：纯零宽术语修复后行为——fatal 排除且混合臂零宽分支不产 span", () => {
+    // 静态层：纯零宽模式在两种模式下都被排除（合法术语仍保留）
+    for (const key of ["(?=x)", "(?<=x)", "\\b"]) {
+      for (const mode of [{}, { fullDiagnostics: false }]) {
+        const parsed = parseTerms(`${key},Y;API,接口`, mode);
+        expect(parsed.terms.map((t) => t.key)).toEqual(["API"]);
+      }
+    }
+    // 运行时层：混合臂 a|(?=x) 在只有零宽分支可命中的文本上零产出
+    //（语料不含字母 a：消费臂无从命中；含 x：零宽分支可命中）
+    const mixed = parseTerms("a|(?=x),Y");
+    const out = applyTermReplace("xX finish line", mixed.terms, matrixReplacer);
+    expect(out.output).toBe("xX finish line");
+    expect(out.spans).toEqual([]);
+  });
+});

--- a/src/libs/translator.js
+++ b/src/libs/translator.js
@@ -33,6 +33,7 @@ import { resolveApiPromptSettings } from "../config/prompt";
 import { interpreter } from "./interpreter";
 import { clearFetchPool } from "./pool";
 import { debounce, scheduleIdle, genEventName, parseAITerms } from "./utils";
+import { parseTerms, buildTermsRegex, buildTermsMatcher, applyTermReplace } from "./terms";
 import { escapeHTML } from "./html";
 import { apiMicrosoftDict, apiTranslate, apiYoudaoDict } from "../apis";
 import { kissLog } from "./log";
@@ -339,8 +340,9 @@ export class Translator {
   #transOnlyRevertEnabled = false;
   #boundTransOnlyMouseOver = null;
   #boundTransOnlyMouseOut = null;
-  #termValues = []; // 按顺序存储术语的替换值
+  #termEntries = []; // 排序后的术语条目（parseTerms 输出，供 applyTermReplace 使用）
   #combinedTermsRegex; // 专业术语正则表达式
+  #termMatcher = null; // 术语扫描 matcher（buildTermsMatcher 一次物化，热路径零编译）
   #combinedSkipsRegex; // 跳过文本正则表达式
 
   #placeholderCache = null; // 缓存正则对象
@@ -1064,39 +1066,36 @@ export class Translator {
 
   // 解析专业术语字符串
   #parseTerms(termsString) {
-    this.#termValues = [];
+    this.#termEntries = [];
     this.#combinedTermsRegex = null;
+    this.#termMatcher = null;
 
     if (!termsString || typeof termsString !== "string") return;
 
-    const termPatterns = [];
-    const lines = termsString.split(/\n|;/); // 按换行或分号分割
+    // 纯函数解析：按 key.length 降序、同 key 去重、非法正则收集。
+    // fast 模式跳过跨术语 O(n²) 冲突分析，避免阻塞 Translator 初始化；
+    // 跨术语 conflicting-pattern 诊断由 Playground / CLI 的完整模式负责。
+    const { terms, invalid, diagnostics, hasErrors } = parseTerms(termsString, {
+      fullDiagnostics: false,
+    });
 
-    for (const line of lines) {
-      const trimmedLine = line.trim();
-      if (!trimmedLine) continue;
-
-      let lastCommaIndex = trimmedLine.lastIndexOf(",");
-      if (lastCommaIndex === -1) {
-        lastCommaIndex = trimmedLine.length;
-      }
-      const key = trimmedLine.substring(0, lastCommaIndex).trim();
-      const value = trimmedLine.substring(lastCommaIndex + 1).trim();
-
-      if (key) {
-        try {
-          new RegExp(key);
-          termPatterns.push(`(${key})`);
-          this.#termValues.push(value);
-        } catch (err) {
-          kissLog(`Invalid RegExp for term: "${key}"`, err);
-        }
-      }
+    if (invalid.length > 0) {
+      invalid.forEach(({ key, error }) =>
+        kissLog(`Invalid RegExp for term: "${key}"`, error)
+      );
     }
 
-    if (termPatterns.length > 0) {
-      this.#combinedTermsRegex = new RegExp(termPatterns.join("|"), "g");
+    // 保留诊断与 hasErrors 日志（供 Playground / 控制台排查），但不再因任一非法段
+    // 禁用整份术语：parseTerms 已逐条排除非法项，返回的 terms 是可安全应用的合法集合。
+    if (hasErrors) {
+      kissLog("Term parse errors (legal terms still applied): ", diagnostics);
     }
+
+    this.#termEntries = terms;
+    this.#combinedTermsRegex = buildTermsRegex(terms);
+    // matcher 一次物化槽位表与 phase 正则，逐文本节点扫描零编译；
+    // 规则更新走 #parseTerms 整体重建，热更新自然失效。
+    this.#termMatcher = buildTermsMatcher(terms);
   }
 
   // #parseAITerms(termsString) {
@@ -3752,21 +3751,20 @@ overflow-wrap: anywhere !important;`;
         let text = node.textContent;
         if (!text.trim()) return "";
 
-        // 专业术语替换
+        // 专业术语替换：matcher 一次物化（热路径零编译），applyTermReplace 内部重置 lastIndex
         if (this.#combinedTermsRegex) {
-          this.#combinedTermsRegex.lastIndex = 0;
-          text = text.replace(this.#combinedTermsRegex, (...args) => {
-            const groups = args.slice(1, -2);
-            const matchedIndex = groups.findIndex(
-              (group) => group !== undefined
-            );
-            const fullMatch = args[0];
-            const termValue = this.#termValues[matchedIndex];
-
-            return pushReplace(
-              `<i class="${Translator.KISS_CLASS.term}" style="${termsStyle}">${termValue || fullMatch}</i>`
-            );
-          });
+          const { output } = applyTermReplace(
+            text,
+            this.#termEntries,
+            (termEntry, fullMatch) => {
+              const termValue = termEntry.value;
+              return pushReplace(
+                `<i class="${Translator.KISS_CLASS.term}" style="${termsStyle}">${termValue || fullMatch}</i>`
+              );
+            },
+            this.#termMatcher || this.#combinedTermsRegex
+          );
+          text = output;
         }
 
         return escapeHTML(text);
@@ -4844,6 +4842,22 @@ overflow-wrap: anywhere !important;`;
     // 配置变更时清空正则缓存
     this.#placeholderCache = null;
     this.#blockSelectorInvalid = false;
+
+    // terms 变更时重新解析术语：updateRule 可能由扩展/Popup 在运行期推送新规则，
+    // 必须同步刷新 #termEntries 与 #combinedTermsRegex，否则术语停留在构造时的旧值
+    // （历史缺陷：只有 #rule.terms 被覆盖，解析状态不更新导致新术语静默不生效）。
+    // 用 hasOwnProperty 判定（与上方 3991 行一致）：显式传 terms: undefined 不触发重解析，
+    // 避免把解析状态置位到 undefined 派生值。
+    if (Object.prototype.hasOwnProperty.call(newRule, "terms")) {
+      this.#parseTerms(this.#rule.terms);
+    }
+
+    // aiTerms 变更时同步刷新 #glossary：与 #terms 同类的运行时不对称缺陷——
+    // 构造后运行期更新规则里的 AI 术语若不同步重解析，glossary 会停留构造时旧值，
+    // 导致 AI 翻译静默不生效。这里与 terms 分支并列，保持两者解析状态一致。
+    if (Object.prototype.hasOwnProperty.call(newRule, "aiTerms")) {
+      this.#glossary = parseAITerms(this.#rule.aiTerms);
+    }
 
     const needsTriggerRescan =
       this.#enabled &&

--- a/src/libs/translator.test.js
+++ b/src/libs/translator.test.js
@@ -4883,4 +4883,684 @@ describe("Translator rule styles", () => {
     ).not.toBeNull();
   });
 
+  describe("Translator terms wiring", () => {
+    test("长词不被短词切割（API/APIKey 接线）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "APIKey and API";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "API,接口;APIKey",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(requestedText).toBe("[[1]] and [[2]]");
+      expect(inner.textContent).toBe("APIKey and 接口");
+      expect(inner.textContent).not.toContain("接口Key");
+    });
+
+    test("长词触发而短词不抢占（GPT/GPTs 接线）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "GPTs and GPT";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "GPT;GPTs,智能体集合",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(requestedText).toBe("[[1]] and [[2]]");
+      expect(inner.textContent).toBe("智能体集合 and GPT");
+    });
+
+    test("Dr.whob,神经病; 真实链路：请求前保护 + 返回后恢复", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent =
+        "The Dr.whob feature will ship in the next release.";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Dr.whob,神经病;",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 1. 发送到翻译提供商前，原始术语已被替换为受保护占位符
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      expect(requestedText).toBe(
+        "The [[1]] feature will ship in the next release."
+      );
+      expect(requestedText).not.toContain("Dr.whob");
+
+      // 2. 提供商返回后，目标术语被正确恢复到最终输出
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toContain("神经病");
+      expect(inner.textContent).not.toContain("Dr.whob");
+      expect(inner.textContent).toContain("feature will ship");
+    });
+
+    test("provider 返回错误自然语言译文时，术语仍由占位符恢复（不依赖 provider 质量）", async () => {
+      apiTranslate.mockImplementation(() =>
+        Promise.resolve({
+          trText: "[[1]] translated by a totally different provider",
+          isSame: false,
+        })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent =
+        "The Dr.whob feature will ship in the next release.";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Dr.whob,神经病;",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      // 本地术语机制独立于 provider 自行翻译：即使 provider 翻错，目标术语仍然恢复
+      expect(inner.textContent).toContain("神经病");
+      expect(inner.textContent).toContain(
+        "translated by a totally different provider"
+      );
+    });
+
+    test("provider 失败后重试：两次请求收到一致的受保护输入，术语仍恢复", async () => {
+      apiTranslate
+        .mockRejectedValueOnce(new Error("provider A down"))
+        .mockImplementation(({ text }) =>
+          Promise.resolve({ trText: text, isSame: false })
+        );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "GPTs and GPT";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "GPT;GPTs,智能体集合",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 首次请求失败 → 出现重试按钮
+      const retry = document.querySelector(`.${Translator.KISS_CLASS.retry}`);
+      expect(retry).not.toBeNull();
+
+      // 用户点击重试（回退路径）→ 第二次请求收到完全一致的受保护输入
+      retry.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushAsync();
+      expect(apiTranslate.mock.calls).toHaveLength(2);
+      expect(apiTranslate.mock.calls[0][0].text).toBe("[[1]] and [[2]]");
+      expect(apiTranslate.mock.calls[1][0].text).toBe(
+        apiTranslate.mock.calls[0][0].text
+      );
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("智能体集合 and GPT");
+    });
+
+    test("占位符序号跨运行隔离：每次请求都从 1 开始编号", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="targetA"></span><span id="targetB"></span></main>';
+      document.getElementById("targetA").textContent = "APIKey and API";
+      document.getElementById("targetB").textContent = "GPTs and GPT";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#targetA",
+          apiSlug: "terms-test",
+          terms: "API,接口;APIKey;GPT;GPTs,智能体集合",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 目标 B（第二条并发请求）也独立从 1 开始编号
+      document.getElementById("targetB").textContent = "GPTs and GPT";
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#targetB",
+          apiSlug: "terms-test",
+          terms: "GPT;GPTs,智能体集合",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      expect(apiTranslate.mock.calls).toHaveLength(2);
+      expect(apiTranslate.mock.calls[1][0].text).toBe("[[1]] and [[2]]");
+      // 两次请求的占位符编号互不污染
+      expect(apiTranslate.mock.calls[0][0].text).toBe("[[1]] and [[2]]");
+    });
+
+    test("哨兵术语由本地占位符恢复：provider 未收到原文、无法代为翻译", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent =
+        "Xyzzy drives the pipeline.";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Xyzzy,比特哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      expect(requestedText).toBe("[[1]] drives the pipeline.");
+      expect(requestedText).not.toContain("Xyzzy");
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      // 最终结果来自本地术语 chain（占位符还原），与 provider 是否认识该词无关
+      expect(inner.textContent).toBe("比特哨兵 drives the pipeline.");
+    });
+
+    test("本地 terms 与 provider aiTerms 并存：两套机制互不替代、互不掩盖", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Xyzzy,本地哨兵",
+          aiTerms: "Xyzzy,服务端哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const args = apiTranslate.mock.calls[0][0];
+      // 本地 terms：原文 Xyzzy 已被替换为占位符，provider 收不到原文
+      expect(args.text).toBe("[[1]]");
+      expect(args.text).not.toContain("Xyzzy");
+      // provider aiTerms：作为 glossary 注入 prompt（机制独立，同时存在）
+      expect(args.glossary).toEqual({ Xyzzy: "服务端哨兵" });
+      // 最终输出由本地占位符还原，不被服务端术语遮蔽
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("本地哨兵");
+    });
+
+    test("整页路径 #translateFetch 携带规则级 aiTerms 生成的 glossary", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy usage";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          aiTerms: "Xyzzy,整页哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 整页翻译：glossary 来自规则级 rule.aiTerms，随 #translateFetch 注入 apiTranslate
+      expect(apiTranslate.mock.calls[0][0].glossary).toEqual({
+        Xyzzy: "整页哨兵",
+      });
+    });
+
+    test("标题翻译同样携带规则级 aiTerms 的 glossary（整页+标题+泡泡范围）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.title = "Xyzzy Title";
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy usage";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          transTitle: "true",
+          aiTerms: "Xyzzy,标题哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 标题翻译走同一个 #translateFetch，同样携带规则级 glossary
+      const titleCall = apiTranslate.mock.calls.find(
+        ([args]) => args.text === document.title
+      );
+      expect(titleCall).toBeDefined();
+      expect(titleCall[0].glossary).toEqual({ Xyzzy: "标题哨兵" });
+    });
+
+    test("provider 返回完全不同的自然语言译文时，哨兵术语仍稳定恢复", async () => {
+      apiTranslate.mockImplementation(() =>
+        Promise.resolve({
+          trText: "[[1]]（完全错误的 provider 译文）",
+          isSame: false,
+        })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy term here";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Xyzzy,比特哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("比特哨兵（完全错误的 provider 译文）");
+    });
+
+    test("合法术语与非法段共存：非法段只产生诊断，合法术语仍生效（API,接口;([,坏规则）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "API and the rest";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          // `([` 无法作为正则解析 → hasErrors=true；`API,接口` 是合法术语，必须继续生效
+          terms: "API,接口;([,坏规则",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 合法术语进入占位符替换链路：provider 收到占位符，不再收到原文 API
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      expect(requestedText).toBe("[[1]] and the rest");
+      expect(requestedText).not.toContain("API");
+      // 翻译返回后，目标译文恢复；非法段不参与替换，也不产生切割残留
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("接口 and the rest");
+      expect(inner.textContent).not.toContain("坏规则");
+    });
+
+    test("所有条目均非法：不构造无效正则、不抛异常，原文仍正常翻译", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "API and the rest";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "([,坏规则;bad[re",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 无合法术语 → 无占位符替换，原文原样送译（无空匹配正则、无异常）
+      expect(apiTranslate.mock.calls[0][0].text).toBe("API and the rest");
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("API and the rest");
+    });
+
+    test("P1 真实生产链路：嵌套捕获组 + lookbehind 规则在整页翻译中正常替换并不吞正文", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "xy";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "((ABCDEFG)),long;(?<=x)y,look",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 占位符正确替换：x 保留，y 被替换为 [[1]]
+      expect(apiTranslate.mock.calls[0][0].text).toBe("x[[1]]");
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("xlook");
+    });
+
+    test("updateRule 推送新 terms 后立即重解析，不会停留构造时旧值", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "API and Xyzzy";
+
+      const translator = createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "API,接口",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 初始术语 API 生效
+      expect(apiTranslate.mock.calls[0][0].text).toBe("[[1]] and Xyzzy");
+
+      // 运行期推送新术语：Xyzzy 应立即生效，API 移除
+      document.getElementById("target").textContent = "API and Xyzzy";
+      translator.updateRule({ terms: "Xyzzy,哨兵" });
+      translator.rescan();
+      await flushAsync();
+
+      const lastCall = apiTranslate.mock.calls.at(-1)[0];
+      expect(lastCall.text).toBe("API and [[1]]");
+      expect(lastCall.text).not.toContain("Xyzzy");
+    });
+
+    test("updateRule 修改 aiTerms 后 #glossary 立即刷新，不停留构造时旧值", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy usage";
+
+      const translator = createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          aiTerms: "Xyzzy,构造旧值",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 初始 #glossary 反映构造时的 aiTerms，作为 glossary 注入 provider
+      expect(apiTranslate.mock.calls[0][0].glossary).toEqual({
+        Xyzzy: "构造旧值",
+      });
+
+      // 运行期推送新 aiTerms：#glossary 必须同步刷新，不得停留构造时旧值
+      document.getElementById("target").textContent = "Xyzzy usage";
+      translator.updateRule({ aiTerms: "Xyzzy,运行新值" });
+      translator.rescan();
+      await flushAsync();
+
+      const lastCall = apiTranslate.mock.calls.at(-1)[0];
+      expect(lastCall.glossary).toEqual({ Xyzzy: "运行新值" });
+    });
+
+    test("updateRule 显式传 terms/aiTerms: undefined 时解析状态与 #rule 保持一致（不留旧值）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      document.getElementById("target").textContent = "Xyzzy usage";
+
+      const translator = createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "Xyzzy,本地哨兵",
+          aiTerms: "Xyzzy,服务端哨兵",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 初始：本地术语替换为占位符、AI glossary 生效
+      expect(apiTranslate.mock.calls[0][0].glossary).toEqual({
+        Xyzzy: "服务端哨兵",
+      });
+
+      // 显式传 terms/aiTerms: undefined（如展开一个缺该 key 的 rule 对象）：
+      // delta 循环会把 #rule.terms/#rule.aiTerms 置为 undefined，解析状态必须同步清空，
+      // 不得停留在构造时旧值（历史缺陷：守卫用 !== undefined 会跳过重解析，导致解析状态残留）。
+      document.getElementById("target").textContent = "Xyzzy usage";
+      translator.updateRule({ terms: undefined, aiTerms: undefined });
+      translator.rescan();
+      await flushAsync();
+
+      const lastCall = apiTranslate.mock.calls.at(-1)[0];
+      // glossary 与 #rule.aiTerms 一致（已清空），不留旧值
+      expect(lastCall.glossary).toEqual({});
+      // 本地术语不再替换原文（#rule.terms 为空 → 无占位符）
+      expect(lastCall.text).toContain("Xyzzy");
+    });
+
+    test("零宽臂术语真实链路：只有零宽分支可命中时，序列化产物无凭空占位符（统一计划 20260829 Task 6）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      // 文本含 x（满足 (?=x) 前瞻）但不含 a（a 臂无命中）：
+      // 修复前零宽分支会逐位置注入译文并产生凭空占位符；修复后运行期守卫跳过零宽命中。
+      document.getElementById("target").textContent = "xX finish line";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          // 混合臂 a|(?=x) 合法保留（含可消费原子 a）；纯零宽模式在静态层即被排除
+          terms: "a|(?=x),Y",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 占位符只能对应真实消费的命中：零命中 → 零占位符，原文原样送译
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      expect(requestedText).toBe("xX finish line");
+      expect(requestedText).not.toMatch(/\[\[\d+\]\]/);
+      // 最终输出无零宽注入的译文 Y
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("xX finish line");
+    });
+
+    test("零宽臂术语真实链路：消费臂命中时占位符与真实命中一一对应（统一计划 20260829 Task 6）", async () => {
+      apiTranslate.mockImplementation(({ text }) =>
+        Promise.resolve({ trText: text, isSame: false })
+      );
+      document.body.innerHTML =
+        '<main id="root"><span id="target"></span></main>';
+      // 文本恰含一个 a（消费臂命中 1 次）与多处 x（零宽分支命中点，必须零产出）
+      document.getElementById("target").textContent = "aX finish line x";
+
+      createTranslator(
+        {
+          autoScan: "false",
+          selector: "#target",
+          apiSlug: "terms-test",
+          terms: "a|(?=x),Y",
+        },
+        {
+          minLength: 0,
+          transApis: [
+            { ...createApiSetting("terms-test"), placeholder: "[[ ]]" },
+          ],
+        }
+      );
+      await flushAsync();
+
+      // 消费臂恰命中 1 次 → 恰 1 个占位符；零宽命中点不产生占位符
+      const requestedText = apiTranslate.mock.calls[0][0].text;
+      const placeholders = requestedText.match(/\[\[\d+\]\]/g) || [];
+      expect(placeholders).toEqual(["[[1]]"]);
+      expect(requestedText).toBe("[[1]]X finish line x");
+      // 恢复后：真实命中被替换为译文，其余文本原样
+      const inner = document.querySelector(`.${Translator.KISS_CLASS.inner}`);
+      expect(inner.textContent).toBe("YX finish line x");
+    });
+  });
 });

--- a/src/libs/utils.test.js
+++ b/src/libs/utils.test.js
@@ -1,0 +1,62 @@
+import { parseAITerms } from "./utils";
+import { parseTerms } from "./terms";
+
+// parseAITerms 纯函数单元测试（Task 1）
+// 目标：锁定现状（含与 parseTerms 的既定差异）为预期行为，不改解析语义。
+describe("parseAITerms", () => {
+  test("empty string and non-string input return {}", () => {
+    expect(parseAITerms("")).toEqual({});
+    expect(parseAITerms("   ")).toEqual({});
+    expect(parseAITerms(null)).toEqual({});
+    expect(parseAITerms(undefined)).toEqual({});
+    expect(parseAITerms(123)).toEqual({});
+    expect(parseAITerms({})).toEqual({});
+  });
+
+  test("splits entries by newline and semicolon", () => {
+    expect(
+      parseAITerms("API,接口\nGPTs,智能体集合;React,React Native")
+    ).toEqual({
+      API: "接口",
+      GPTs: "智能体集合",
+      React: "React Native",
+    });
+  });
+
+  test("comma semantics: key is text before FIRST comma, extra segments are silently dropped", () => {
+    // "a,b,c" -> key "a", value "b", the trailing ",c" is dropped (contrast with parseTerms lastIndexOf)
+    expect(parseAITerms("a,b,c")).toEqual({ a: "b" });
+    expect(parseAITerms("a,b,c\nd,e,f")).toEqual({ a: "b", d: "e" });
+  });
+
+  test("comma-in-key differs from parseTerms: AI uses split(',') first-comma, local uses lastIndexOf", () => {
+    // AI terms: key cannot contain a comma (first comma separates, trailing dropped)
+    expect(parseAITerms("a,b,c")).toEqual({ a: "b" });
+    // Local terms: key CAN contain a comma (lastIndexOf splits at the last comma)
+    const { terms } = parseTerms("a,b,c");
+    expect(terms[0].key).toBe("a,b");
+    expect(terms[0].value).toBe("c");
+  });
+
+  test("last-wins dedup: later entry overwrites earlier same key (Object.fromEntries)", () => {
+    expect(parseAITerms("a,1\na,2")).toEqual({ a: "2" });
+    expect(parseAITerms("a,1;a,2")).toEqual({ a: "2" });
+  });
+
+  test("does no regex validation, no sorting, and produces no diagnostics (contrast with parseTerms)", () => {
+    // Invalid regex key "bad[re" is accepted as-is by parseAITerms
+    expect(parseAITerms("bad[re,value")).toEqual({ "bad[re": "value" });
+    // parseTerms flags it as invalid
+    const { invalid } = parseTerms("bad[re,value");
+    expect(invalid).toHaveLength(1);
+
+    // No sorting: parseAITerms preserves nothing (object), parseTerms length-sorts
+    const parsed = parseAITerms("APIKey,x\nAPI,y");
+    expect(parsed).toEqual({ APIKey: "x", API: "y" });
+  });
+
+  test("empty key lines are filtered out", () => {
+    expect(parseAITerms("a,1\n,value\nb,2")).toEqual({ a: "1", b: "2" });
+    expect(parseAITerms(",value")).toEqual({});
+  });
+});

--- a/src/scripts/test-term-replace.js
+++ b/src/scripts/test-term-replace.js
@@ -1,0 +1,201 @@
+// 免打包专业术语 CLI 验证脚本
+// 纯 Node（babel-node），复用 terms.js / termTestUtils.js 真实生产逻辑，
+// 零 DOM、零 React、零网络，毫秒级完成。
+//
+// 用法：
+//   pnpm test:terms                          # 默认内置固定用例
+//   pnpm test:terms --terms "API,接口;APIKey" # 自定义术语
+//   pnpm test:terms --verbose                 # 输出完整 detail
+//   pnpm test:terms --terms "bad[re"          # 非法正则测试
+//
+// 退出码：0（全部通过）/ 1（存在失败）
+
+import {
+  parseTerms,
+  applyTermReplace,
+  applyNaiveReplace,
+  FATAL_DIAGNOSTIC_TYPES,
+  formatDiagnosticMessage,
+} from "../libs/terms";
+import {
+  generateTermTestText,
+  assertTermReplacements,
+  getDiagnosticSampleTerms,
+} from "../libs/termTestUtils";
+
+// ─── 内置固定用例（覆盖冲突矩阵 4 类场景）────────────────────────────────
+// 与 Playground / 自动化测试共用 getDiagnosticSampleTerms() 同一份 fixture，
+// 避免 CLI 与 UI 的样例语义分叉。
+//  类型 1：API(有) ↔ APIKey(有)   类型 2：UI(有) ↔ UIView(无)
+//  类型 3：GPT(无) ↔ GPTs(有)     类型 4：React(无) ↔ ReactNative(无)
+const BUILTIN_TERMS = getDiagnosticSampleTerms();
+
+// 标准替换器：有译文用译文，无译文保留原文
+const REPLACER = (term, fullMatch) => term.value || fullMatch;
+
+// ─── 参数解析 ────────────────────────────────────────────────────────────
+function parseArguments(argv) {
+  const result = { terms: null, verbose: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) continue;
+    const [rawName, inlineValue] = token.slice(2).split("=", 2);
+    const value =
+      inlineValue === undefined && argv[index + 1]?.startsWith("--") === false
+        ? argv[++index]
+        : (inlineValue ?? true);
+    if (rawName === "terms") {
+      result.terms = String(value);
+    } else if (rawName === "verbose") {
+      result.verbose = true;
+    }
+  }
+  return result;
+}
+
+// ─── 格式化输出 ──────────────────────────────────────────────────────────
+function formatAssertion(ok) {
+  return ok ? "\u2705" : "\u274C"; // ✅ / ❌
+}
+
+function truncate(text, maxLen = 80) {
+  if (typeof text !== "string") return String(text);
+  return text.length > maxLen ? text.slice(0, maxLen - 3) + "..." : text;
+}
+
+// ─── 主逻辑 ──────────────────────────────────────────────────────────────
+async function run() {
+  const args = parseArguments(process.argv.slice(2));
+  const termsString = args.terms || BUILTIN_TERMS;
+  const verbose = args.verbose;
+
+  // 1. 解析术语（显式完整诊断：CLI 需要 conflicting-pattern 的失败契约）
+  const parsed = parseTerms(termsString, { fullDiagnostics: true });
+
+  if (parsed.invalid.length > 0) {
+    for (const { key, error } of parsed.invalid) {
+      console.log(`[INVALID] 非法正则术语: "${key}" — ${error.message}`);
+    }
+  }
+
+  // 存在致命非法段（多余逗号/空源术语/冲突映射/非法正则/空匹配正则等）时给出段号与原因
+  // 判定复用 terms.js 导出的 FATAL_DIAGNOSTIC_TYPES，避免硬编码清单与解析器漂移。
+  if (parsed.hasErrors) {
+    for (const d of parsed.diagnostics) {
+      if (FATAL_DIAGNOSTIC_TYPES.has(d.type)) {
+        // 终端格式化函数负责可读文本（诊断核心只输出稳定 type + 结构化 detail）
+        console.log(`[FAIL] ${formatDiagnosticMessage(d)}`);
+      }
+    }
+    // 与 Playground 非法态一致：非法段只跳过自身，仍可应用的合法术语在真实链路中照常生效
+    if (parsed.terms.length > 0) {
+      console.log(
+        `[INFO] 仍可应用的合法术语: ${parsed.terms.map((t) => `「${t.key}」`).join(", ")}`
+      );
+    }
+    console.log("[FAIL] 输入存在非法段，未生成测试用例");
+  }
+
+  if (parsed.terms.length === 0) {
+    console.log("[FAIL] 没有有效术语，无法生成测试用例");
+  }
+
+  if (parsed.hasErrors || parsed.terms.length === 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `[INFO] 解析到 ${parsed.terms.length} 个有效术语` +
+      (parsed.invalid.length > 0
+        ? `，${parsed.invalid.length} 个非法正则已跳过`
+        : "")
+  );
+  console.log(
+    `[INFO] 术语（按长度降序）: ${parsed.terms.map((t) => t.key + (t.value ? "→" + t.value : "")).join(", ")}`
+  );
+  console.log("");
+
+  // 2. 生成测试用例
+  const cases = generateTermTestText(parsed);
+  console.log(`[INFO] 生成了 ${cases.length} 个测试用例\n`);
+
+  let totalFail = 0;
+  let totalCases = 0;
+
+  for (let index = 0; index < cases.length; index++) {
+    const testCase = cases[index];
+    totalCases++;
+
+    // 修复后 / 修复前输出
+    const fixed = applyTermReplace(testCase.text, parsed.terms, REPLACER);
+    const naive = applyNaiveReplace(testCase.text, parsed);
+
+    // 结构化断言
+    const assertion = assertTermReplacements(parsed, testCase);
+
+    const directionLabel =
+      testCase.type === "conflict" && testCase.direction
+        ? `（${testCase.direction === "short-first" ? "短词→长词" : "长词→短词"}）`
+        : "";
+    const header =
+      testCase.type === "conflict"
+        ? `用例 ${index + 1}：长短词冲突（类型 ${testCase.conflictType}）` +
+          directionLabel +
+          (testCase.short && testCase.long
+            ? ` — ${testCase.short.key} ↔ ${testCase.long.key}`
+            : "")
+        : `用例 ${index + 1}：单术语 — ${testCase.term?.key || "?"}`;
+
+    console.log(`─── ${header} ───`);
+    console.log(`📄 自然文本: ${truncate(testCase.text)}`);
+    console.log(`✅ 修复后:   ${truncate(fixed.output)}`);
+    console.log(`❌ 修复前:   ${truncate(naive.output)}`);
+
+    if (assertion.ok) {
+      console.log(`   ${formatAssertion(true)} 断言通过`);
+    } else {
+      totalFail++;
+      console.log(`   ${formatAssertion(false)} 断言失败`);
+
+      for (const issue of assertion.issues) {
+        console.log(`     ❌ [${issue.type}] ${issue.message}`);
+      }
+
+      if (verbose) {
+        for (const issue of assertion.issues) {
+          console.log(`   ── detail ──`);
+          console.log(JSON.stringify(issue.detail, null, 2));
+        }
+      }
+    }
+
+    // 修复前/后对比证据（仅 verbose 模式）
+    if (verbose && assertion.evidence.length > 0) {
+      for (const ev of assertion.evidence) {
+        console.log(`   ℹ️ [evidence] ${ev.message}`);
+        console.log(JSON.stringify(ev.detail, null, 2));
+      }
+    }
+
+    console.log("");
+  }
+
+  // 3. 汇总
+  const passCount = totalCases - totalFail;
+  console.log(`═══════════════════════════════════════`);
+  console.log(`总计: ${totalCases} 个用例`);
+  console.log(`通过: ${passCount}`);
+  console.log(`失败: ${totalFail}`);
+  console.log(`状态: ${totalFail === 0 ? "✅ 全部通过" : "❌ 存在失败"}`);
+  console.log(`═══════════════════════════════════════`);
+
+  if (totalFail > 0) {
+    process.exitCode = 1;
+  }
+}
+
+run().catch((error) => {
+  console.error("[FATAL] 脚本执行异常:", error);
+  process.exitCode = 1;
+});

--- a/src/scripts/test-term-replace.test.js
+++ b/src/scripts/test-term-replace.test.js
@@ -1,0 +1,148 @@
+// 免打包专业术语 CLI 脚本的进程级测试
+// 通过子进程运行真实的 babel-node CLI（src/scripts/test-term-replace.js），
+// 验证：成功（默认内置 4 类冲突全部通过、退出码 0）、
+// 失败（断言失败输出、退出码 1）、
+// 非法输入（非法正则提示、退出码 1）、以及 --verbose 结构化 detail。
+import { spawn } from "child_process";
+import path from "path";
+import { getDiagnosticSampleTerms } from "../libs/termTestUtils";
+import { parseTerms } from "../libs/terms";
+
+const PROJECT_ROOT = path.join(__dirname, "../..");
+const BABEL_NODE = path.join(
+  PROJECT_ROOT,
+  "node_modules/@babel/node/bin/babel-node.js"
+);
+const CLI_SCRIPT = path.join(__dirname, "test-term-replace.js");
+
+/** 以子进程运行 CLI，返回 { code, stdout, stderr }。 */
+function runCli(args = []) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [BABEL_NODE, CLI_SCRIPT, ...args], {
+      cwd: PROJECT_ROOT,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+describe("test-term-replace CLI", () => {
+  test("exits 0 and covers all four conflict matrix classes with built-in terms", async () => {
+    const { code, stdout, stderr } = await runCli([]);
+
+    expect(stderr).toBe("");
+    expect(code).toBe(0);
+    // 默认内置固定用例覆盖冲突矩阵 4 类。
+    expect(stdout).toContain("类型 1");
+    expect(stdout).toContain("类型 2");
+    expect(stdout).toContain("类型 3");
+    expect(stdout).toContain("类型 4");
+    // 逐用例输出：自然文本 / 修复后 / 修复前 / 断言 ✅。
+    expect(stdout).toContain("自然文本");
+    expect(stdout).toContain("修复后");
+    expect(stdout).toContain("修复前");
+    expect(stdout).toContain("✅ 断言通过");
+    expect(stdout).not.toContain("❌ 断言失败");
+    expect(stdout).toContain("状态: ✅ 全部通过");
+  }, 60000);
+
+  test("exits 0 with custom terms passed via --terms", async () => {
+    const { code, stdout } = await runCli(["--terms", "API,接口;APIKey"]);
+
+    expect(code).toBe(0);
+    // 自定义术语只生成该对（类型 2）用例：长词保持原文、短词单独替换。
+    expect(stdout).toContain("长短词冲突（类型 2）");
+    expect(stdout).toContain("API ↔ APIKey");
+    expect(stdout).toContain("✅ 断言通过");
+  }, 60000);
+
+  test("exits 1 and emits structured failure details when assertions fail", async () => {
+    const { code, stdout } = await runCli([
+      "--terms",
+      "API\\.\\d+,版本", // 正则术语插入自然模板后不能自匹配 → 断言失败
+    ]);
+
+    expect(code).toBe(1);
+    expect(stdout).toContain("❌ 断言失败");
+    expect(stdout).toContain("[single-term-not-found]");
+    expect(stdout).toContain("术语 API\\.\\d+ 未被命中");
+    expect(stdout).toContain("状态: ❌ 存在失败");
+  }, 60000);
+
+  test("--verbose prints full structured detail for failing issues", async () => {
+    const { code, stdout } = await runCli([
+      "--terms",
+      "API\\.\\d+,版本",
+      "--verbose",
+    ]);
+
+    expect(code).toBe(1);
+    // verbose 输出 issue detail 的 JSON（含 spans/修复前后文本等完整上下文）。
+    expect(stdout).toContain("── detail ──");
+    expect(stdout).toContain('"spans"');
+    expect(stdout).toContain('"fixedOutput"');
+    expect(stdout).toContain('"naiveOutput"');
+    expect(stdout).toContain('"text"');
+  }, 60000);
+
+  test("exits 1 and reports invalid regex terms", async () => {
+    const { code, stdout } = await runCli(["--terms", "bad[re,x"]);
+
+    expect(code).toBe(1);
+    expect(stdout).toContain("[INVALID]");
+    expect(stdout).toContain("非法正则术语");
+    expect(stdout).toContain("bad[re");
+    // 全部术语非法时没有可执行的用例，明确失败。
+    expect(stdout).toContain("没有有效术语");
+  }, 60000);
+
+  // hasErrors 三方行为契约（计划 v4 节明文化）：
+  // 预览层（Playground/CLI）在存在致命诊断时不出"通过"摘要、不生成用例，
+  // 但必须列出仍可应用的合法术语；生产 Translator 不受影响照常应用合法术语。
+  // 判定统一复用 terms.js 导出的 FATAL_DIAGNOSTIC_TYPES，不得各自硬编码清单。
+  test.each([
+    ["Dr\\.who;Dr.who,神经病患者", "conflicting-pattern", "冲突映射"],
+    ["Dr.who;,abc;入门,", "empty-source-term", "空源术语"],
+    ["a*,x", "empty-matching-pattern", "空字符串"],
+  ])(
+    "rejects illegal input %s with a specific diagnostic",
+    async (terms, expectedType, expectedText) => {
+      const { code, stdout } = await runCli(["--terms", terms]);
+
+      expect(code).toBe(1);
+      // 诊断带段号 + 原始内容 + 具体原因，且不生成成功摘要。
+      expect(stdout).toContain("[FAIL]");
+      expect(stdout).toContain(expectedText);
+      expect(stdout).toContain("输入存在非法段，未生成测试用例");
+      expect(stdout).not.toContain("✅ 全部通过");
+      expect(stdout).not.toContain("✅ 断言通过");
+    },
+    60000
+  );
+
+  test("尾巴逗号 Dr.who, 按保留原文处理：非致命、退出码 0", async () => {
+    // extra-comma 不再视为致命诊断：`key,` 作为保留原文术语可执行。
+    const { code, stdout } = await runCli(["--terms", "Dr.who,;API,接口"]);
+
+    expect(code).toBe(0);
+    // 不因尾巴逗号而拒绝整个输入、不报"输入存在非法段"。
+    expect(stdout).not.toContain("输入存在非法段");
+    expect(stdout).not.toContain("[FAIL]");
+    // 合法术语与保留规则仍生成用例并全部通过。
+    expect(stdout).toContain("✅ 全部通过");
+  }, 60000);
+
+  test("uses the same built-in fixture as getDiagnosticSampleTerms()", async () => {
+    const { code, stdout } = await runCli([]);
+
+    expect(code).toBe(0);
+    // CLI 默认用例与 Playground/自动化测试共用同一 fixture（8 个术语）。
+    const sample = parseTerms(getDiagnosticSampleTerms());
+    for (const term of sample.terms) {
+      expect(stdout).toContain(term.key);
+    }
+  }, 60000);
+});

--- a/src/views/Options/Playground.js
+++ b/src/views/Options/Playground.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
@@ -6,6 +6,7 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import TranForm from "../Selection/TranForm";
 import SubtitleSegmentationPlayground from "./SubtitleSegmentationPlayground";
+import TerminologyPlayground from "./TerminologyPlayground";
 import {
   DEFAULT_SETTING,
   DEFAULT_TRANBOX_SETTING,
@@ -13,6 +14,15 @@ import {
 } from "../../config";
 import { useSetting } from "../../hooks/Setting";
 import { useI18n } from "../../hooks/I18n";
+import { debounce } from "../../libs/utils";
+
+// localStorage 持久化键必须保持模块级：组件体内声明的键会被下方 useMemo 闭包
+// 与卸载 cleanup 引用而触发 react-hooks/exhaustive-deps 警告（lint 以
+// --max-warnings=0 作门禁），不得下移回组件体。
+const LS_TERMS_KEY = "kt-playground-terms-draft";
+const LS_AITERMS_KEY = "kt-playground-aiterms-draft";
+// 文本翻译页签多选接口的持久化键（TranForm 内部读写，刷新/页签往返后回填）。
+const LS_API_SLUGS_KEY = "kt-playground-api-slugs";
 
 export const normalizePlaygroundLineBreaks = (text) =>
   String(text ?? "")
@@ -31,6 +41,91 @@ export default function Playgound() {
   // Playground 内的页签状态只影响页面展示，不写入用户设置。
   const [activeTab, setActiveTab] = useState("translation");
   const [mergeSingleLineBreaks, setMergeSingleLineBreaks] = useState(false);
+  // 专业术语页签草稿：术语输入、AI 术语输入、例句 seed 都提升到父级状态，
+  // 不会随页签子组件卸载而销毁（页签往返不丢失用户草稿，且不写入正式规则）。
+  // 同时持久化到 localStorage，跨路由切换（组件卸载）后回来仍可回填。
+  const readDraft = (key) => {
+    try {
+      const v = window.localStorage.getItem(key);
+      return typeof v === "string" ? v : null;
+    } catch {
+      return null;
+    }
+  };
+  const [termsDraft, setTermsDraft] = useState(
+    () => readDraft(LS_TERMS_KEY) ?? ""
+  );
+  // 有 localStorage 回填时标记为已编辑，避免挂载时被规则初始术语覆盖。
+  // 仅当回填草稿为非空字符串时才视为已编辑：空串（用户清空过）不应阻断
+  // 术语页挂载时的默认填入示例 + 例句自动生成，保证开箱即可测试。
+  const [termDraftTouched, setTermDraftTouched] = useState(() => {
+    const draft = readDraft(LS_TERMS_KEY);
+    return typeof draft === "string" && draft.trim() !== "";
+  });
+  // 例句轮换 seed（"" = 缺省确定性行为；切片按钮后递增轮换）。
+  const [termSeed, setTermSeed] = useState("");
+  // AI 专业术语草稿：与 termsDraft 一样提升到父级，并持久化到 localStorage。
+  const [aiTermsDraft, setAiTermsDraft] = useState(
+    () => readDraft(LS_AITERMS_KEY) ?? ""
+  );
+
+  // 草稿变更防抖写入 localStorage（临时测试数据留存，不写入正式规则/接口配置）：
+  // 逐键同步写盘在高频输入下产生过量 storage 写，200ms trailing 防抖合并为末值单次写。
+  const writeTermsDraft = useMemo(
+    () =>
+      debounce((v) => {
+        try {
+          window.localStorage.setItem(LS_TERMS_KEY, v);
+        } catch {
+          // localStorage 不可用时静默降级：仅丢失跨路由留存，不影响本页使用。
+        }
+      }, 200),
+    []
+  );
+  const writeAiTermsDraft = useMemo(
+    () =>
+      debounce((v) => {
+        try {
+          window.localStorage.setItem(LS_AITERMS_KEY, v);
+        } catch {
+          // 同上，静默降级。
+        }
+      }, 200),
+    []
+  );
+  const termsDraftRef = useRef(termsDraft);
+  const aiTermsDraftRef = useRef(aiTermsDraft);
+
+  // ref 同步并入 effect 体：渲染期零 ref 写。
+  useEffect(() => {
+    termsDraftRef.current = termsDraft;
+    writeTermsDraft(termsDraft);
+  }, [termsDraft, writeTermsDraft]);
+  useEffect(() => {
+    aiTermsDraftRef.current = aiTermsDraft;
+    writeAiTermsDraft(aiTermsDraft);
+  }, [aiTermsDraft, writeAiTermsDraft]);
+
+  // 卸载：先同步 flush 最终已提交值（不丢字，硬关闭/崩溃前的最后落盘），再
+  // cancel 未决定时器（无幽灵写盘）。refs 由上方 effect 体在 commit 阶段更新，
+  // cleanup 运行时必为最新已提交值。
+  useEffect(
+    () => () => {
+      try {
+        window.localStorage.setItem(LS_TERMS_KEY, termsDraftRef.current);
+      } catch {
+        // 静默降级。
+      }
+      try {
+        window.localStorage.setItem(LS_AITERMS_KEY, aiTermsDraftRef.current);
+      } catch {
+        // 静默降级。
+      }
+      writeTermsDraft.cancel();
+      writeAiTermsDraft.cancel();
+    },
+    [writeTermsDraft, writeAiTermsDraft]
+  );
   const i18n = useI18n();
   // 从全局钩子中读取设置
   const { setting } = useSetting();
@@ -77,6 +172,7 @@ export default function Playgound() {
           value="segmentation"
           label={i18n("subtitle_segmentation", "字幕断句")}
         />
+        <Tab value="terms" label={i18n("terminology_playground", "专业术语")} />
       </Tabs>
 
       {activeTab === "translation" && (
@@ -115,6 +211,7 @@ export default function Playgound() {
             prompts={prompts}
             translateVariants={translateVariants}
             isPlaygound={true} // 标识为 Playground 环境以进行特定的渲染样式和交互处理
+            apiSlugsStorageKey={LS_API_SLUGS_KEY}
           />
         </>
       )}
@@ -124,6 +221,22 @@ export default function Playgound() {
           subtitleSetting={subtitleSetting}
           transApis={resolvedTransApis}
           prompts={prompts}
+        />
+      )}
+
+      {activeTab === "terms" && (
+        <TerminologyPlayground
+          setText={setText}
+          setActiveTab={setActiveTab}
+          termsDraft={termsDraft}
+          setTermsDraft={setTermsDraft}
+          termDraftTouched={termDraftTouched}
+          setTermDraftTouched={setTermDraftTouched}
+          termSeed={termSeed}
+          setTermSeed={setTermSeed}
+          aiTermsDraft={aiTermsDraft}
+          setAiTermsDraft={setAiTermsDraft}
+          transApis={resolvedTransApis}
         />
       )}
     </Box>

--- a/src/views/Options/Playground.test.js
+++ b/src/views/Options/Playground.test.js
@@ -1,15 +1,27 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import Playground, { normalizePlaygroundLineBreaks } from "./Playground";
+import { defaultSystemPrompt } from "../../config";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const mockTranForm = jest.fn();
+const mockTerminology = jest.fn();
 
 jest.mock("../../hooks/Setting", () => ({
   useSetting: () => ({
     setting: {
-      transApis: [],
+      // OpenAI 兼容 AI 接口条目（含 batchPromptSlug 引用），父组件应 resolve 为聚合提示词后下传。
+      transApis: [
+        {
+          apiSlug: "openai",
+          apiName: "OpenAI 兼容",
+          apiType: "OpenAI",
+          isDisabled: false,
+          useBatchFetch: true,
+          batchPromptSlug: "batch-translation-json",
+        },
+      ],
       prompts: [],
       subtitleSetting: {},
       tranboxSetting: {},
@@ -32,6 +44,14 @@ jest.mock("./SubtitleSegmentationPlayground", () => {
     React.createElement("div", { "data-testid": "segmentation-tab" });
 });
 
+jest.mock("./TerminologyPlayground", () => {
+  const React = require("react");
+  return (props) => {
+    mockTerminology(props);
+    return React.createElement("div", { "data-testid": "terminology-tab" });
+  };
+});
+
 test("moves the existing translator into the text tab and exposes segmentation testing", async () => {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -52,6 +72,20 @@ test("moves the existing translator into the text tab and exposes segmentation t
   expect(
     container.querySelector('[data-testid="segmentation-tab"]')
   ).not.toBeNull();
+  act(() => root.unmount());
+});
+
+test("passes the apiSlugs storage key to the translation test form", async () => {
+  mockTranForm.mockClear();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  // TranForm 收到 Playground 专属的接口选择持久化键（刷新后多选接口回填）。
+  const props = mockTranForm.mock.calls.at(-1)[0];
+  expect(props.apiSlugsStorageKey).toBe("kt-playground-api-slugs");
+
   act(() => root.unmount());
 });
 
@@ -95,4 +129,366 @@ test("keeps the original input while toggling request-only normalization", async
     "First line Second line\n\nNext paragraph"
   );
   act(() => root.unmount());
+});
+
+test("mounts the terminology tab and forwards shared text state to it", async () => {
+  mockTranForm.mockClear();
+  mockTerminology.mockClear();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  const translationTab = [...container.querySelectorAll('[role="tab"]')].find(
+    (tab) => tab.textContent === "文本翻译"
+  );
+  const terminologyTab = [...container.querySelectorAll('[role="tab"]')].find(
+    (tab) => tab.textContent === "专业术语"
+  );
+  expect(terminologyTab).not.toBeUndefined();
+
+  // 点击新页签后确实挂载 TerminologyPlayground（替身以 data-testid 标识）。
+  await act(async () => {
+    terminologyTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(
+    container.querySelector('[data-testid="terminology-tab"]')
+  ).not.toBeNull();
+  expect(container.querySelector('[data-testid="translation-tab"]')).toBeNull();
+
+  // 共享回调正确传入新组件（text 由 state 提升共享，不通过 prop 传递）。
+  let props = mockTerminology.mock.calls.at(-1)[0];
+  expect(props.text).toBeUndefined();
+  expect(typeof props.setText).toBe("function");
+  expect(typeof props.setActiveTab).toBe("function");
+  // 父组件把 resolve 后的 resolvedTransApis 传给 TerminologyPlayground（与 TranForm 一致）。
+  expect(Array.isArray(props.transApis)).toBe(true);
+  // resolvedTransApis 中 batchPromptSlug 被展开为聚合翻译提示词。
+  const forwarded = props.transApis[0];
+  expect(forwarded.apiSlug).toBe("openai");
+  expect(forwarded.useBatchFetch).toBe(true);
+  expect(forwarded.systemPrompt).toContain("Act as a translation API");
+
+  // 先回翻译页签写入文本，再切回术语页签，确认共享 text 通过 setText 提升正确更新。
+  await act(async () => {
+    translationTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  act(() => {
+    mockTranForm.mock.calls.at(-1)[0].setText("Hello world");
+  });
+  await act(async () => {
+    terminologyTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  // TerminologyPlayground 不接收 text prop（text 由 state 提升，经 setText 共享）。
+  props = mockTerminology.mock.calls.at(-1)[0];
+  expect(props.text).toBeUndefined();
+
+  // 新组件通过 setText 修改共享文本后，切换页签再回来文本仍然保留在 TraceForm 中。
+  act(() => {
+    mockTerminology.mock.calls.at(-1)[0].setText("Hello replaced");
+  });
+  await act(async () => {
+    translationTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(mockTranForm.mock.calls.at(-1)[0].text).toBe("Hello replaced");
+
+  // setActiveTab 回调实际生效：从术语页签调用后渲染出翻译页签。
+  act(() => {
+    mockTerminology.mock.calls.at(-1)[0].setActiveTab("translation");
+  });
+  expect(container.querySelector('[data-testid="terminology-tab"]')).toBeNull();
+  expect(
+    container.querySelector('[data-testid="translation-tab"]')
+  ).not.toBeNull();
+  expect(mockTranForm.mock.calls.at(-1)[0].text).toBe("Hello replaced");
+
+  act(() => root.unmount());
+});
+
+test("keeps the terminology draft across tab round-trips (编辑术语 → 切走 → 返回)", async () => {
+  mockTerminology.mockClear();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  const termsTab = () =>
+    [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "专业术语"
+    );
+  const translationTab = () =>
+    [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "文本翻译"
+    );
+
+  // 进入术语页签。
+  await act(async () => {
+    termsTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  // 用户编辑术语草稿（父级状态提升，不因子组件卸载而销毁）。
+  act(() => {
+    mockTerminology.mock.calls.at(-1)[0].setTermsDraft("API,接口;APIKey");
+    mockTerminology.mock.calls.at(-1)[0].setTermDraftTouched(true);
+    mockTerminology.mock.calls.at(-1)[0].setTermSeed("3");
+  });
+
+  // 切到翻译页签（术语页签子组件卸载）。
+  await act(async () => {
+    translationTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(container.querySelector('[data-testid="terminology-tab"]')).toBeNull();
+
+  // 返回术语页签：草稿完整保留（术语、touched 标记、seed）。
+  await act(async () => {
+    termsTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  const props = mockTerminology.mock.calls.at(-1)[0];
+  expect(props.termsDraft).toBe("API,接口;APIKey");
+  expect(props.termDraftTouched).toBe(true);
+  expect(props.termSeed).toBe("3");
+
+  act(() => root.unmount());
+});
+
+test("preserves the terminology draft across the send-to-translation flow", async () => {
+  mockTerminology.mockClear();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  const termsTab = () =>
+    [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "专业术语"
+    );
+  await act(async () => {
+    termsTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  // 编辑草稿并发送原文到翻译页签。
+  act(() => {
+    mockTerminology.mock.calls.at(-1)[0].setTermsDraft("GPT;GPTs,智能体集合");
+    mockTerminology.mock.calls.at(-1)[0].setTermDraftTouched(true);
+    mockTerminology.mock.calls
+      .at(-1)[0]
+      .setText("Please check the GPT and GPTs configuration in this document.");
+    mockTerminology.mock.calls.at(-1)[0].setActiveTab("translation");
+  });
+  // 翻译页签显示发送的原文。
+  expect(mockTranForm.mock.calls.at(-1)[0].text).toContain("GPT");
+
+  // 返回术语页签后，未保存的术语草稿仍然保留。
+  await act(async () => {
+    termsTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  const props = mockTerminology.mock.calls.at(-1)[0];
+  expect(props.termsDraft).toBe("GPT;GPTs,智能体集合");
+  expect(props.termDraftTouched).toBe(true);
+
+  act(() => root.unmount());
+});
+
+test("never leaks the terminology resize handle into other playground tabs", async () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+
+  // 遍历全部页签：无论切换到哪里，术语库的自定义缩放手柄都不得出现在
+  // 翻译、字幕断句等页面（其他 multiline 输入框保持原样，不共享该控件）。
+  const tabs = [...container.querySelectorAll('[role="tab"]')];
+  expect(tabs.length).toBeGreaterThanOrEqual(3);
+  for (const tab of tabs) {
+    await act(async () => {
+      tab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-resize-handle"]')
+    ).toBeNull();
+  }
+
+  act(() => root.unmount());
+});
+
+test("persists terminology drafts to localStorage across unmount/remount", async () => {
+  mockTerminology.mockClear();
+  // 清空 localStorage，确保从干净状态开始。
+  window.localStorage.removeItem("kt-playground-terms-draft");
+  window.localStorage.removeItem("kt-playground-aiterms-draft");
+
+  const render = () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => root.render(<Playground />));
+    return { container, root };
+  };
+
+  // 第一次挂载：编辑两个草稿。
+  let { container, root } = render();
+  const termsTab = () =>
+    [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "专业术语"
+    );
+  await act(async () => {
+    termsTab().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  act(() => {
+    mockTerminology.mock.calls.at(-1)[0].setTermsDraft("API,接口");
+    mockTerminology.mock.calls
+      .at(-1)[0]
+      .setAiTermsDraft("API,Application Interface");
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  // 卸载组件（模拟切走路由）。
+  act(() => root.unmount());
+  document.body.removeChild(container);
+
+  // localStorage 已写入。
+  expect(window.localStorage.getItem("kt-playground-terms-draft")).toBe(
+    "API,接口"
+  );
+  expect(window.localStorage.getItem("kt-playground-aiterms-draft")).toBe(
+    "API,Application Interface"
+  );
+
+  // 第二次挂载：两个草稿被回填，且 termDraftTouched 为 true（不被规则覆盖）。
+  ({ container, root } = render());
+  const termsTab2 = () =>
+    [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "专业术语"
+    );
+  await act(async () => {
+    termsTab2().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  let props = mockTerminology.mock.calls.at(-1)[0];
+  expect(props.termsDraft).toBe("API,接口");
+  expect(props.aiTermsDraft).toBe("API,Application Interface");
+  expect(props.termDraftTouched).toBe(true);
+
+  act(() => root.unmount());
+  window.localStorage.removeItem("kt-playground-terms-draft");
+  window.localStorage.removeItem("kt-playground-aiterms-draft");
+});
+
+test("does not mark an empty or whitespace-only restored draft as touched", async () => {
+  mockTerminology.mockClear();
+  window.localStorage.setItem("kt-playground-terms-draft", "");
+  window.localStorage.removeItem("kt-playground-aiterms-draft");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Playground />));
+  const termsTab = [...container.querySelectorAll('[role="tab"]')].find(
+    (tab) => tab.textContent === "专业术语"
+  );
+  await act(async () => {
+    termsTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  // 空串草稿不标记已编辑：术语页挂载时仍可执行默认填入示例 + 例句自动生成。
+  expect(mockTerminology.mock.calls.at(-1)[0].termDraftTouched).toBe(false);
+  act(() => root.unmount());
+  window.localStorage.removeItem("kt-playground-terms-draft");
+  window.localStorage.removeItem("kt-playground-aiterms-draft");
+});
+
+describe("draft persistence debounce", () => {
+  // 断言用键字面量（与生产实现同值）。
+  const TERMS_KEY = "kt-playground-terms-draft";
+  const AI_TERMS_KEY = "kt-playground-aiterms-draft";
+
+  // act 回调内以具名中转函数挂载：testing-library/no-unnecessary-act 按
+  // 标识符名子串匹配 TL 工具（含 "render" 子串的名称一律命中），act 直接
+  // 包裹 render 名称调用会被误报，故经由不含该子串的中转函数。
+  const mountIntoRoot = (root) => {
+    root.render(<Playground />);
+  };
+  const mountView = () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    act(() => {
+      mountIntoRoot(root);
+    });
+    return { host, root };
+  };
+  const openTermsTab = async (host) => {
+    const termsTab = [...host.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent === "专业术语"
+    );
+    act(() => {
+      termsTab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    window.localStorage.removeItem(TERMS_KEY);
+    window.localStorage.removeItem(AI_TERMS_KEY);
+    document.body.innerHTML = "";
+  });
+
+  test("C2 Red：settle 前零落盘，settle 后 trailing 恰好一次写入最终值", async () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    const termsCalls = () =>
+      setItemSpy.mock.calls.filter(([key]) => key === TERMS_KEY);
+
+    const { host, root } = mountView();
+    await openTermsTab(host);
+
+    // 连击三次草稿输入（每次触发一次 effect 调度）。
+    act(() => {
+      mockTerminology.mock.calls.at(-1)[0].setTermsDraft("A");
+    });
+    act(() => {
+      mockTerminology.mock.calls.at(-1)[0].setTermsDraft("B");
+    });
+    act(() => {
+      mockTerminology.mock.calls.at(-1)[0].setTermsDraft("C");
+    });
+    // 防抖窗口内不得有任何同步落盘（旧实现 mount + 每击键各写一次 → Red）。
+    expect(termsCalls()).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    // trailing 语义：settle 后恰好一次，且只写最终值 "C"。
+    const settled = termsCalls();
+    expect(settled).toHaveLength(1);
+    expect(settled[0][1]).toBe("C");
+
+    act(() => root.unmount());
+  });
+
+  test("C2 回归锁定：unmount 同步 flush 最终值且 cancel 未决防抖（无幽灵写盘）", async () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    const termsCalls = () =>
+      setItemSpy.mock.calls.filter(([key]) => key === TERMS_KEY);
+
+    const { host, root } = mountView();
+    await openTermsTab(host);
+
+    act(() => {
+      mockTerminology.mock.calls.at(-1)[0].setTermsDraft("final");
+    });
+
+    // 不推进 timer 直接卸载：卸载 flush 必须同步落盘（既有持久化语义）。
+    act(() => root.unmount());
+    expect(window.localStorage.getItem(TERMS_KEY)).toBe("final");
+
+    // 推进一个防抖周期：cancel 生效，不得再有幽灵写盘。
+    const callsAfterUnmount = termsCalls().length;
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(termsCalls()).toHaveLength(callsAfterUnmount);
+  });
 });

--- a/src/views/Options/TerminologyPlayground.js
+++ b/src/views/Options/TerminologyPlayground.js
@@ -1,0 +1,2947 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import Collapse from "@mui/material/Collapse";
+import FormHelperText from "@mui/material/FormHelperText";
+import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import { useTheme, alpha } from "@mui/material/styles";
+import Check from "@mui/icons-material/Check";
+import CheckCircle from "@mui/icons-material/CheckCircle";
+import Close from "@mui/icons-material/Close";
+import Cancel from "@mui/icons-material/Cancel";
+import Warning from "@mui/icons-material/Warning";
+import RemoveCircle from "@mui/icons-material/RemoveCircle";
+import Remove from "@mui/icons-material/Remove";
+import HelpOutline from "@mui/icons-material/HelpOutline";
+import DataObjectIcon from "@mui/icons-material/DataObject";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import SubjectIcon from "@mui/icons-material/Subject";
+import {
+  API_SPE_TYPES,
+  BUILTIN_PLACEHOLDERS,
+  DEFAULT_TRANBOX_SETTING,
+  GLOBAL_KEY,
+  OPT_LANGS_MAP,
+  OPT_LANGS_TO_REVERSED as OPT_LANGS_TO,
+  OPT_TRANS_CUSTOMIZE,
+  OPT_TRANS_QWENMT,
+  defaultSystemPrompt,
+  defaultSystemPromptXml,
+  defaultSystemPromptLines,
+  defaultNobatchUserPrompt,
+} from "../../config";
+import { apiTranslate } from "../../apis";
+import { useAlert } from "../../hooks/Alert";
+import { useI18n } from "../../hooks/I18n";
+import { useRules } from "../../hooks/Rules";
+import { useSetting } from "../../hooks/Setting";
+import { isWeb } from "../../libs/client";
+import { logger } from "../../libs/log";
+import { matchRule } from "../../libs/rules";
+import { debounce } from "../../libs/utils";
+import { parseAITerms } from "../../libs/utils";
+import {
+  FATAL_DIAGNOSTIC_TYPES,
+  applyNaiveReplace,
+  applyTermReplace,
+  parseTerms,
+} from "../../libs/terms";
+import {
+  assertTermReplacements,
+  detectTermConflicts,
+  generateTermTestText,
+  getDiagnosticSampleTerms,
+  joinIntoParagraph,
+  selectDisplayedResults,
+} from "../../libs/termTestUtils";
+
+// 占位符格式由 apiSetting.placeholder 配置决定，默认取内置第一项 "{ }" → 生成 {1}、{2}…
+const [PLACEHOLDER_START, PLACEHOLDER_END] = BUILTIN_PLACEHOLDERS[0].split(" ");
+
+// 接口条目的运行时必需默认字段（2026-08-20 根因修复）。
+// 生产引擎的 #apiSetting 直接从 transApis 条目读取，不做默认字段合并
+// （translator.js #apiSetting: #apisMap.get(apiSlug) || DEFAULT_API_SETTING）。
+// 缺 placeholder 会让 #placeholderConfig 的 placeholder.split(" ") 抛 TypeError，
+// 整页翻译在发请求前就失败。真实扩展条目由设置页基于 defaultApi 构建；
+// Playground 做真实 AI 测试前，必须在所有读取点补齐这些字段，否则必然复现同一崩溃。
+const API_RUNTIME_DEFAULTS = {
+  placeholder: "{ }", // BUILTIN_PLACEHOLDERS[0]
+  placetag: "i", // BUILTIN_PLACETAGS[0]
+  placetagFormat: "compact",
+  rootMargin: 2000, // defaultApi.rootMargin
+  transAllnow: false, // defaultApi.transAllnow
+  batchPromptSlug: "batch-translation-json",
+  subtitlePromptSlug: "subtitle-segmentation",
+  dictPromptSlug: "dictionary-en-zh",
+  nobatchPromptSlug: "nobatch-translation",
+  useBatchFetch: false,
+  useStream: false,
+  streamRenderMode: "disabled",
+  fetchLimit: 5,
+  fetchInterval: 1500,
+  httpTimeout: 10000,
+  batchInterval: 0,
+  batchSize: 100,
+  batchLength: 4000,
+  batchConcurrency: 1,
+};
+
+/** 为单条接口配置补齐运行时必需默认字段（与真实引擎测试台 harness 的补齐一致）。 */
+const fillApiDefaults = (api) => ({ ...API_RUNTIME_DEFAULTS, ...api });
+
+// 冲突矩阵 4 类固定演示用例（8 个术语，4 组独立冲突对，覆盖全部四类矩阵）。
+// 从 termTestUtils 获取，确保与单元测试共用同一套 fixture。
+const CONFLICT_MATRIX_SAMPLE = getDiagnosticSampleTerms();
+
+// 与翻译器 #serializeForTranslation 的空译文语义一致：无译文时保留原文。
+const REPLACER = (term, fullMatch) => term.value || fullMatch;
+
+// UI 默认展示上限（完整计算结果与 UI 展示分离，失败优先）。
+const DISPLAY_LIMIT = 4;
+
+// 敏感键集合（大小写不敏感匹配）。
+const SENSITIVE_KEYS = new Set([
+  "authorization",
+  "api-key",
+  "x-api-key",
+  "apikey",
+  "key",
+  "access_token",
+  "token",
+]);
+
+/** 递归打码敏感键值。 */
+function maskSensitiveJson(obj) {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  const copy = Array.isArray(obj) ? [...obj] : { ...obj };
+  for (const key of Object.keys(copy)) {
+    const val = copy[key];
+    if (typeof val === "string" && SENSITIVE_KEYS.has(key.toLowerCase())) {
+      if (val.startsWith("Bearer ")) {
+        copy[key] = `Bearer ${val.slice(7, 13)}****`;
+      } else {
+        copy[key] = `${val.slice(0, 4)}****`;
+      }
+    } else if (typeof val === "object" && val !== null) {
+      copy[key] = maskSensitiveJson(val);
+    }
+  }
+  return copy;
+}
+
+/** 把 URL query 里的 key / api_key 等参数值打码。 */
+function maskUrl(url) {
+  if (typeof url !== "string") return url;
+  try {
+    const u = new URL(url);
+    for (const [key] of u.searchParams) {
+      const lower = key.toLowerCase();
+      if (
+        lower === "key" ||
+        lower === "api_key" ||
+        lower === "apikey" ||
+        lower === "token"
+      ) {
+        u.searchParams.set(key, "****");
+      }
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+/** 递归截断超长字符串，保留前 maxLen 字符；截断后缀文案走 i18n。 */
+function truncateLongStrings(obj, maxLen, i18n) {
+  if (typeof obj === "string") {
+    if (obj.length > maxLen) {
+      const suffix = formatI18n(
+        i18n,
+        "terminology_playground_truncated",
+        "…[已省略 {n} 字符]",
+        { n: obj.length - maxLen }
+      );
+      return `${obj.slice(0, maxLen)}${suffix}`;
+    }
+    return obj;
+  }
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (Array.isArray(obj))
+    return obj.map((item) => truncateLongStrings(item, maxLen, i18n));
+  const copy = {};
+  for (const key of Object.keys(obj)) {
+    copy[key] = truncateLongStrings(obj[key], maxLen, i18n);
+  }
+  return copy;
+}
+
+/** 把 init.body 归一为可展示对象。 */
+function parseBody(body) {
+  if (body === null || body === undefined) return null;
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return body;
+    }
+  }
+  return body;
+}
+
+/** JSON 格式化展示，字符串原样返回。 */
+function stringifyForDisplay(obj) {
+  if (typeof obj === "string") return obj;
+  return JSON.stringify(obj, null, 2);
+}
+
+// 截断常量（D6）
+const SYSTEM_PROMPT_MAX = 80;
+const GENERIC_MAX = 1200;
+const RESPONSE_MAX = 300;
+
+/** 递归打码，跳过 glossary 与 terms 子树（D7）。 */
+function maskForDisplay(obj, skipKeys = ["glossary", "terms"]) {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== "object") return obj;
+  if (!Array.isArray(obj)) {
+    const proto = Object.getPrototypeOf(obj);
+    // 仅拦"零 own 可枚举键且原型非 Object.prototype"的真 {} 场景
+    // （原生 Response / Date / Map / 空类实例）：展开必得 {}，诚实呈现类型标签。
+    // 带 own 可枚举键的类实例保持既有展开 + 掩码显示（E1 窄门闸，零旁支行为变化）。
+    // Object.create(null)（proto===null）仍按纯对象。
+    if (
+      proto !== Object.prototype &&
+      proto !== null &&
+      Object.keys(obj).length === 0
+    ) {
+      return {
+        __type: obj?.constructor?.name || "Object",
+        ownKeys: 0,
+      };
+    }
+  }
+  const copy = Array.isArray(obj) ? [...obj] : { ...obj };
+  for (const key of Object.keys(copy)) {
+    if (skipKeys.includes(key.toLowerCase())) continue;
+    const val = copy[key];
+    if (typeof val === "string" && SENSITIVE_KEYS.has(key.toLowerCase())) {
+      if (val.startsWith("Bearer ")) {
+        copy[key] = `Bearer ${val.slice(7, 13)}****`;
+      } else {
+        copy[key] = `${val.slice(0, 4)}****`;
+      }
+    } else if (typeof val === "object" && val !== null) {
+      copy[key] = maskForDisplay(val, skipKeys);
+    }
+  }
+  return copy;
+}
+
+/** 从 userMsg 三种互不兼容结构中提取纯文本（D5）。 */
+function extractUserPromptText(userMsg) {
+  if (typeof userMsg === "string") return userMsg;
+  if (!userMsg || typeof userMsg !== "object") return null;
+  if (typeof userMsg.content === "string") return userMsg.content;
+  if (Array.isArray(userMsg.content)) {
+    return (
+      userMsg.content
+        .map((c) => c?.text)
+        .filter(Boolean)
+        .join("") || null
+    );
+  }
+  if (Array.isArray(userMsg.parts)) {
+    return (
+      userMsg.parts
+        .map((p) => p?.text)
+        .filter(Boolean)
+        .join("") || null
+    );
+  }
+  return null;
+}
+
+/**
+ * 把请求体里「字符串形式的嵌套 JSON」就地展开成对象（C4/V5）。
+ *
+ * 用户消息在真实请求体里是字符串：批量模式下 messages[].content 是双重编码的 JSON
+ * （`'{"targetLanguage":"zh-CN",...}'`），直接打印满屏 \" 不可读；非批量是带字面
+ * \n 的长文本模板。这里对已知的三个承载位置尝试 JSON.parse，成功就换成对象
+ * （缩进打印天然可读），失败就原样保留 —— <pre> 的 whiteSpace: pre-wrap 会把真实
+ * 换行正常渲染出来。
+ *
+ * 跳过 role === "system"：系统提示词由 truncateRequestForDisplay 截到 SYSTEM_PROMPT_MAX，
+ * 不需要也不应该展开。必须在 truncateRequestForDisplay **之前**调用。
+ */
+function expandNestedUserMessage(bodyObj) {
+  if (!bodyObj || typeof bodyObj !== "object" || Array.isArray(bodyObj))
+    return bodyObj;
+  const tryParse = (text) => {
+    if (typeof text !== "string") return text;
+    const trimmed = text.trim();
+    // 只对看起来像 JSON 的字符串尝试解析，避免把普通文本误判
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return text;
+    try {
+      const parsed = JSON.parse(trimmed);
+      return parsed !== null && typeof parsed === "object" ? parsed : text;
+    } catch {
+      return text;
+    }
+  };
+  const copy = { ...bodyObj };
+  // OpenAI 兼容 / Claude / QwenMT：messages[*].content
+  if (Array.isArray(copy.messages)) {
+    copy.messages = copy.messages.map((msg) =>
+      msg &&
+      typeof msg === "object" &&
+      msg.role !== "system" &&
+      typeof msg.content === "string"
+        ? { ...msg, content: tryParse(msg.content) }
+        : msg
+    );
+  }
+  // Gemini generateContent：contents[*].parts[*].text
+  if (Array.isArray(copy.contents)) {
+    copy.contents = copy.contents.map((item) =>
+      item && typeof item === "object" && Array.isArray(item.parts)
+        ? {
+            ...item,
+            parts: item.parts.map((p) =>
+              p && typeof p === "object" && typeof p.text === "string"
+                ? { ...p, text: tryParse(p.text) }
+                : p
+            ),
+          }
+        : item
+    );
+  }
+  // Gemini Interactions：input[*].content[*].text
+  if (Array.isArray(copy.input)) {
+    copy.input = copy.input.map((item) =>
+      item && typeof item === "object" && Array.isArray(item.content)
+        ? {
+            ...item,
+            content: item.content.map((c) =>
+              c && typeof c === "object" && typeof c.text === "string"
+                ? { ...c, text: tryParse(c.text) }
+                : c
+            ),
+          }
+        : item
+    );
+  }
+  return copy;
+}
+
+/** 对请求体做差异化截断（D6）：四个系统提示词位置用 SYSTEM_PROMPT_MAX，其余 GENERIC_MAX。 */
+function truncateRequestForDisplay(reqObj, i18n) {
+  if (!reqObj || typeof reqObj !== "object") return reqObj;
+  const copy = { ...reqObj };
+  if (typeof copy.url === "string")
+    copy.url = truncateLongStrings(copy.url, GENERIC_MAX, i18n);
+  if (copy.headers && typeof copy.headers === "object") {
+    copy.headers = truncateLongStrings(copy.headers, GENERIC_MAX, i18n);
+  }
+  if (copy.body && typeof copy.body === "object" && !Array.isArray(copy.body)) {
+    const truncatedBody = {};
+    for (const key of Object.keys(copy.body)) {
+      const val = copy.body[key];
+      // systemInstruction 为 camelCase 对象带 parts 数组
+      if (
+        key === "systemInstruction" &&
+        val &&
+        typeof val === "object" &&
+        Array.isArray(val.parts)
+      ) {
+        truncatedBody[key] = {
+          ...val,
+          parts: val.parts.map((p) =>
+            p && typeof p === "object" && typeof p.text === "string"
+              ? {
+                  ...p,
+                  text: truncateLongStrings(p.text, SYSTEM_PROMPT_MAX, i18n),
+                }
+              : p
+          ),
+        };
+        // system_instruction 为 snake_case 纯字符串
+      } else if (key === "system_instruction" && typeof val === "string") {
+        truncatedBody[key] = truncateLongStrings(val, SYSTEM_PROMPT_MAX, i18n);
+        // system 为 Claude 字段，纯字符串
+      } else if (key === "system" && typeof val === "string") {
+        truncatedBody[key] = truncateLongStrings(val, SYSTEM_PROMPT_MAX, i18n);
+        // messages 数组：role==="system" 的 content 用 SYSTEM_PROMPT_MAX
+      } else if (key === "messages" && Array.isArray(val)) {
+        truncatedBody.messages = val.map((msg) => {
+          if (
+            msg &&
+            typeof msg === "object" &&
+            msg.role === "system" &&
+            typeof msg.content === "string"
+          ) {
+            return {
+              ...msg,
+              content: truncateLongStrings(
+                msg.content,
+                SYSTEM_PROMPT_MAX,
+                i18n
+              ),
+            };
+          }
+          return msg;
+        });
+      } else {
+        truncatedBody[key] = truncateLongStrings(val, GENERIC_MAX, i18n);
+      }
+    }
+    copy.body = truncatedBody;
+  } else {
+    copy.body = truncateLongStrings(copy.body, GENERIC_MAX, i18n);
+  }
+  return copy;
+}
+
+/** 传递状态渲染元数据（D2）：MUI 图标 + 语义色 Chip（未发出=红、值不一致=橙）。 */
+const DELIVERY_STATES = {
+  delivered: {
+    Icon: CheckCircle,
+    labelKey: "terminology_playground_delivery_delivered",
+    color: "success",
+    variant: "filled",
+  },
+  mismatch: {
+    Icon: Warning,
+    labelKey: "terminology_playground_delivery_mismatch",
+    color: "warning",
+    variant: "outlined",
+  },
+  missing: {
+    Icon: Cancel,
+    labelKey: "terminology_playground_delivery_missing",
+    color: "error",
+    variant: "outlined",
+  },
+  uncaptured: {
+    Icon: RemoveCircle,
+    labelKey: "terminology_playground_delivery_uncaptured",
+    color: "default",
+    variant: "outlined",
+  },
+};
+
+/** 结果表与摘要软术语块共用的状态 Chip：data-state 是给测试用的稳定锚点。 */
+function DeliveryChip({ state, actualValue, ...rest }) {
+  const i18n = useI18n();
+  const meta = DELIVERY_STATES[state] ?? DELIVERY_STATES.uncaptured;
+  const Icon = meta.Icon;
+  return (
+    <Chip
+      size="small"
+      color={meta.color}
+      variant={meta.variant}
+      icon={<Icon fontSize="small" />}
+      data-state={state}
+      label={
+        state === "mismatch"
+          ? formatI18n(
+              i18n,
+              "terminology_playground_delivery_value_wrap",
+              "{label}（实际值：{value}）",
+              {
+                label: i18n(meta.labelKey, ""),
+                value:
+                  actualValue ??
+                  i18n("terminology_playground_delivery_empty", "（空）"),
+              }
+            )
+          : i18n(meta.labelKey, "")
+      }
+      {...rest}
+    />
+  );
+}
+
+/** 根据快照判断术语注入通道（D3）。 */
+function buildInjectionChannel({ apiType, category, isBatch }, i18n) {
+  if (apiType === OPT_TRANS_CUSTOMIZE) {
+    return i18n(
+      "terminology_playground_channel_custom",
+      "自定义接口：不注入提示词与术语（需自行实现 reqHook）"
+    );
+  }
+  if (category === "qwenmt")
+    return i18n(
+      "terminology_playground_channel_qwenmt",
+      "服务端原生术语 translation_options.terms"
+    );
+  if (category === "ai" && isBatch)
+    return i18n(
+      "terminology_playground_channel_batch",
+      "批量 JSON glossary 字段"
+    );
+  if (category === "ai" && !isBatch)
+    return i18n(
+      "terminology_playground_channel_nobatch",
+      "非批量 {{glossary}} 占位符"
+    );
+  return "";
+}
+
+/** 根据快照计算提示词标签（Task 4）。 */
+function buildPromptLabel(
+  { apiType, category, isBatch, systemPrompt, nobatchUserPrompt },
+  i18n
+) {
+  if (category === "qwenmt" || apiType === OPT_TRANS_CUSTOMIZE) {
+    return i18n("terminology_playground_prompt_none", "不使用翻译提示词");
+  }
+  if (category === "ai" && isBatch) {
+    if (systemPrompt === defaultSystemPrompt)
+      return i18n("terminology_playground_prompt_json", "JSON 聚合翻译提示词");
+    if (systemPrompt === defaultSystemPromptXml)
+      return i18n("terminology_playground_prompt_xml", "XML 聚合翻译提示词");
+    if (systemPrompt === defaultSystemPromptLines)
+      return i18n("terminology_playground_prompt_line", "LINE 聚合翻译提示词");
+    return i18n(
+      "terminology_playground_prompt_custom_batch",
+      "自定义聚合提示词"
+    );
+  }
+  if (category === "ai" && !isBatch) {
+    const actualNobatch = nobatchUserPrompt ?? defaultNobatchUserPrompt;
+    return actualNobatch === defaultNobatchUserPrompt
+      ? i18n("terminology_playground_prompt_nobatch", "非批量翻译提示词")
+      : i18n(
+          "terminology_playground_prompt_custom_nobatch",
+          "自定义非批量提示词"
+        );
+  }
+  return "";
+}
+
+/** 根据快照检测每条术语的注入事实（D2）。 */
+function detectGlossaryDelivery({ rawRequest, entries, apiSnapshot }) {
+  const result = new Map();
+  const setState = (key, state, actualValue) =>
+    result.set(key, { state, actualValue });
+  if (rawRequest == null) {
+    entries.forEach(({ key }) => setState(key, "uncaptured"));
+    return result;
+  }
+  const { apiType, category, isBatch } = apiSnapshot;
+  if (apiType === OPT_TRANS_CUSTOMIZE) {
+    entries.forEach(({ key }) => setState(key, "missing"));
+    return result;
+  }
+  if (category === "qwenmt") {
+    const parsed = parseBody(rawRequest.body);
+    const terms = parsed?.translation_options?.terms ?? [];
+    entries.forEach(({ key, value }) => {
+      const hit = terms.find((t) => t.source === key);
+      if (!hit) return setState(key, "missing");
+      const expected = value || key;
+      return hit.target === expected
+        ? setState(key, "delivered")
+        : setState(key, "mismatch", hit.target);
+    });
+    return result;
+  }
+  const userText = extractUserPromptText(rawRequest.userMsg);
+  if (category === "ai" && isBatch) {
+    const promptObj = parseBody(userText);
+    const glossary = promptObj?.glossary ?? {};
+    entries.forEach(({ key, value }) => {
+      if (!Object.prototype.hasOwnProperty.call(glossary, key))
+        return setState(key, "missing");
+      return glossary[key] === value
+        ? setState(key, "delivered")
+        : setState(key, "mismatch", glossary[key]);
+    });
+    return result;
+  }
+  if (category === "ai" && !isBatch) {
+    const lines = (userText ?? "").split("\n");
+    entries.forEach(({ key, value }) => {
+      const prefix = `- ${key}:`;
+      const line = lines.find((l) => l.trim().startsWith(prefix));
+      if (!line) return setState(key, "missing");
+      const actual = line.slice(line.indexOf(":") + 1).trim();
+      return actual === value
+        ? setState(key, "delivered")
+        : setState(key, "mismatch", actual);
+    });
+    return result;
+  }
+  return result;
+}
+
+// 术语页把聚焦边框压回 1px（局部 sx），notch 遮罩条取 3（遮盖 1px border + 各 1px anti-aliasing）。
+
+// 说明类 Alert 的统一「caption 族」排版：正文跟随主题 caption 字号（rem，随
+// Theme.js 注入的 htmlFontSize 缩放），图标同步缩到 16px 等效 rem
+// —— MUI Alert 的 icon slot 硬编码 fontSize: 22（Alert.js:111），不缩会与 12px
+// 正文视觉失衡。三个接口 note 与结果区的启发式说明共用这一份口径。
+const NOTE_ALERT_SX = {
+  fontSize: (t) => t.typography.caption.fontSize,
+  "& .MuiAlert-icon": { fontSize: (t) => t.typography.pxToRem(16) },
+};
+
+// AI 测试接口选择的持久化键：仅用户手动选择时写入（默认逻辑不持久化），
+// 刷新/页签往返后回填；恢复值失效（接口被删除/禁用）时清除并回落默认。
+const LS_AI_API_SLUG_KEY = "kt-playground-ai-api-slug";
+const readStoredAiApiSlug = () => {
+  try {
+    const v = window.localStorage.getItem(LS_AI_API_SLUG_KEY);
+    return typeof v === "string" ? v : "";
+  } catch {
+    return "";
+  }
+};
+
+// AI 测试目标语言的持久化键：仅用户手动选择时写入，刷新/页签往返后回填。
+// 恢复值不是合法语言代码（脏值/旧版本残留）时立即清除并回落全局默认，
+// 与 LS_AI_API_SLUG_KEY 的失效清理语义一致，避免脏值永久留存。
+const LS_AI_TO_LANG_KEY = "kt-playground-ai-to-lang";
+const readStoredAiToLang = () => {
+  try {
+    const v = window.localStorage.getItem(LS_AI_TO_LANG_KEY);
+    if (typeof v === "string" && OPT_LANGS_MAP.has(v)) {
+      return v;
+    }
+    if (v !== null) {
+      window.localStorage.removeItem(LS_AI_TO_LANG_KEY);
+    }
+    return "";
+  } catch {
+    return "";
+  }
+};
+
+// AI 术语例句的源语言：例句正文恒由 generateTermTestText 的英文模板生成，
+// 模型端按系统提示词自行检测 sourceLanguage（请求不带 fromLang 字段），故此处固定标注英语。
+// 取纯语言名（"English - English" → "English"）避免重复冗长。
+const AI_EXAMPLE_SOURCE_LANG = "en";
+const AI_EXAMPLE_SOURCE_LANG_NAME = (
+  OPT_LANGS_MAP.get(AI_EXAMPLE_SOURCE_LANG) || AI_EXAMPLE_SOURCE_LANG
+).split(" - ")[0];
+
+// AI 测试状态的初始（无结果）形态：三处共用同一份定义，防止新增字段时漏改一处造成漂移。
+//   ① useState 初值；
+//   ② 点「测试」时的会话初始化基座（D2：每轮都是全新会话，摘要与 JSON 必然同源）；
+//   ③ 「取消」早退时的状态复位（D8：否则 status 永久停在 testing，按钮死锁到刷新）。
+// 视为只读常量：组件内只读不写（glossaryEntries 仅参与 map/length），不得就地修改。
+const AI_TEST_INITIAL_STATE = {
+  status: "idle", // idle | testing | done | error
+  requestText: "",
+  trText: "",
+  glossaryEntries: [],
+  error: "",
+  rawRequest: null,
+  rawResponse: null,
+  srLang: "",
+  srCode: "",
+  isSame: false,
+  toLang: "",
+  apiSnapshot: null,
+};
+
+/** 用命名占位符组装包含运行时数据的多语言文案。 */
+function formatI18n(i18n, key, fallback, values = {}) {
+  return Object.entries(values).reduce(
+    (text, [name, value]) =>
+      text.split(`{${name}}`).join(value === undefined ? "" : String(value)),
+    i18n(key, fallback)
+  );
+}
+
+/**
+ * 把一次致命诊断格式化为 UI 可读的多语言文案。
+ * 诊断核心（terms.js）只输出稳定 type + 结构化 detail；本函数按 type 映射主 I18N key
+ * 并插入 detail 参数，不再直接展示核心层硬编码中文 message。CLI 终端走 formatDiagnosticMessage。
+ */
+function formatFatalDiagnostic(diagnostic, i18n) {
+  const d = diagnostic || {};
+  const detail = d.detail || {};
+  const segmentIndex = detail.segmentIndex ?? d.segmentIndex ?? "?";
+  const segment = detail.segment ?? d.segment ?? "";
+  const key = detail.key ?? d.key ?? "";
+  switch (d.type) {
+    case "empty-source-term":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_empty_source_term",
+        "第 {segmentIndex} 段「{segment}」的逗号前没有源术语（空源术语）",
+        { segmentIndex, segment }
+      );
+    case "invalid-regex":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_invalid_regex",
+        "第 {segmentIndex} 段「{segment}」无法作为正则解析：{error}",
+        { segmentIndex, segment, error: detail.error ?? "" }
+      );
+    case "empty-matching-pattern":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_empty_matching_pattern",
+        "第 {segmentIndex} 段「{segment}」的正则可匹配空字符串（{key}），会在任意位置注入译文导致错乱，请改用非空匹配的正则",
+        { segmentIndex, segment, key }
+      );
+    case "zero-width-matching-pattern":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_zero_width_matching_pattern",
+        "第 {segmentIndex} 段「{segment}」的正则不消费任何字符（{key}），会在原文任意位置零宽注入译文导致错乱，请改用消费字符的正则",
+        { segmentIndex, segment, key }
+      );
+    case "conflicting-mapping":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_conflicting_mapping",
+        "第 {segmentIndex} 段「{segment}」与第 {prevIndex} 段「{key},{prevValue}」同源但译文不同（冲突映射）",
+        {
+          segmentIndex,
+          segment,
+          key,
+          prevIndex: detail.prevIndex ?? "?",
+          prevValue: detail.prevValue ?? "",
+        }
+      );
+    case "conflicting-pattern":
+      return formatI18n(
+        i18n,
+        "terminology_playground_diag_conflicting_pattern",
+        "第 {segmentIndexA} 段「{keyA}」与第 {segmentIndexB} 段「{keyB}」的正则同时命中同一原文「{literal}」（冲突映射），请转义或统一术语写法",
+        {
+          segmentIndexA: detail.segmentIndexA ?? "?",
+          keyA: detail.keyA ?? "",
+          segmentIndexB: detail.segmentIndexB ?? "?",
+          keyB: detail.keyB ?? "",
+          literal: detail.literal ?? "",
+        }
+      );
+    default:
+      return String(d.type || "diagnostic");
+  }
+}
+
+/**
+ * 把字典里的 Markdown-lite 标记渲染成 JSX：**粗体** → <strong>，`代码` → <code>。
+ * 只支持这两种、不支持嵌套，足够覆盖本页说明文案；不引入 dangerouslySetInnerHTML。
+ * 已知边界：代码段内部含 *（如 `. + * ? ( ) [ ] \ | ^ $`）时，因 ** 分支先判且
+ * `[^`]+` 不贪婪，内部 * 不会误拆。
+ */
+function renderRichI18n(text) {
+  const parts = String(text).split(/(\*\*[^*]+\*\*|`[^`]+`)/g);
+  return parts.map((part, index) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return <strong key={index}>{part.slice(2, -2)}</strong>;
+    }
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return <code key={index}>{part.slice(1, -1)}</code>;
+    }
+    return part;
+  });
+}
+
+export { renderRichI18n, maskForDisplay };
+
+/**
+ * 按命中区间把替换结果渲染为带 <mark> 高亮的文本。
+ * 注意 text 必须是原始文本（span 区间记录的是原始文本位置），
+ * 渲染片段为命中的 replacement，最终视觉输出即"替换后文本"。
+ */
+function renderHighlighted(text, spans) {
+  const nodes = [];
+  let cursor = 0;
+  spans.forEach((span, index) => {
+    nodes.push(text.slice(cursor, span.start));
+    nodes.push(<mark key={index}>{span.replacement}</mark>);
+    cursor = span.end;
+  });
+  nodes.push(text.slice(cursor));
+  return nodes;
+}
+
+/**
+ * 专业术语专项预览测试页签。
+ * 只做本地术语替换预览（零网络）：自然语境测试文本 → 防抖实时重算 →
+ * 修复前/后对比 → 按冲突矩阵 4 类给出断言状态（图标 + 一行 message），
+ * 完整 detail 通过 logger 输出到控制台，遵循"UI 简短 + 控制台完整"范式。
+ *
+ * 规模控制：完整计算结果与 UI 展示分离，默认最多展示 4 条，失败优先。
+ * 同时包含开发态旧引擎失败诊断样例，用于验证错误状态的可识别性。
+ */
+export default function TerminologyPlayground({
+  termsDraft,
+  setTermsDraft,
+  termDraftTouched,
+  setTermDraftTouched,
+  termSeed,
+  setTermSeed,
+  aiTermsDraft,
+  setAiTermsDraft,
+  transApis = [],
+}) {
+  const i18n = useI18n();
+  const alert = useAlert();
+  const theme = useTheme();
+  // 表格分隔线：原先写死 #ccc/#eee，深色模式下几乎不可见。用主题 token 取代，
+  // 表头线比行线略强（alpha 0.28 vs divider 0.12）以保留原有层次。
+  const tableHeadBorder = `1px solid ${alpha(theme.palette.text.primary, 0.28)}`;
+  const tableRowBorder = `1px solid ${theme.palette.divider}`;
+  const { setting } = useSetting();
+  const { list: userRules } = useRules();
+  // 术语/seed 草稿由父级 Playground 持有并随页签切换保留（不持久化、不写入正式规则）。
+  const [computed, setComputed] = useState(null);
+  const [loadError, setLoadError] = useState("");
+  // 跟踪用户是否在异步初始加载完成前编辑了输入框，避免覆盖用户已编辑内容。
+  const hasUserEdited = useRef(false);
+  // 输入框采用原生 resize:vertical 缩放，不引入自定义手柄。
+
+  // 本地重算：解析 → 自然文本生成 → 结构化断言，并把完整 detail 打到控制台。
+  // seed 用于例句轮换（同一 seed 确定不变；UI"换一个例句"递增 seed）。
+  const runCompute = useMemo(
+    () =>
+      (value, seed = "") => {
+        // Playground 显式请求完整诊断（含 O(n²) 跨术语 conflicting-pattern 分析）
+        const parsed = parseTerms(value, { fullDiagnostics: true });
+
+        // 存在致命诊断时：不生成用例，记录诊断并显示错误
+        if (parsed.hasErrors) {
+          const fatalDiagnostics = parsed.diagnostics.filter((d) =>
+            FATAL_DIAGNOSTIC_TYPES.has(d.type)
+          );
+          logger.error(
+            "[TermPlayground] fatal invalid term segments in input:",
+            fatalDiagnostics
+          );
+          if (parsed.metaWarnings.length > 0) {
+            logger.info(
+              "[TermPlayground] metacharacter warnings:",
+              parsed.metaWarnings
+            );
+          }
+          setComputed({
+            parsed,
+            fatalDiagnostics,
+            metaWarnings: parsed.metaWarnings,
+            invalid: parsed.invalid,
+            hasErrors: true,
+          });
+          return;
+        }
+
+        // 冲突分析只算一次（统一计划 20260829 Task 4）：generateTermTestText
+        // 复用同一份结果（不传则其内部自算），uniqueConflictPairs / conflictKeys
+        // 也复用，避免 runCompute 内触发 3 次 O(n²) 分析。
+        const conflicts = detectTermConflicts(parsed);
+        const cases = generateTermTestText(parsed, seed, { conflicts });
+        const results = cases.map((testCase) => ({
+          testCase,
+          assertion: assertTermReplacements(parsed, testCase),
+          fixed: applyTermReplace(testCase.text, parsed.terms, REPLACER),
+          naive: applyNaiveReplace(testCase.text, parsed),
+        }));
+
+        // 完整计算结果统计（不受 UI 展示上限影响）。
+        const termCount = parsed.terms.length;
+        const conflictPairCount = cases.filter(
+          (c) => c.type === "conflict"
+        ).length;
+        const singleCaseCount = cases.filter((c) => c.type === "single").length;
+        const totalCaseCount = cases.length;
+        const passCount = results.filter((entry) => entry.assertion.ok).length;
+        const failCount = totalCaseCount - passCount;
+
+        // 唯一冲突对数（来自检测，非术语数除以二）；复用上方已算好的 conflicts。
+        const uniqueConflictPairs = conflicts.length;
+
+        // 独立术语数（未参与任何冲突的术语数量）。
+        const conflictKeys = new Set();
+        for (const c of conflicts) {
+          conflictKeys.add(c.short.key);
+          conflictKeys.add(c.long.key);
+        }
+        const independentTermCount = parsed.terms.filter(
+          (t) => !conflictKeys.has(t.key)
+        ).length;
+
+        // UI 展示规模控制。
+        const { displayed, hiddenFailCount, hiddenPassCount } =
+          selectDisplayedResults(results, { limit: DISPLAY_LIMIT });
+
+        // 控制台输出完整所有 issue/detail，不受 UI 展示上限影响。
+        logger.info("[TermPlayground]", {
+          termCount,
+          uniqueConflictPairs,
+          independentTermCount,
+          conflictPairCount,
+          singleCaseCount,
+          totalCaseCount,
+          passCount,
+          failCount,
+          displayedCount: displayed.length,
+          hiddenFailCount,
+          hiddenPassCount,
+        });
+        const allIssues = results.flatMap((entry) => entry.assertion.issues);
+        if (allIssues.length > 0) {
+          logger.error("[TermPlayground]", allIssues);
+        }
+
+        setComputed({
+          parsed,
+          cases,
+          results,
+          displayed,
+          invalid: parsed.invalid,
+          metaWarnings: parsed.metaWarnings,
+          hasErrors: false,
+          summary: {
+            termCount,
+            uniqueConflictPairs,
+            independentTermCount,
+            conflictPairCount,
+            singleCaseCount,
+            totalCaseCount,
+            passCount,
+            failCount,
+            displayedCount: displayed.length,
+            hiddenFailCount,
+            hiddenPassCount,
+          },
+        });
+      },
+    []
+  );
+
+  // 输入变化后 300ms 内没有再次输入才重算，避免每敲一个字符都做全量断言。
+  const recompute = useMemo(() => debounce(runCompute, 300), [runCompute]);
+
+  // 卸载时取消未执行的防抖任务，避免在已卸载的组件上 setState。
+  useEffect(() => {
+    return () => {
+      recompute.cancel();
+    };
+  }, [recompute]);
+
+  // 规则加载（恢复 activeRuleData / initial terms）：与用户草稿覆盖解耦。
+  // touched 只阻止 setTermsDraft 覆盖草稿，不阻止 matchRule() 恢复规则元数据——
+  // activeRuleData 是子组件本地状态，页签往返会随卸载消失，必须每次挂载按当前规则身份恢复，
+  // 否则规则级 aiTerms 与默认接口（规则 apiSlug）都会丢失。
+  // 异步竞态：matchRule 完成前用户已编辑时，仍写回与当前规则身份一致的只读元数据，
+  // 但绝不覆盖草稿；卸载（cancelled）后不得写 state。
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const globalRule =
+        userRules?.find((rule) => rule.pattern === GLOBAL_KEY) || null;
+      let rule = null;
+      let loadError = null;
+      try {
+        rule = await matchRule(window.location.href, {
+          injectRules: setting?.injectRules,
+          subrulesList: setting?.subrulesList,
+        });
+      } catch (error) {
+        loadError = error;
+        // 规则加载失败：回退到全局规则（元数据与初始术语来源）。
+        rule = globalRule;
+      }
+      if (cancelled) return;
+
+      // 只读规则元数据总是写回：规则身份由本次 matchRule 结果决定，
+      // 不受用户是否已编辑草稿影响（touched / hasUserEdited 只保护 termsDraft）。
+      setActiveRuleData(rule || null);
+      if (loadError) {
+        setLoadError(
+          formatI18n(
+            i18n,
+            "terminology_playground_rule_load_failed",
+            "当前规则术语加载失败，已回退到全局规则：{message}",
+            { message: loadError?.message || String(loadError) }
+          )
+        );
+      }
+
+      // termsDraft 覆盖仅限「无草稿」（未 touched 且用户未编辑）场景：
+      // 规则术语与全局术语都为空时默认填入冲突矩阵示例，保证例句自动生成。
+      if (hasUserEdited.current || termDraftTouched) return;
+      const ruleTerms = rule?.terms || "";
+      const initial = ruleTerms || CONFLICT_MATRIX_SAMPLE;
+      setTermsDraft(initial);
+      runCompute(initial, termSeed);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // 只在挂载时加载一次初始术语，避免 uiLang/规则列表变化时覆盖用户输入。
+    // 页签往返时 termDraftTouched 已由父级保留，据此只跳过草稿覆盖、不跳过元数据恢复。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 页签往返 + 已有草稿：首次挂载 computed 为 null 时补算例句（不覆盖草稿、
+  // 不跑空算）。与规则加载 effect 独立，避免规则加载与否影响例句生成。
+  useEffect(() => {
+    if (termDraftTouched && computed === null && (termsDraft || "").trim()) {
+      runCompute(termsDraft, termSeed);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [termDraftTouched, computed, termsDraft, termSeed]);
+
+  const handleTermsChange = (event) => {
+    const value = event.target.value;
+    hasUserEdited.current = true;
+    setTermDraftTouched(true);
+    setTermsDraft(value);
+    recompute(value, termSeed);
+  };
+
+  const handleLoadSample = () => {
+    hasUserEdited.current = true;
+    setTermDraftTouched(true);
+    setTermsDraft(CONFLICT_MATRIX_SAMPLE);
+    recompute(CONFLICT_MATRIX_SAMPLE, termSeed);
+  };
+
+  // 换一个例句：在有限模板集合内通过显式 seed 轮换（确定性、可复现），
+  // 不依赖随机数或模块缓存；同一 seed 必产生同一例句。
+  const handleRotateSeed = () => {
+    const nextSeed = String((Number(termSeed) || 0) + 1);
+    setTermSeed(nextSeed);
+    recompute(termsDraft, nextSeed);
+  };
+
+  // 「测试」按钮：对当前生成的例句跑一次本地术语替换，结果以顶部居中
+  // Snackbar 弹出（绿色=通过、红色=失败），样式与接口设置的测试弹窗一致。
+  const handleRunTest = () => {
+    if (!computed) return;
+    if (computed.hasErrors) {
+      alert.error(
+        i18n(
+          "terminology_playground_alert_invalid_terms",
+          "存在非法术语段，请先修正输入后再测试。"
+        )
+      );
+      return;
+    }
+    const entry = computed.results?.[0];
+    if (!entry) {
+      alert.error(
+        i18n("terminology_playground_alert_no_example", "未生成可测试的例句。")
+      );
+      return;
+    }
+    const { testCase, assertion, fixed } = entry;
+    if (assertion.ok) {
+      alert.success(
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+            {i18n("terminology_playground_alert_test_passed", "测试通过")}
+          </Typography>
+          <Typography variant="body2">
+            {i18n("terminology_playground_alert_example_label", "例句：")}
+            {testCase.text}
+          </Typography>
+          <Typography variant="body2">
+            {i18n("terminology_playground_alert_replaced_label", "替换后：")}
+            {renderHighlighted(testCase.text, fixed.spans)}
+          </Typography>
+        </Box>
+      );
+    } else {
+      alert.error(
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+            {i18n("terminology_playground_alert_test_failed", "测试失败")}
+          </Typography>
+          <Typography variant="body2">
+            {assertion.issues[0]?.message ||
+              i18n("terminology_playground_none", "（无）")}
+          </Typography>
+        </Box>
+      );
+    }
+  };
+
+  // 真实 AI 翻译测试：AI 术语例句 → glossary 合并 → 调 apiTranslate → 结果展示。
+  const handleRunAiTest = async () => {
+    if (!selectedApi) {
+      alert.error(
+        i18n(
+          "terminology_playground_alert_no_api",
+          "请先在顶部选择要测试的翻译接口。"
+        )
+      );
+      return;
+    }
+    if (selectedApiCategory !== "ai" && selectedApiCategory !== "qwenmt") {
+      alert.warning(
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+            {i18n(
+              "terminology_playground_alert_api_not_supported",
+              "该接口不支持 AI 专业术语"
+            )}
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 0.5 }}>
+            {formatI18n(
+              i18n,
+              "terminology_playground_alert_api_not_supported_body",
+              "{apiName} 是 {type}接口，不支持注入提示词，AI 专业术语（规则级/接口级）不会生效。 请选 AI 接口（OpenAI 兼容/Gemini/Claude 等）。",
+              {
+                apiName: selectedApi.apiName || selectedApi.apiType,
+                type:
+                  selectedApiCategory === "machine"
+                    ? i18n(
+                        "terminology_playground_api_type_machine",
+                        "机器翻译"
+                      )
+                    : i18n(
+                        "terminology_playground_api_type_traditional",
+                        "传统翻译"
+                      ),
+              }
+            )}
+          </Typography>
+        </Box>
+      );
+      return;
+    }
+    if (!aiExampleText) {
+      alert.error(
+        i18n(
+          "terminology_playground_alert_ai_terms_required",
+          "请先输入 AI 专业术语以生成测试例句。"
+        )
+      );
+      return;
+    }
+    const testText = aiExampleText;
+
+    // 1. Glossary 合并（用户输入优先，接口级覆盖规则级，规则级作为补充）。
+    //    合并顺序：rule.aiTerms → apiSetting.aiTerms → aiTermsDraft（用户输入最高优先级）。
+    //    这与生产引擎的 {rule, api} 合并一致，用户输入代替规则级参与测试。
+    const inputGlossary = parseAITerms(aiTermsDraft);
+    const ruleGlossary = parseAITerms(activeRuleData?.aiTerms || "");
+    const apiGlossary = parseAITerms(selectedApi?.aiTerms || "");
+    const mergedGlossary = {
+      ...ruleGlossary,
+      ...apiGlossary,
+      ...inputGlossary,
+    };
+    // 标记每个 key 的来源（input / rule / api），用于贡献展示。
+    const glossaryEntries = Object.entries(mergedGlossary).map(
+      ([key, value]) => {
+        // 反向查找最高优先级来源：input 优先，其次 api，最后 rule。
+        const source =
+          inputGlossary[key] !== undefined
+            ? "input"
+            : apiGlossary[key] !== undefined
+              ? "api"
+              : "rule";
+        return { source, key, value };
+      }
+    );
+
+    // 2. 发起真实 AI 翻译请求。
+    //    保留接口原始 useBatchFetch（AI 接口默认 true → 走 batch 聚合翻译提示词路径），
+    //    仅强制 useStream:false 走非流式 runNonStream，一次性测试更可预测稳定；
+    //    streamRenderMode 在非流式路径不被读取，无需覆盖。
+    //    aiTerms 置空：接口级术语已在上面折进 mergedGlossary，若再透传会在
+    //    genUserPrompt 里二次合并并反向覆盖用户输入（R2）。
+    //    useContext 置 false：handleTranslate 按 apiSlug 取全局 getMsgHistory 单例，
+    //    上一轮的问答会被注入下一轮 messages（用户抓包实证：第 2 轮出现上一轮 user +
+    //    空 assistant，第 3 轮首条被环形队列挤成 assistant 而违反协议报错）。
+    //    本页测的是术语注入而非对话能力，历史上下文是纯干扰，故整轮关闭。
+    //    副作用（已知且无害）：index.js 的 effectiveBatchConcurrency 不再被强制为 1，
+    //    队列 key 随之改变，本页因此拿到独立的批量队列实例，隔离性更好。
+    const controller = new AbortController();
+    aiAbortRef.current = controller;
+    // 目标语言优先取本页下拉（持久化于 localStorage），未选中时回落全局设置。
+    // fromLang 保持 "auto"：例句正文恒为英文模板，请求体本身不带 fromLang 字段，
+    // 由模型按系统提示词检测每个 segment 的 sourceLanguage 并回填（parseAIRes → srLang）。
+    const toLang =
+      aiToLang ||
+      setting?.tranboxSetting?.toLang ||
+      DEFAULT_TRANBOX_SETTING.toLang;
+    const testApiSetting = {
+      ...selectedApi,
+      useStream: false,
+      aiTerms: "",
+      useContext: false,
+    };
+    // 请求身份快照（D4）：结果区一切派生信息只读请求时快照，不读当前 selectedApi。
+    // 切换接口选择器不会重置结果区，若读 selectedApi 会输出与 rawRequest 矛盾的结论。
+    const isBatch =
+      !!selectedApi.useBatchFetch &&
+      API_SPE_TYPES.batch.has(selectedApi.apiType);
+    const apiSnapshot = {
+      apiName: selectedApi.apiName || selectedApi.apiType || "",
+      apiType: selectedApi.apiType,
+      category: selectedApiCategory,
+      isBatch,
+      model: selectedApi.model || "",
+      host: getApiHost(selectedApi),
+      maskedKey: getMaskedAuthSummary(selectedApi),
+      promptLabel: buildPromptLabel(
+        {
+          apiType: selectedApi.apiType,
+          category: selectedApiCategory,
+          isBatch,
+          systemPrompt: selectedApi.systemPrompt,
+          nobatchUserPrompt: selectedApi.nobatchUserPrompt,
+        },
+        i18n
+      ),
+      injectionChannel: buildInjectionChannel(
+        {
+          apiType: selectedApi.apiType,
+          category: selectedApiCategory,
+          isBatch,
+        },
+        i18n
+      ),
+    };
+    // 会话初始化（D2/D3）：以初始态为基座整体替换，本轮字段一次写入、上一轮
+    // 残留字段（rawRequest/rawResponse/trText/srLang 等）显式归零，
+    // 保证 done 之后请求摘要、请求 JSON、响应摘要、响应 JSON 必然同源于同一轮。
+    setAiTestState({
+      ...AI_TEST_INITIAL_STATE,
+      status: "testing",
+      requestText: testText,
+      glossaryEntries,
+      apiSnapshot,
+      toLang,
+    });
+    let capturedReq = null;
+    let capturedResp = null;
+    try {
+      const result = await apiTranslate({
+        text: testText,
+        fromLang: "auto",
+        toLang,
+        apiSetting: testApiSetting,
+        glossary: mergedGlossary,
+        useCache: false,
+        usePool: false,
+        textFormat: "html",
+        signal: controller.signal,
+        capture: {
+          onRequest: (input, init, userMsg) => {
+            capturedReq = {
+              url: input,
+              method: init?.method || "POST",
+              headers: init?.headers || {},
+              body: init?.body ?? null,
+              userMsg,
+            };
+          },
+          onResponse: (response) => {
+            capturedResp = response;
+          },
+        },
+      });
+      // 取消（D8）：复位为初始无结果态。只 return 不复位会把 status 永久留在
+      // "testing" —— 「测试」按钮永久禁用、「取消」按钮常驻，直到刷新页面。
+      if (controller.signal.aborted) {
+        setAiTestState(AI_TEST_INITIAL_STATE);
+        return;
+      }
+      const trText = result?.trText || "";
+      setAiTestState({
+        status: "done",
+        requestText: testText,
+        trText,
+        glossaryEntries,
+        error: "",
+        rawRequest: capturedReq,
+        rawResponse: capturedResp,
+        srLang: result?.srLang || "",
+        srCode: result?.srCode || "",
+        isSame: result?.isSame || false,
+        toLang,
+        apiSnapshot,
+      });
+    } catch (error) {
+      // 取消（D8）：与上面的 aborted 早退同一语义，复位而非留在 "testing"。
+      // 取消是用户主动行为，不弹错误 Snackbar、不落 error 态。
+      if (error?.name === "AbortError") {
+        setAiTestState(AI_TEST_INITIAL_STATE);
+        return;
+      }
+      // 用 Snackbar 展示错误信息（网络/HTTP 状态/接口字段缺失），不抛未捕获异常。
+      alert.error(
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+            {i18n(
+              "terminology_playground_alert_ai_test_failed",
+              "AI 翻译测试失败"
+            )}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{ mt: 0.5, fontFamily: "monospace", fontSize: 12 }}
+          >
+            {error?.message || String(error)}
+          </Typography>
+        </Box>
+      );
+      setAiTestState({
+        status: "error",
+        requestText: testText,
+        trText: "",
+        glossaryEntries,
+        error: error?.message || String(error),
+        rawRequest: capturedReq,
+        rawResponse: capturedResp,
+        srLang: "",
+        srCode: "",
+        isSame: false,
+        toLang,
+        apiSnapshot,
+      });
+    } finally {
+      aiAbortRef.current = null;
+    }
+  };
+
+  const handleCancelAiTest = () => {
+    aiAbortRef.current?.abort();
+  };
+
+  // AI 术语区专属示例：填入默认 AI 专业术语样例并生成例句（不依赖本地术语库）。
+  const handleAiLoadSample = () => {
+    setAiTermsDraft(
+      i18n(
+        "terminology_playground_terms_sample",
+        "zorp,数据管道\nquzzle,缓存节点"
+      )
+    );
+  };
+
+  // AI 例句换一个：递增 aiTermSeed 触发例句重新生成（与本地术语区 handleRotateSeed 一致）。
+  const handleAiRotateSeed = () => {
+    setAiTermSeed(String((Number(aiTermSeed) || 0) + 1));
+  };
+
+  // 用户手动切换测试接口：标记已触摸，默认逻辑不再覆盖；同时持久化到 localStorage
+  // （仅手动选择写入，默认逻辑选出的接口不持久化，避免规则改接口后仍恢复旧默认）。
+  const handleSelectApi = (event) => {
+    apiSelectionTouchedRef.current = true;
+    setSelectedApiSlug(event.target.value);
+    try {
+      if (event.target.value) {
+        window.localStorage.setItem(LS_AI_API_SLUG_KEY, event.target.value);
+      } else {
+        // 选择被清空：一并清除持久化键，避免留下过期值。
+        window.localStorage.removeItem(LS_AI_API_SLUG_KEY);
+      }
+    } catch {
+      // localStorage 不可用时静默降级：仅丢失跨刷新留存，不影响本页使用。
+    }
+  };
+
+  // 用户手动切换 AI 测试目标语言：写入 localStorage（清空则移除键），
+  // 与 handleSelectApi 同款失败静默降级。
+  const handleSelectAiToLang = (event) => {
+    const value = event.target.value;
+    setAiToLang(value);
+    try {
+      if (value) {
+        window.localStorage.setItem(LS_AI_TO_LANG_KEY, value);
+      } else {
+        window.localStorage.removeItem(LS_AI_TO_LANG_KEY);
+      }
+    } catch {
+      // localStorage 不可用时静默降级：仅丢失跨刷新留存，不影响本页使用。
+    }
+  };
+
+  // 卸载时清理未完成的 AI 测试请求。
+  useEffect(() => {
+    return () => {
+      aiAbortRef.current?.abort();
+      aiAbortRef.current = null;
+    };
+  }, []);
+
+  // 展示占位符格式：配置的分隔符 + n + 配置的结束分隔符（默认 {n}）。
+  const placeholderFormat = `${PLACEHOLDER_START}n${PLACEHOLDER_END}`;
+
+  // 当前例句（首个生成用例）及其通过/异常状态（供例句旁紧凑徽标）。
+  const exampleEntry =
+    computed && !computed.hasErrors ? computed.results?.[0] : null;
+  const exampleText = exampleEntry?.testCase?.text ?? "";
+  const exampleOk = exampleEntry?.assertion?.ok;
+
+  // AI 专业术语草稿（由父级 Playground 持有，跨页签/跨路由经 localStorage 临时留存）
+  const aiGlossary = useMemo(() => parseAITerms(aiTermsDraft), [aiTermsDraft]);
+  const aiGlossaryEntries = useMemo(
+    () => Object.entries(aiGlossary),
+    [aiGlossary]
+  );
+
+  // 真实 AI 翻译测试：接口选择 + 请求/结果状态。
+  // 接口列表来自父组件 resolve 后的 resolvedTransApis（含展开的 systemPrompt 等字段，
+  // 与 TranForm/SubtitleSegmentationPlayground 一致），过 fillApiDefaults 补齐运行时默认字段。
+  const availableApis = useMemo(() => {
+    const list = Array.isArray(transApis) ? transApis : [];
+    return list
+      .filter((api) => api && api.apiSlug && api.isDisabled !== true)
+      .map(fillApiDefaults);
+  }, [transApis]);
+  // AI 测试接口选择：首帧渲染即进行有效性归一化，确保永远向 MUI Select 传递合法 value。
+  // 1. 若 localStorage 恢复值仍在可用列表中 → 首帧直接选用；
+  // 2. 若恢复值已失效（如已删除/禁用）或不存在 → 首帧回落至第一个可用接口（或 "" 对应无接口占位项），
+  //    完全消除 MUI out-of-range 控制台 warning；
+  // 3. 失效键清理与规则级默认接口覆盖由下方 useEffect 异步完成。
+  const [selectedApiSlug, setSelectedApiSlug] = useState(() => {
+    const restored = readStoredAiApiSlug();
+    const valid =
+      restored && availableApis.some((api) => api.apiSlug === restored);
+    if (valid) return restored;
+    return availableApis[0]?.apiSlug || "";
+  });
+  // 挂载时恢复的接口（只读一次）：默认选择 effect 据此校验有效性，
+  // 校验后立即清空引用，避免后续 availableApis 变化时用过期恢复值误删用户新保存的选择。
+  const restoredApiSlugRef = useRef(null);
+  if (restoredApiSlugRef.current === null) {
+    restoredApiSlugRef.current = readStoredAiApiSlug();
+  }
+  // 用户是否手动改过接口选择：手动选择后不再被默认逻辑覆盖。
+  const apiSelectionTouchedRef = useRef(false);
+  // AI 测试目标语言：挂载时只读一次 localStorage（StrictMode 幂等，同 restoredApiSlugRef 先例），
+  // 无有效持久化值时回落全局 tranboxSetting.toLang —— 与本下拉引入前的行为完全一致。
+  const restoredToLangRef = useRef(null);
+  if (restoredToLangRef.current === null) {
+    restoredToLangRef.current = readStoredAiToLang();
+  }
+  const [aiToLang, setAiToLang] = useState(() => {
+    const restored = restoredToLangRef.current;
+    const valid = restored && OPT_LANGS_MAP.has(restored) ? restored : "";
+    return (
+      valid || setting?.tranboxSetting?.toLang || DEFAULT_TRANBOX_SETTING.toLang
+    );
+  });
+  // 当前匹配规则对象（含 rule.terms / rule.aiTerms / rule.apiSlug，用于默认接口与规则级 glossary）。
+  const [activeRuleData, setActiveRuleData] = useState(null);
+  // AI 测试状态：idle | testing | done | error（初始形态见 AI_TEST_INITIAL_STATE）
+  const [aiTestState, setAiTestState] = useState(AI_TEST_INITIAL_STATE);
+  const [showRequestRaw, setShowRequestRaw] = useState(false);
+  const [showResponseRaw, setShowResponseRaw] = useState(false);
+  const aiAbortRef = useRef(null);
+  // AI 术语说明「更多」折叠（U4/U6）：常显 3 短句，长说明默认折叠。
+  const [aiHelpOpen, setAiHelpOpen] = useState(false);
+  // 请求/响应面板为普通 Box 容器，不做拖高。
+  // AI 术语例句轮换 seed（与本地术语区 termSeed 语义一致："" = 缺省确定性行为，递增轮换）。
+  const [aiTermSeed, setAiTermSeed] = useState("");
+
+  // 「已发出」通道判定（D2/D3）：只读请求时快照，不做 JSON 子串搜索
+  // （例句必然包含术语 key，子串判定恒真、未发出不可达）。
+  const deliveryMap = useMemo(() => {
+    if (aiTestState.status !== "done" || !aiTestState.apiSnapshot) return null;
+    return detectGlossaryDelivery({
+      rawRequest: aiTestState.rawRequest,
+      entries: aiTestState.glossaryEntries,
+      apiSnapshot: aiTestState.apiSnapshot,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    aiTestState.status,
+    aiTestState.rawRequest,
+    aiTestState.glossaryEntries,
+    aiTestState.apiSnapshot,
+  ]);
+
+  // 接口类型分类：QwenMT 特例优先（虽属 machine 集合，但原生支持术语）。
+  const apiCategory = (apiType) => {
+    if (apiType === OPT_TRANS_QWENMT) return "qwenmt";
+    if (API_SPE_TYPES.ai.has(apiType)) return "ai";
+    if (API_SPE_TYPES.machine.has(apiType)) return "machine";
+    return "other";
+  };
+  const selectedApi =
+    availableApis.find((api) => api.apiSlug === selectedApiSlug) || null;
+  const selectedApiCategory = selectedApi
+    ? apiCategory(selectedApi.apiType)
+    : null;
+  // AI 术语例句：当 aiTermsDraft 非空时，用 parseAITerms 解析为 {key:value} 对象，
+  // 转成 [{key, value}] 数组，再调用 generateTermTestText 生成自然例句。
+  // 与本地术语区的区别：AI 术语不支持正则，用 parseAITerms 而非 parseTerms。
+  // 用 joinIntoParagraph 拼接全部用例（而非只取 cases[0]），保证每条术语都进入待翻译文本，
+  // 否则未被首条例句覆盖的术语物理上不可能被替换（R1 根因）。
+  const aiExampleText = useMemo(() => {
+    const trimmed = aiTermsDraft.trim();
+    if (!trimmed) return null;
+    const parsed = parseAITerms(trimmed);
+    const entries = Object.entries(parsed);
+    if (entries.length === 0) return null;
+    const termsArray = entries.map(([key, value]) => ({ key, value }));
+    // 统一计划 §2.3 字面兑现：冲突分析显式传入 { conflicts }（与本地术语区
+    // runCompute 同一调用形态）。detectTermConflicts 自带 WeakMap 引用缓存，
+    // 改前改后本路径均恰 1 次分析，非性能优化。
+    const cases = generateTermTestText(termsArray, aiTermSeed, {
+      conflicts: detectTermConflicts(termsArray),
+    });
+    return joinIntoParagraph(cases) || null;
+  }, [aiTermsDraft, aiTermSeed]);
+
+  // 从 apiSetting.url 提取 host（模型/接口摘要展示用）。
+  const getApiHost = (api) => {
+    try {
+      return new URL(api?.url || "").host;
+    } catch {
+      return api?.url || "";
+    }
+  };
+
+  // 鉴权摘要：打码 Key 的首段前若干字符。
+  const getMaskedAuthSummary = (api) => {
+    const key = api?.key || "";
+    if (!key) return "-";
+    const firstKey = key.split(/\n|,/)[0].trim();
+    return maskSensitiveJson({ key: firstKey }).key;
+  };
+
+  // 默认接口：优先取 localStorage 恢复的有效选择，其次当前匹配规则的 apiSlug，再次第一个启用接口。
+  // 用户手动选择后不再被默认逻辑覆盖。
+  useEffect(() => {
+    if (availableApis.length === 0) return;
+    const restored = restoredApiSlugRef.current;
+    if (restored) {
+      const restoredValid = availableApis.some(
+        (api) => api.apiSlug === restored
+      );
+      // 一次性校验：校验后立即清空引用，避免后续 availableApis 变化时
+      // 用过期的恢复值误删用户已重新保存的选择。
+      restoredApiSlugRef.current = "";
+      if (restoredValid) {
+        // 恢复的接口仍存在：视为已选择，默认逻辑不再覆盖。
+        apiSelectionTouchedRef.current = true;
+        if (selectedApiSlug !== restored) setSelectedApiSlug(restored);
+        return;
+      }
+      // 恢复的接口已被删除/禁用：清除失效持久化值，回落默认逻辑。
+      try {
+        window.localStorage.removeItem(LS_AI_API_SLUG_KEY);
+      } catch {
+        // 静默降级。
+      }
+    }
+    if (apiSelectionTouchedRef.current) return;
+    const ruleApi = activeRuleData?.apiSlug;
+    const preferred = availableApis.find((api) => api.apiSlug === ruleApi);
+    const next = (preferred || availableApis[0])?.apiSlug || "";
+    if (next && next !== selectedApiSlug) setSelectedApiSlug(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableApis, activeRuleData]);
+
+  return (
+    <Stack spacing={2} data-testid="terminology-tab-root">
+      {loadError && <Alert severity="warning">{loadError}</Alert>}
+      {isWeb && (
+        <Alert severity="warning" data-testid="terminology-web-note">
+          {i18n(
+            "terminology_playground_web_note",
+            "当前为 web 模式（普通浏览器标签页）：AI 翻译请求可能被浏览器 CORS 拦截（多数 AI 接口未开放跨域）。本地术语替换预览不受影响；真实 AI 翻译测试请在打包后的扩展（background 代发）或油猴（GM.xmlHttpRequest）环境中验证。"
+          )}
+        </Alert>
+      )}
+
+      {/* 真实 AI 翻译测试：接口选择器（顶部首个板块）。
+          原顶部三行「术语类型/配置位置/特点/生效范围」对照表已移除（窄屏累赘，
+          100% 宽表格只会压缩换行、永不横向滚动）；完整对照见 preview/专业术语.md，
+          唯一关键语义「机翻不支持 AI 专业术语」由下方 api_desc 承接。 */}
+      <Paper
+        variant="outlined"
+        sx={{ p: 2 }}
+        data-testid="terminology-api-selector"
+      >
+        <Typography variant="subtitle2" gutterBottom>
+          {i18n("terminology_playground_api_title", "接口选择")}
+        </Typography>
+        {/* 说明降到 caption（12px）与 subtitle2 标题（14px/600）形成字号层级，
+            文案必须与下方 apiCategory() 三分支一致：QwenMT 虽属 machine 集合但被
+            特判为可生效，不得归入"不支持"侧。 */}
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+          sx={{ mb: 1.5 }}
+        >
+          {i18n(
+            "terminology_playground_api_desc",
+            "机器翻译与传统翻译接口（Microsoft、DeepL、Google 等）不支持 AI 专业术语；AI 模型接口与 QwenMT 支持。"
+          )}
+        </Typography>
+        <TextField
+          select
+          fullWidth
+          size="small"
+          label={i18n("terminology_playground_api_label", "翻译接口")}
+          value={selectedApiSlug}
+          onChange={handleSelectApi}
+          data-testid="terminology-api-select"
+        >
+          {availableApis.length === 0 && (
+            <MenuItem disabled value="">
+              {i18n(
+                "terminology_playground_api_none",
+                "未配置可用接口，请先到「接口设置」页配置"
+              )}
+            </MenuItem>
+          )}
+          {availableApis.map((api) => (
+            <MenuItem key={api.apiSlug} value={api.apiSlug}>
+              {api.apiName || api.apiType || api.apiSlug}
+            </MenuItem>
+          ))}
+        </TextField>
+        {selectedApi && (
+          <Box sx={{ mt: 1 }}>
+            {selectedApiCategory === "machine" ||
+            selectedApiCategory === "other" ? (
+              <Alert
+                severity="warning"
+                sx={NOTE_ALERT_SX}
+                data-testid="terminology-api-machine-note"
+              >
+                {formatI18n(
+                  i18n,
+                  "terminology_playground_api_machine_note",
+                  "当前为{type}，AI 专业术语无法生效。",
+                  {
+                    type:
+                      selectedApiCategory === "machine"
+                        ? i18n(
+                            "terminology_playground_api_type_machine",
+                            "机器翻译"
+                          )
+                        : i18n(
+                            "terminology_playground_api_type_traditional",
+                            "传统翻译"
+                          ),
+                  }
+                )}
+              </Alert>
+            ) : selectedApiCategory === "qwenmt" ? (
+              <Alert
+                severity="info"
+                sx={NOTE_ALERT_SX}
+                data-testid="terminology-api-qwenmt-note"
+              >
+                {i18n(
+                  "terminology_playground_api_qwenmt_note",
+                  "当前为 QwenMT，AI 专业术语可生效。"
+                )}
+              </Alert>
+            ) : (
+              <Alert
+                severity="info"
+                sx={NOTE_ALERT_SX}
+                data-testid="terminology-api-ai-note"
+              >
+                {i18n(
+                  "terminology_playground_api_ai_note",
+                  "当前为 AI 翻译，AI 专业术语可生效。"
+                )}
+              </Alert>
+            )}
+          </Box>
+        )}
+      </Paper>
+
+      {/* 术语库输入区：格式与规则表单的 terms 字段一致，初始值取当前匹配规则，不持久化。 */}
+      <Paper variant="outlined" sx={{ p: 2 }} data-testid="terminology-config">
+        <Typography variant="subtitle2" gutterBottom>
+          {i18n("terminology_playground_title", "专业术语库（本地替换预览）")}
+        </Typography>
+        {/* 术语库输入区：格式与规则表单的 terms 字段一致，初始值取当前匹配规则，不持久化。
+            使用浏览器原生 resize:vertical 缩放（右下角斜纹 grip），不引入自定义手柄。 */}
+        <TextField
+          fullWidth
+          multiline
+          minRows={5}
+          maxRows={10}
+          value={termsDraft}
+          onChange={handleTermsChange}
+          label={i18n(
+            "terminology_playground_terms_label",
+            "术语库（键值对，每行或 ; 分隔）"
+          )}
+          inputProps={{
+            "aria-describedby": "terminology-terms-helper",
+          }}
+          sx={{
+            "& textarea": {
+              resize: "vertical",
+            },
+          }}
+          data-testid="terminology-terms-input"
+        />
+        {/* 术语格式说明 */}
+        <FormHelperText
+          id="terminology-terms-helper"
+          sx={{ margin: "3px 14px 0" }}
+        >
+          {i18n(
+            "terminology_playground_terms_helper",
+            "术语键按正则语义解析；译文留空 = 不翻译（保留原文）；重复键只保留首次；术语按正则语义在原文任意位置匹配（与生产一致），建议长度长的术语写在前面。"
+          )}
+        </FormHelperText>
+        {computed?.fatalDiagnostics?.length > 0 && (
+          <Alert
+            severity="error"
+            sx={{ mt: 2 }}
+            data-testid="terminology-invalid"
+          >
+            {formatI18n(
+              i18n,
+              "terminology_playground_invalid_terms",
+              "检测到 {count} 条非法术语段，未生成本地替换结果：{reasons}",
+              {
+                count: computed.fatalDiagnostics.length,
+                reasons: computed.fatalDiagnostics
+                  .map((d) => formatFatalDiagnostic(d, i18n))
+                  .join("；"),
+              }
+            )}
+          </Alert>
+        )}
+        {computed?.metaWarnings?.length > 0 && (
+          <Alert
+            severity="warning"
+            sx={{ mt: 2 }}
+            data-testid="terminology-meta-warning"
+          >
+            {formatI18n(
+              i18n,
+              "terminology_playground_meta_warning",
+              "{count} 个术语含未转义正则元字符（术语按正则语义解析）：{terms}。若要字面匹配，请在字符前加反斜杠，例如 Dr.whob 应写为 Dr\\.whob。",
+              {
+                count: computed.metaWarnings.length,
+                terms: computed.metaWarnings
+                  .map((w) => `「${w.key}」（${w.metas.join(" ")})`)
+                  .join("、"),
+              }
+            )}
+          </Alert>
+        )}
+        {computed?.hasErrors && (
+          <Alert
+            severity="info"
+            sx={{ mt: 2 }}
+            data-testid="terminology-invalid-state"
+          >
+            {formatI18n(
+              i18n,
+              "terminology_playground_invalid_state",
+              "存在被拒绝的非法段（已跳过，不影响仍可应用的合法术语）。为免误导，未生成整体“通过”摘要；仍可应用的合法术语：{terms}。完整诊断见控制台（logger.error [TermPlayground]）。",
+              {
+                terms:
+                  computed.parsed.terms.length > 0
+                    ? computed.parsed.terms
+                        .map((t) => `「${t.key}」`)
+                        .join("、")
+                    : i18n("terminology_playground_none", "（无）"),
+              }
+            )}
+          </Alert>
+        )}
+        {/* 本地术语操作按钮：同 AI 操作区，useFlexGap 消除 wrap 后零垂直间距与左偏移。 */}
+        <Stack
+          direction="row"
+          spacing={1}
+          useFlexGap
+          flexWrap="wrap"
+          sx={{ mt: 1 }}
+        >
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleLoadSample}
+            data-testid="terminology-sample"
+          >
+            {i18n("terminology_playground_sample", "填入冲突矩阵 4 类示例")}
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleRotateSeed}
+            data-testid="terminology-rotate-seed"
+          >
+            {i18n("terminology_playground_rotate_seed", "换一个例句")}
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={handleRunTest}
+            data-testid="terminology-run-test"
+          >
+            {i18n("terminology_playground_local_test", "测试")}
+          </Button>
+        </Stack>
+        <Grid container spacing={1} sx={{ mt: 0 }}>
+          <Grid item xs={12} sm={6} md={3}>
+            <Typography variant="caption" color="text.secondary">
+              {i18n("terminology_playground_placeholder_label", "占位符格式")}
+            </Typography>
+            <Typography variant="body1">{placeholderFormat}</Typography>
+          </Grid>
+          <Grid item xs={12} sm={6} md={3}>
+            <Typography variant="caption" color="text.secondary">
+              {i18n("terminology_playground_seed_label", "例句序号")}
+            </Typography>
+            <Typography variant="body1" data-testid="terminology-seed">
+              {termSeed === "" || termSeed === "0"
+                ? i18n("terminology_playground_local_default", "默认")
+                : termSeed}
+            </Typography>
+          </Grid>
+        </Grid>
+        {/* 例句：当前 seed 生成的首个自然文本，右侧「测试」按钮对其做本地替换。 */}
+        {computed && !computed.hasErrors && exampleText && (
+          <Box sx={{ mt: 2 }} data-testid="terminology-example">
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              sx={{ mb: 0.5 }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                {i18n("terminology_playground_local_example", "例句")}
+              </Typography>
+              <Chip
+                size="small"
+                color={exampleOk ? "success" : "error"}
+                label={
+                  exampleOk
+                    ? i18n("terminology_playground_local_pass", "通过")
+                    : i18n("terminology_playground_local_fail", "异常")
+                }
+                data-testid="terminology-example-status"
+              />
+            </Stack>
+            <Box
+              sx={{ fontFamily: "monospace", whiteSpace: "pre-wrap" }}
+              data-testid="terminology-example-text"
+            >
+              {exampleText}
+            </Box>
+            {/* 徽标语义澄清：仅本地正则替换自检，不代表 AI 接口的遵循效果。 */}
+            <Typography
+              variant="caption"
+              component="div"
+              color="text.secondary"
+              sx={{ mt: 0.5 }}
+            >
+              {i18n(
+                "terminology_playground_local_replace_hint",
+                "本地自检：已对当前例句执行一次正则替换断言，全部术语命中并按预期替换；不代表 AI 接口的实际遵循效果。"
+              )}
+            </Typography>
+          </Box>
+        )}
+      </Paper>
+
+      {/* AI 专业术语预览区：解析键值对，不调 API */}
+      <Paper
+        variant="outlined"
+        sx={{ p: 2 }}
+        data-testid="terminology-ai-terms"
+      >
+        <Typography variant="subtitle2" gutterBottom>
+          {i18n(
+            "terminology_playground_terms_title",
+            "AI 专业术语（术语表预览 + 真实 AI 翻译测试）"
+          )}
+        </Typography>
+        {/* 常显说明：3 短句 + 行内「更多」。「更多」必须留在本段末尾行内，
+            否则它会紧贴下方输入框、看起来像输入框的标题。 */}
+        <Typography variant="caption" component="div" color="text.secondary">
+          {renderRichI18n(
+            i18n(
+              "terminology_playground_terms_help_intro",
+              "键值对，每行或 `;` 分隔。选 AI 接口后点「测试」发起真实请求。 术语表为**软注入**，模型不保证遵循。"
+            )
+          )}
+          <Button
+            size="small"
+            variant="text"
+            disableRipple
+            onClick={() => setAiHelpOpen((v) => !v)}
+            endIcon={
+              aiHelpOpen ? (
+                <ExpandLessIcon fontSize="inherit" />
+              ) : (
+                <ExpandMoreIcon fontSize="inherit" />
+              )
+            }
+            sx={{
+              minWidth: 0,
+              p: 0,
+              ml: 0.5,
+              // 跟随 caption 字号/行高，避免行内按钮把整行撑高
+              fontSize: "inherit",
+              lineHeight: "inherit",
+              verticalAlign: "baseline",
+            }}
+            data-testid="terminology-ai-help-more"
+          >
+            {aiHelpOpen
+              ? i18n("terminology_playground_terms_help_collapse", "收起")
+              : i18n("terminology_playground_terms_help_more", "更多")}
+          </Button>
+        </Typography>
+        <Collapse in={aiHelpOpen} unmountOnExit={false}>
+          <Typography
+            variant="caption"
+            component="div"
+            color="text.secondary"
+            data-testid="terminology-ai-help-detail"
+            // 比常显的 caption(0.75rem) 再小一档，明确二级信息层级
+            sx={{ mt: 0.75, fontSize: "0.6875rem", lineHeight: 1.6 }}
+          >
+            {renderRichI18n(
+              i18n(
+                "terminology_playground_terms_help_detail_a",
+                "本区数据为临时测试数据，已自动保留上一次输入，正式保存请复制到「规则/接口设置」页。 AI 专业术语不支持正则表达式。 注意：术语表是通过提示词**软注入**的，模型不保证一定遵循；遇到强先验词 （模型已熟知的专有名词/固定译法，如 API、token）可能压不住，建议用造词 （如 zorp,数据管道）排除干扰。要**必定**替换请写到本地专业术语 （规则 → 术语）：那是正则硬替换、原词不进请求，但注意它按正则语义解析， 元字符 `. + * ? ( ) [ ] \\ | ^ $` 需转义，且只作用于整页翻译的段落正文。 AI 专业术语仅作辅助。"
+              )
+            )}
+            <br />
+            {renderRichI18n(
+              i18n(
+                "terminology_playground_terms_help_detail_b",
+                "另外，接口的**「聚合发送翻译请求」开关会影响遵循率**：开启时术语作为结构化 `glossary` 字段发出，且系统提示词带「最高优先级、只输出术语值」的显式指令； 关闭时术语退化为提示词里的 `- 原词: 译文` 文本行，无结构、指令权重低， 小参数模型（8B 级）经常压不住。实测 Qwen3-8B 关闭聚合时替换不稳定、开启后显著改善； Qwen3.6-27B 与 Gemini 3.5 Flash Lite 两种模式都能稳定替换。**术语不生效时优先试着开启聚合。**"
+              )
+            )}
+          </Typography>
+        </Collapse>
+        {/* 说明区与输入框之间留出间距，避免「更多」展开后紧贴输入框标签 */}
+        <TextField
+          fullWidth
+          multiline
+          minRows={3}
+          maxRows={10}
+          value={aiTermsDraft}
+          onChange={(e) => setAiTermsDraft(e.target.value)}
+          label={i18n(
+            "terminology_playground_terms_input_label",
+            "AI 专业术语"
+          )}
+          placeholder={i18n(
+            "terminology_playground_terms_sample",
+            "zorp,数据管道\nquzzle,缓存节点"
+          )}
+          inputProps={{
+            "aria-describedby": "terminology-ai-terms-helper",
+          }}
+          sx={{
+            mt: 2,
+            "& textarea": {
+              resize: "vertical",
+            },
+          }}
+          data-testid="terminology-ai-terms-input"
+        />
+        {/* AI 术语格式说明 */}
+        <FormHelperText
+          id="terminology-ai-terms-helper"
+          sx={{ margin: "3px 14px 0" }}
+        >
+          {aiTermsDraft.trim()
+            ? formatI18n(
+                i18n,
+                "terminology_playground_terms_count",
+                "解析出 {count} 条术语",
+                { count: aiGlossaryEntries.length }
+              )
+            : i18n(
+                "terminology_playground_terms_helper_empty",
+                "输入键值对格式的术语，每行或 ; 分隔"
+              )}
+        </FormHelperText>
+        {aiGlossaryEntries.length > 0 && (
+          <Paper variant="outlined" sx={{ p: 1.5, bgcolor: "action.hover" }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
+              {i18n(
+                "terminology_playground_terms_parsed_title",
+                "解析后的术语表键值对（将按此格式合并到提示词中的术语表占位符）："
+              )}
+            </Typography>
+            {/* 窄屏真滚动：外层 overflowX:auto 只有在内容确有溢出时才产生横向滚动，
+                而 width:100% 的表格永远只压缩换行、永不溢出。给表格设 minWidth
+                （3 列约 480px）后，<480px 视口才会真正出现横向滑动。 */}
+            <Box sx={{ overflowX: "auto" }}>
+              <table
+                style={{
+                  width: "100%",
+                  minWidth: 480,
+                  borderCollapse: "collapse",
+                  fontSize: 13,
+                  marginTop: 4,
+                }}
+              >
+                <thead>
+                  <tr style={{ borderBottom: tableHeadBorder }}>
+                    <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                      {i18n(
+                        "terminology_playground_terms_col_term",
+                        "术语（键）"
+                      )}
+                    </th>
+                    <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                      {i18n(
+                        "terminology_playground_terms_col_value",
+                        "定义（值）"
+                      )}
+                    </th>
+                    <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                      {i18n(
+                        "terminology_playground_terms_col_format",
+                        "提示词格式"
+                      )}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {aiGlossaryEntries.map(([key, value]) => (
+                    <tr key={key} style={{ borderBottom: tableRowBorder }}>
+                      <td
+                        style={{ padding: "4px 6px", fontFamily: "monospace" }}
+                      >
+                        {key}
+                      </td>
+                      <td
+                        style={{ padding: "4px 6px", fontFamily: "monospace" }}
+                      >
+                        {value || (
+                          <Box component="em" sx={{ color: "text.disabled" }}>
+                            {i18n(
+                              "terminology_playground_terms_no_translation",
+                              "（无译文，保留原文）"
+                            )}
+                          </Box>
+                        )}
+                      </td>
+                      <td
+                        style={{
+                          padding: "4px 6px",
+                          fontFamily: "monospace",
+                          fontSize: 12,
+                        }}
+                      >
+                        - {key}: {value || key}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Box>
+          </Paper>
+        )}
+
+        {/* AI 例句展示：由 AI 术语独立生成，不依赖本地术语库。 */}
+        {aiExampleText && (
+          <Box sx={{ mt: 1 }} data-testid="terminology-ai-example">
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mb: 0.5, display: "block" }}
+            >
+              {i18n(
+                "terminology_playground_terms_example_title",
+                "AI 术语例句"
+              )}
+            </Typography>
+            {/* 源语言标注：例句正文恒为英文模板，明示"源语言=英语"，
+                避免用户把目标语言下拉误当成例句语言开关。 */}
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mb: 0.5, display: "block" }}
+              data-testid="terminology-ai-source-lang"
+            >
+              {`${i18n("from_lang", "源语言")}：${AI_EXAMPLE_SOURCE_LANG_NAME}`}
+            </Typography>
+            <Box
+              sx={{
+                fontFamily: "monospace",
+                whiteSpace: "pre-wrap",
+                fontSize: 13,
+                p: 1,
+                bgcolor: "action.hover",
+                borderRadius: 1,
+              }}
+            >
+              {aiExampleText}
+            </Box>
+          </Box>
+        )}
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ mt: 0.5, display: "block" }}
+        >
+          {i18n(
+            "terminology_playground_terms_hint",
+            "要专门测试某一个术语是否生效，只需填入该术语；其他术语留空有助于观察单个术语的生效情况。"
+          )}
+        </Typography>
+
+        {/* AI 术语操作按钮：填入示例、换一个例句、测试（/测试中的取消）单起一行。
+            useFlexGap 必须开：MUI Stack 默认用 sibling marginLeft 实现 spacing，
+            配合 flexWrap 换行后第二行零垂直间距、首元素带左偏移（真机"样式损坏"根因）。 */}
+        <Stack
+          direction="row"
+          spacing={1}
+          useFlexGap
+          flexWrap="wrap"
+          sx={{ mt: 1 }}
+        >
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleAiLoadSample}
+            data-testid="terminology-ai-sample"
+          >
+            {i18n("terminology_playground_terms_sample_button", "填入示例")}
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleAiRotateSeed}
+            data-testid="terminology-ai-rotate-seed"
+          >
+            {i18n("terminology_playground_terms_rotate_button", "换一个例句")}
+          </Button>
+          <Button
+            size="small"
+            variant="contained"
+            onClick={handleRunAiTest}
+            disabled={aiTestState.status === "testing"}
+            startIcon={
+              aiTestState.status === "testing" ? (
+                <CircularProgress size={16} color="inherit" />
+              ) : undefined
+            }
+            data-testid="terminology-ai-run-test"
+          >
+            {aiTestState.status === "testing"
+              ? i18n("terminology_playground_terms_testing", "测试中…")
+              : i18n("terminology_playground_terms_test", "测试")}
+          </Button>
+          {aiTestState.status === "testing" && (
+            <Button
+              size="small"
+              variant="text"
+              onClick={handleCancelAiTest}
+              data-testid="terminology-ai-cancel"
+            >
+              {i18n("terminology_playground_terms_cancel", "取消")}
+            </Button>
+          )}
+        </Stack>
+
+        {/* 目标语言：仅覆盖本页 AI 测试请求，不改全局 tranboxSetting.toLang。
+            选项/标签/样式全部复用全站既有目标语言下拉（OPT_LANGS_TO_REVERSED + to_lang）；
+            窄屏（412px 竖屏）下与按钮同排必然折行损坏，故独立成行、mt:2 与上行拉开
+            分组间距（真机反馈 mt:1 的 8px 与普通行距无异、贴得太近）。
+            宽度 200：SelectInput 本身 ellipsis+nowrap，常规语言名完整显示，
+            个别最长名（繁體中文 - Traditional Chinese 等）省略号截断，与原 240 行为一致。 */}
+        <TextField
+          select
+          size="small"
+          variant="outlined"
+          label={i18n("to_lang")}
+          value={aiToLang}
+          onChange={handleSelectAiToLang}
+          data-testid="terminology-ai-target-lang"
+          sx={{ width: 200, mt: 2 }}
+        >
+          {OPT_LANGS_TO.map(([code, name]) => (
+            <MenuItem key={code} value={code}>
+              {name}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        {/* 结果区在 done 与 error 两态都渲染（E5）：capture.onRequest 在 fetchData 之前
+            执行，失败轮的请求必然已被捕获，是排查 4xx/协议错误最关键的现场。
+            仅 done 态计算 deliveryMap 与生效检测表 —— 请求发失败时不该对术语给出
+            「已发出」结论。 */}
+        {(aiTestState.status === "done" || aiTestState.status === "error") && (
+          <Box sx={{ mt: 2 }} data-testid="terminology-ai-result">
+            <Typography variant="body2" sx={{ fontWeight: 700, mb: 1 }}>
+              {formatI18n(
+                i18n,
+                "terminology_playground_result_title",
+                "测试结果（{name}）",
+                { name: aiTestState.apiSnapshot?.apiName || "" }
+              )}
+            </Typography>
+
+            {/* 发送的请求 / 接收的响应 左右并排（U1）：<900px 自动上下堆叠；各自拖动手柄独立调高（U5）。 */}
+            <Grid
+              container
+              spacing={1}
+              columns={12}
+              alignItems="flex-start"
+              sx={{ mb: 1 }}
+            >
+              <Grid
+                item
+                xs={12}
+                md={6}
+                data-testid="terminology-ai-req-col"
+                sx={{ pb: 1.5 }}
+              >
+                {/* 请求面板：普通 Box 容器（border/padding 保持），不做拖高 */}
+                <Box
+                  sx={{
+                    border: `1px solid ${theme.palette.divider}`,
+                    borderRadius: 1,
+                    backgroundColor: theme.palette.background.paper,
+                    p: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      flexShrink: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      mb: 0.5,
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {i18n(
+                        "terminology_playground_result_req_title",
+                        "发送的请求（Request）"
+                      )}
+                    </Typography>
+                    <Tooltip
+                      title={
+                        showRequestRaw
+                          ? i18n(
+                              "terminology_playground_result_req_view_summary",
+                              "返回摘要视图"
+                            )
+                          : i18n(
+                              "terminology_playground_result_req_view_json",
+                              "查看原始 JSON"
+                            )
+                      }
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => setShowRequestRaw((prev) => !prev)}
+                        data-testid="terminology-ai-req-toggle"
+                        sx={{
+                          color: showRequestRaw
+                            ? theme.palette.primary.main
+                            : theme.palette.text.secondary,
+                        }}
+                      >
+                        {showRequestRaw ? (
+                          <SubjectIcon fontSize="small" />
+                        ) : (
+                          <DataObjectIcon fontSize="small" />
+                        )}
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                  <Box data-testid="terminology-ai-req-scroll">
+                    {showRequestRaw ? (
+                      aiTestState.rawRequest ? (
+                        <Box
+                          data-testid="terminology-ai-req-json"
+                          sx={{
+                            p: 1,
+                            fontFamily:
+                              "ui-monospace, SFMono-Regular, Menlo, monospace",
+                            fontSize: 12,
+                          }}
+                        >
+                          <pre
+                            style={{
+                              margin: 0,
+                              fontFamily: "inherit",
+                              whiteSpace: "pre-wrap",
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {stringifyForDisplay(
+                              truncateRequestForDisplay(
+                                {
+                                  url: maskUrl(aiTestState.rawRequest.url),
+                                  method: aiTestState.rawRequest.method,
+                                  headers: maskSensitiveJson(
+                                    aiTestState.rawRequest.headers
+                                  ),
+                                  body: expandNestedUserMessage(
+                                    maskForDisplay(
+                                      parseBody(aiTestState.rawRequest.body)
+                                    )
+                                  ),
+                                },
+                                i18n
+                              )
+                            )}
+                          </pre>
+                        </Box>
+                      ) : (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontStyle: "italic" }}
+                        >
+                          {i18n(
+                            "terminology_playground_result_req_uncaptured",
+                            "未捕获到请求"
+                          )}
+                        </Typography>
+                      )
+                    ) : (
+                      <Box sx={{ display: "grid", gap: 0.5 }}>
+                        {aiTestState.glossaryEntries.length > 0 && (
+                          <Box
+                            data-testid="terminology-ai-soft-glossary"
+                            sx={{
+                              p: 1,
+                              borderRadius: 1,
+                              backgroundColor: theme.palette.action.hover,
+                            }}
+                          >
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ display: "block", mb: 0.5 }}
+                            >
+                              {i18n(
+                                "terminology_playground_result_soft_glossary_title",
+                                "AI 专业术语（软提示词注入）"
+                              )}
+                            </Typography>
+                            {aiTestState.glossaryEntries.map(
+                              ({ source, key, value }) => {
+                                const delivery = deliveryMap?.get(key);
+                                return (
+                                  <Typography
+                                    key={`${source}:${key}`}
+                                    variant="caption"
+                                    component="div"
+                                    // 状态 Chip 靠该块右边缘：左侧术语文本吃掉剩余宽度，
+                                    // Chip 不参与收缩，避免长术语把它挤走。
+                                    sx={{
+                                      display: "flex",
+                                      alignItems: "center",
+                                      justifyContent: "space-between",
+                                      gap: 1,
+                                      fontFamily: "monospace",
+                                    }}
+                                  >
+                                    <Box
+                                      component="span"
+                                      sx={{
+                                        flex: "1 1 auto",
+                                        minWidth: 0,
+                                        whiteSpace: "pre-wrap",
+                                      }}
+                                    >
+                                      - {key}: {value}
+                                    </Box>
+                                    {/* 状态 Chip 只在 done 态出现：deliveryMap 只在 done 计算，
+                                      失败轮兜底成 "uncaptured"（未捕获）与事实相反 ——
+                                      失败轮的请求恰恰已被捕获，只是不该给出「已发出」结论。 */}
+                                    {aiTestState.status === "done" && (
+                                      <DeliveryChip
+                                        state={delivery?.state ?? "uncaptured"}
+                                        actualValue={delivery?.actualValue}
+                                        sx={{ flexShrink: 0 }}
+                                      />
+                                    )}
+                                  </Typography>
+                                );
+                              }
+                            )}
+                          </Box>
+                        )}
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          data-testid="terminology-ai-prompt-label"
+                        >
+                          {i18n(
+                            "terminology_playground_result_prompt_label",
+                            "翻译提示词："
+                          )}
+                          {aiTestState.apiSnapshot?.promptLabel || "-"}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          data-testid="terminology-ai-inject-channel"
+                        >
+                          {i18n(
+                            "terminology_playground_result_channel_label",
+                            "注入通道："
+                          )}
+                          {aiTestState.apiSnapshot?.injectionChannel || "-"}
+                        </Typography>
+                        <Box
+                          sx={{
+                            p: 1,
+                            borderRadius: 1,
+                            backgroundColor: theme.palette.action.hover,
+                          }}
+                        >
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: "block" }}
+                          >
+                            {i18n(
+                              "terminology_playground_result_request_label",
+                              "翻译例句："
+                            )}
+                          </Typography>
+                          <Box
+                            data-testid="terminology-ai-request-text"
+                            sx={{
+                              fontFamily: "monospace",
+                              fontSize: 12,
+                              whiteSpace: "pre-wrap",
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {aiTestState.requestText}
+                          </Box>
+                        </Box>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatI18n(
+                            i18n,
+                            "terminology_playground_result_model_host",
+                            "模型：{model} · 接口地址：{host}",
+                            {
+                              model: aiTestState.apiSnapshot?.model || "-",
+                              host: aiTestState.apiSnapshot?.host,
+                            }
+                          )}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatI18n(
+                            i18n,
+                            "terminology_playground_result_auth",
+                            "鉴权：{key}",
+                            { key: aiTestState.apiSnapshot?.maskedKey }
+                          )}
+                        </Typography>
+                        {/* 实际发出的提示词 —— 摘要视图专属。
+                            userMsg 在原始请求体里是转义串：批量是双重编码的 JSON 字符串
+                            （满屏 \" ），非批量是带字面 \n 的长文本，两者都难读。这里反转义后展示。
+                            原始 JSON 视图**不渲染本块**：那边 body 已由 expandNestedUserMessage
+                            就地反转义，再显示一份就是重复噪音（这正是上一轮的设计失误）。 */}
+                        <Box sx={{ mt: 0.5 }}>
+                          <Typography variant="caption" color="text.secondary">
+                            {i18n(
+                              "terminology_playground_result_actual_prompt",
+                              "实际发出的提示词"
+                            )}
+                          </Typography>
+                          {(() => {
+                            if (!aiTestState.rawRequest) {
+                              return (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ fontStyle: "italic", display: "block" }}
+                                  data-testid="terminology-ai-usermsg-json"
+                                >
+                                  {i18n(
+                                    "terminology_playground_result_uncaptured_prompt",
+                                    "未捕获到提示词"
+                                  )}
+                                </Typography>
+                              );
+                            }
+                            const userText = extractUserPromptText(
+                              aiTestState.rawRequest.userMsg
+                            );
+                            const parsed = parseBody(userText);
+                            if (parsed == null || parsed === "") {
+                              return (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ fontStyle: "italic", display: "block" }}
+                                  data-testid="terminology-ai-usermsg-json"
+                                >
+                                  {i18n(
+                                    "terminology_playground_result_uncaptured_prompt",
+                                    "未捕获到提示词"
+                                  )}
+                                </Typography>
+                              );
+                            }
+                            return (
+                              <Box
+                                data-testid="terminology-ai-usermsg-json"
+                                sx={{
+                                  p: 1,
+                                  mt: 0.5,
+                                  borderRadius: 1,
+                                  backgroundColor: theme.palette.action.hover,
+                                  fontFamily:
+                                    "ui-monospace, SFMono-Regular, Menlo, monospace",
+                                  fontSize: 12,
+                                  whiteSpace: "pre-wrap",
+                                  wordBreak: "break-all",
+                                }}
+                              >
+                                {stringifyForDisplay(
+                                  truncateLongStrings(
+                                    maskForDisplay(parsed),
+                                    GENERIC_MAX,
+                                    i18n
+                                  )
+                                )}
+                              </Box>
+                            );
+                          })()}
+                        </Box>
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
+              </Grid>
+
+              <Grid
+                item
+                xs={12}
+                md={6}
+                data-testid="terminology-ai-resp-col"
+                sx={{ pb: 1.5 }}
+              >
+                {/* 响应面板：普通 Box 容器（border/padding 保持），不做拖高 */}
+                <Box
+                  sx={{
+                    border: `1px solid ${theme.palette.divider}`,
+                    borderRadius: 1,
+                    backgroundColor: theme.palette.background.paper,
+                    p: 1,
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      flexShrink: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      mb: 0.5,
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {i18n(
+                        "terminology_playground_result_resp_title",
+                        "接收的响应（Response）"
+                      )}
+                    </Typography>
+                    {/* 摘要 ↔ JSON 切换按钮只在 done 态出现：失败轮没有可摘要的译文，
+                        面板固定展示原始响应（或未捕获提示），留个空转的开关只会误导。 */}
+                    {aiTestState.status === "done" && (
+                      <Tooltip
+                        title={
+                          showResponseRaw
+                            ? i18n(
+                                "terminology_playground_result_req_view_summary",
+                                "返回摘要视图"
+                              )
+                            : i18n(
+                                "terminology_playground_result_req_view_json",
+                                "查看原始 JSON"
+                              )
+                        }
+                      >
+                        <IconButton
+                          size="small"
+                          onClick={() => setShowResponseRaw((prev) => !prev)}
+                          data-testid="terminology-ai-resp-toggle"
+                          sx={{
+                            color: showResponseRaw
+                              ? theme.palette.primary.main
+                              : theme.palette.text.secondary,
+                          }}
+                        >
+                          {showResponseRaw ? (
+                            <SubjectIcon fontSize="small" />
+                          ) : (
+                            <DataObjectIcon fontSize="small" />
+                          )}
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </Box>
+                  <Box data-testid="terminology-ai-resp-scroll">
+                    {/* error 态强制走原始分支：失败轮没有译文可摘要，能给出的只有
+                        已捕获的原始响应体（HTTP 200 但解析失败时最有价值），
+                        或既有的「未捕获到响应」提示（请求阶段就失败/被取消）。 */}
+                    {showResponseRaw || aiTestState.status === "error" ? (
+                      aiTestState.rawResponse ? (
+                        <Box
+                          data-testid="terminology-ai-resp-json"
+                          sx={{
+                            p: 1,
+                            fontFamily:
+                              "ui-monospace, SFMono-Regular, Menlo, monospace",
+                            fontSize: 12,
+                          }}
+                        >
+                          <pre
+                            style={{
+                              margin: 0,
+                              fontFamily: "inherit",
+                              whiteSpace: "pre-wrap",
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {stringifyForDisplay(
+                              truncateLongStrings(
+                                maskForDisplay(aiTestState.rawResponse),
+                                RESPONSE_MAX,
+                                i18n
+                              )
+                            )}
+                          </pre>
+                        </Box>
+                      ) : (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ fontStyle: "italic" }}
+                        >
+                          {i18n(
+                            "terminology_playground_result_resp_uncaptured",
+                            "未捕获到响应（可能失败/被取消）"
+                          )}
+                        </Typography>
+                      )
+                    ) : (
+                      <Box sx={{ display: "grid", gap: 0.5 }}>
+                        <Box
+                          sx={{
+                            p: 1,
+                            borderRadius: 1,
+                            backgroundColor: theme.palette.action.hover,
+                          }}
+                        >
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: "block" }}
+                          >
+                            {i18n(
+                              "terminology_playground_result_translation_label",
+                              "翻译译文："
+                            )}
+                          </Typography>
+                          <Box
+                            data-testid="terminology-ai-response-text"
+                            sx={{
+                              fontFamily: "monospace",
+                              fontSize: 12,
+                              whiteSpace: "pre-wrap",
+                              wordBreak: "break-all",
+                            }}
+                          >
+                            {aiTestState.trText}
+                          </Box>
+                        </Box>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatI18n(
+                            i18n,
+                            "terminology_playground_result_lang_same",
+                            "语言：{lang}（{code}）· 同语言：{same}",
+                            {
+                              lang: aiTestState.srLang || "-",
+                              code: aiTestState.srCode || "-",
+                              same: aiTestState.isSame
+                                ? i18n(
+                                    "terminology_playground_result_yes",
+                                    "是"
+                                  )
+                                : i18n(
+                                    "terminology_playground_result_no",
+                                    "否"
+                                  ),
+                            }
+                          )}
+                        </Typography>
+                        {/* 目标语言：本次实际发送的目标语言快照（不读当前下拉），
+                            与上方检测出的源语言并列，消除"为什么翻成中文"的困惑。 */}
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          data-testid="terminology-ai-result-to-lang"
+                        >
+                          {`${i18n("to_lang", "目标语言")}：${
+                            OPT_LANGS_MAP.get(aiTestState.toLang) ||
+                            aiTestState.toLang ||
+                            "-"
+                          }（${aiTestState.toLang || "-"}）`}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
+              </Grid>
+            </Grid>
+
+            {/* 启发式说明：与三个接口 note 共用 caption 族排版（随主题字号缩放），
+                文案已去掉 **粗体** 标记，纯文本即可，不再走 renderRichI18n。
+                说明与检测表都只在 done 态出现（E5）：失败轮没有译文可对照，
+                更不该对术语给出「已发出/已应用」结论。 */}
+            {aiTestState.status === "done" && (
+              <Alert severity="info" sx={{ mb: 1, ...NOTE_ALERT_SX }}>
+                {i18n(
+                  "terminology_playground_check_heuristic",
+                  "以下术语表生效检测为启发式参考（模型可能改写措辞/加括号/不保留占位符），真实对照以上方原始返回译文为准。"
+                )}
+              </Alert>
+            )}
+            {aiTestState.status === "done" &&
+              aiTestState.glossaryEntries.length > 0 && (
+                <Box>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ fontWeight: 700 }}
+                  >
+                    {i18n(
+                      "terminology_playground_check_title",
+                      "术语表贡献与生效检测"
+                    )}
+                  </Typography>
+                  {/* 窄屏真滚动：4 列且含 Chip，minWidth 约 560px（同解析术语表口径）。 */}
+                  <Box sx={{ overflowX: "auto" }}>
+                    <table
+                      style={{
+                        width: "100%",
+                        minWidth: 560,
+                        borderCollapse: "collapse",
+                        fontSize: 12,
+                        marginTop: 4,
+                      }}
+                    >
+                      <thead>
+                        <tr style={{ borderBottom: tableHeadBorder }}>
+                          <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                            {i18n(
+                              "terminology_playground_check_col_source",
+                              "来源"
+                            )}
+                          </th>
+                          <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                            {i18n(
+                              "terminology_playground_check_col_term",
+                              "术语（键→值）"
+                            )}
+                          </th>
+                          <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                            {i18n(
+                              "terminology_playground_check_col_delivered",
+                              "已发出（事实）"
+                            )}
+                          </th>
+                          <th style={{ textAlign: "left", padding: "4px 6px" }}>
+                            {i18n(
+                              "terminology_playground_check_col_hit",
+                              "译文命中（启发式）"
+                            )}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {aiTestState.glossaryEntries.map(
+                          ({ source, key, value }) => {
+                            const sourceLabel =
+                              source === "input"
+                                ? i18n(
+                                    "terminology_playground_check_source_input",
+                                    "用户输入"
+                                  )
+                                : source === "api"
+                                  ? i18n(
+                                      "terminology_playground_check_source_api",
+                                      "接口级"
+                                    )
+                                  : i18n(
+                                      "terminology_playground_check_source_rule",
+                                      "规则级"
+                                    );
+                            const delivery = deliveryMap?.get(key);
+                            // 译文命中为启发式：空值术语语义 = 不翻译（保留原文）；
+                            // 例句未覆盖该术语原词时无法判断（Task 1 修复后的护栏态）。
+                            // 「未应用」保持灰：启发式判定，模型可能改写措辞，涂红会误读成 bug。
+                            let hitChip;
+                            if (!value) {
+                              hitChip = (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  color="default"
+                                  icon={<Remove fontSize="small" />}
+                                  label={i18n(
+                                    "terminology_playground_check_hit_empty",
+                                    "不翻译（空值）"
+                                  )}
+                                />
+                              );
+                            } else if (!aiTestState.requestText.includes(key)) {
+                              hitChip = (
+                                <Chip
+                                  size="small"
+                                  variant="outlined"
+                                  color="default"
+                                  icon={<HelpOutline fontSize="small" />}
+                                  label={i18n(
+                                    "terminology_playground_check_hit_not_covered",
+                                    "例句未覆盖"
+                                  )}
+                                />
+                              );
+                            } else {
+                              const applied =
+                                aiTestState.trText.includes(value);
+                              hitChip = (
+                                <Chip
+                                  size="small"
+                                  color={applied ? "success" : "default"}
+                                  label={
+                                    applied
+                                      ? i18n(
+                                          "terminology_playground_check_hit_applied",
+                                          "已应用"
+                                        )
+                                      : i18n(
+                                          "terminology_playground_check_hit_not_applied",
+                                          "未应用"
+                                        )
+                                  }
+                                  variant={applied ? "filled" : "outlined"}
+                                  icon={
+                                    applied ? (
+                                      <Check fontSize="small" />
+                                    ) : (
+                                      <Close fontSize="small" />
+                                    )
+                                  }
+                                />
+                              );
+                            }
+                            return (
+                              <tr
+                                key={`${source}:${key}`}
+                                style={{
+                                  borderBottom: tableRowBorder,
+                                  ...(delivery?.state === "mismatch"
+                                    ? {
+                                        backgroundColor:
+                                          theme.palette.warning.light,
+                                      }
+                                    : {}),
+                                }}
+                              >
+                                <td style={{ padding: "4px 6px" }}>
+                                  {sourceLabel}
+                                </td>
+                                <td
+                                  style={{
+                                    padding: "4px 6px",
+                                    fontFamily: "monospace",
+                                  }}
+                                >
+                                  {key} →{" "}
+                                  {value ||
+                                    i18n(
+                                      "terminology_playground_check_empty_value",
+                                      "（空值）"
+                                    )}
+                                </td>
+                                <td style={{ padding: "4px 6px" }}>
+                                  <DeliveryChip
+                                    state={delivery?.state ?? "uncaptured"}
+                                    actualValue={delivery?.actualValue}
+                                    data-testid={`terminology-ai-delivery-${key}`}
+                                  />
+                                </td>
+                                <td style={{ padding: "4px 6px" }}>
+                                  {hitChip}
+                                </td>
+                              </tr>
+                            );
+                          }
+                        )}
+                      </tbody>
+                    </table>
+                  </Box>
+                </Box>
+              )}
+          </Box>
+        )}
+        {aiTestState.status === "error" && (
+          <Alert
+            severity="error"
+            sx={{ mt: 2 }}
+            data-testid="terminology-ai-error"
+          >
+            <Typography variant="body2" sx={{ fontWeight: 700 }}>
+              {i18n(
+                "terminology_playground_alert_ai_test_failed",
+                "AI 翻译测试失败"
+              )}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ fontFamily: "monospace", fontSize: 12, mt: 0.5 }}
+            >
+              {aiTestState.error}
+            </Typography>
+            {/* 目标语言：失败态也展示本次请求发往的语种，避免"为什么翻成中文"式困惑（与 done 态同 testid，两态互斥不重复）。 */}
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5, display: "block" }}
+              data-testid="terminology-ai-result-to-lang"
+            >
+              {`${i18n("to_lang", "目标语言")}：${
+                OPT_LANGS_MAP.get(aiTestState.toLang) ||
+                aiTestState.toLang ||
+                "-"
+              }（${aiTestState.toLang || "-"}）`}
+            </Typography>
+          </Alert>
+        )}
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/views/Options/TerminologyPlayground.test.js
+++ b/src/views/Options/TerminologyPlayground.test.js
@@ -1,0 +1,3622 @@
+import { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import fs from "fs";
+import path from "path";
+import TerminologyPlayground, {
+  maskForDisplay,
+  renderRichI18n,
+} from "./TerminologyPlayground";
+import { I18N, UI_LANGS } from "../../config/i18n";
+import { defaultSystemPrompt } from "../../config";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// 便于在测试中切换 web 模式提示与规则/日志行为。
+const mockMatchRule = jest.fn();
+const mockClient = { isWeb: false };
+const mockRulesList = [{ pattern: "*", terms: "" }];
+// 模拟父组件 Playground 的 resolvedTransApis（resolve 后的接口列表，含展开的 systemPrompt）。
+// 子组件 TerminologyPlayground 改读 transApis prop，不再自行 resolve。
+const mockResolvedTransApis = [];
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+const mockAlert = {
+  success: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warning: jest.fn(),
+};
+
+// 模拟父组件 resolve 后的接口条目：必须显式带 systemPrompt（子组件改读 prop 后不再自行 resolve）。
+// AI 接口默认 useBatchFetch:true（defaultAiApiOpts），mock 也要带上，模拟真实接口条目。
+const mockResolvedApi = (overrides = {}) => ({
+  apiSlug: "openai",
+  apiName: "OpenAI",
+  apiType: "OpenAI",
+  isDisabled: false,
+  useBatchFetch: true,
+  systemPrompt: defaultSystemPrompt,
+  ...overrides,
+});
+
+jest.mock("../../hooks/Alert", () => ({
+  useAlert: () => mockAlert,
+}));
+
+// 全局设置 mock：tranboxSetting 用模块级可变对象持有，用例可覆写全局目标语言默认值
+// （AI 测试目标语言下拉未选择时回落到它）。默认值在 beforeEach 恢复为 zh-CN。
+const mockTranboxSetting = { toLang: "zh-CN" };
+
+jest.mock("../../hooks/Setting", () => ({
+  useSetting: () => ({
+    setting: {
+      injectRules: false,
+      subrulesList: [],
+      tranboxSetting: mockTranboxSetting,
+    },
+  }),
+}));
+
+jest.mock("../../hooks/I18n", () => {
+  // 模拟真实 useI18n 的中文文案（直接读字典），避免动态 key（如冲突类型描述）退化为 fallback。
+  const { I18N } = require("../../config/i18n");
+  return {
+    useI18n:
+      () =>
+      (key, fallback = "") =>
+        I18N[key]?.zh ?? fallback,
+  };
+});
+
+jest.mock("../../hooks/Rules", () => ({
+  useRules: () => ({ list: mockRulesList }),
+}));
+
+jest.mock("../../libs/rules", () => ({
+  matchRule: (...args) => mockMatchRule(...args),
+}));
+
+jest.mock("../../libs/log", () => {
+  // LogLevel 仍由真实模块提供：config/setting.js 在导入期读取 LogLevel.INFO。
+  // logger 用 getter 延迟读取：mock 工厂在 import 阶段执行，直接返回对象会命中 TDZ。
+  const actual = jest.requireActual("../../libs/log");
+  return {
+    LogLevel: actual.LogLevel,
+    get logger() {
+      return mockLogger;
+    },
+    kissLog: jest.fn(),
+  };
+});
+
+// 真实 AI 翻译测试走 apiTranslate；单测中 mock，避免引入 ESM-only 依赖（query-string）。
+const mockApiTranslate = jest.fn();
+jest.mock("../../apis", () => ({
+  apiTranslate: (...args) => mockApiTranslate(...args),
+}));
+
+jest.mock("../../libs/client", () => {
+  // isWeb 用 getter 延迟读取，测试内可随时切换 web 模式提示。
+  const actual = jest.requireActual("../../libs/client");
+  return {
+    ...actual,
+    get isWeb() {
+      return mockClient.isWeb;
+    },
+  };
+});
+
+/** 等待 React effect 和异步事件处理器完成一次状态提交。 */
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** 用原生 value setter 触发 React 的受控 TextField 输入事件。 */
+async function enterTerms(container, value, { waitDebounce = true } = {}) {
+  const textarea = container.querySelector(
+    '[data-testid="terminology-terms-input"] textarea'
+  );
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value"
+  ).set;
+  await act(async () => {
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  if (waitDebounce) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+  }
+}
+
+function renderPlayground(
+  { rule = null, userRules, matchRuleImpl } = {},
+  {
+    initialTermsDraft = "",
+    initialTermDraftTouched = false,
+    initialTermSeed = "",
+  } = {}
+) {
+  if (userRules !== undefined) mockRulesList.length = 0;
+  if (userRules) mockRulesList.push(...userRules);
+  if (matchRuleImpl) {
+    mockMatchRule.mockImplementation(matchRuleImpl);
+  } else {
+    mockMatchRule.mockImplementation(() => Promise.resolve(rule));
+  }
+
+  // 父级 Playground 提升的草稿状态（术语输入、touched 标记、例句 seed）用真实 state 模拟：
+  // 组件读写这些 props，与真实父级行为一致（页签往返不丢草稿）。
+  // 支持通过 initialTermsDraft/initialTermDraftTouched/initialTermSeed 注入初始草稿，
+  // 用于覆盖"localStorage 回填后 touched=true"的挂载场景（挂载后再 set 无法触发挂载期 effect）。
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const mockSetText = jest.fn();
+  const mockSetActiveTab = jest.fn();
+  const mockSetTermsDraft = jest.fn();
+  const mockSetTermDraftTouched = jest.fn();
+  const mockSetTermSeed = jest.fn();
+  const mockSetAiTermsDraft = jest.fn();
+  function DraftHarness() {
+    const [termsDraft, setTermsDraft] = useState(initialTermsDraft);
+    const [termDraftTouched, setTermDraftTouched] = useState(
+      initialTermDraftTouched
+    );
+    const [termSeed, setTermSeed] = useState(initialTermSeed);
+    const [aiTermsDraft, setAiTermsDraft] = useState("");
+    // 可观察的 mock setter 委托给真实 state setter：既能断言调用，又能驱动真实状态。
+    mockSetTermsDraft.mockImplementation(setTermsDraft);
+    mockSetTermDraftTouched.mockImplementation(setTermDraftTouched);
+    mockSetTermSeed.mockImplementation(setTermSeed);
+    mockSetAiTermsDraft.mockImplementation(setAiTermsDraft);
+    return (
+      <TerminologyPlayground
+        setText={mockSetText}
+        setActiveTab={mockSetActiveTab}
+        termsDraft={termsDraft}
+        setTermsDraft={mockSetTermsDraft}
+        termDraftTouched={termDraftTouched}
+        setTermDraftTouched={mockSetTermDraftTouched}
+        termSeed={termSeed}
+        setTermSeed={mockSetTermSeed}
+        aiTermsDraft={aiTermsDraft}
+        setAiTermsDraft={mockSetAiTermsDraft}
+        transApis={mockResolvedTransApis}
+      />
+    );
+  }
+
+  // testing-library/no-unnecessary-act 误报：本处是 createRoot 并发根的初始
+  // render，去掉 act 后 DOM 不同步提交（实测 37 用例 textarea 为 null），
+  // 属计划 :196 回退纪律——保留 act + 行内 disable 并申报。
+  // eslint-disable-next-line testing-library/no-unnecessary-act
+  act(() => {
+    root.render(<DraftHarness />);
+  });
+  return {
+    container,
+    root,
+    setText: mockSetText,
+    setActiveTab: mockSetActiveTab,
+    setTermsDraft: mockSetTermsDraft,
+    setTermDraftTouched: mockSetTermDraftTouched,
+    setTermSeed: mockSetTermSeed,
+    setAiTermsDraft: mockSetAiTermsDraft,
+  };
+}
+
+describe("renderRichI18n", () => {
+  it("keeps plain text untouched", () => {
+    const view = renderRichI18n("纯文本，没有标记。");
+    expect(view).toHaveLength(1);
+    expect(view[0]).toBe("纯文本，没有标记。");
+  });
+
+  it("renders a lone bold marker as <strong>", () => {
+    const view = renderRichI18n("**必定**替换");
+    expect(view).toHaveLength(3);
+    expect(view[0]).toBe("");
+    expect(view[1].type).toBe("strong");
+    expect(view[1].props.children).toBe("必定");
+    expect(view[2]).toBe("替换");
+  });
+
+  it("renders a lone code marker as <code>", () => {
+    const view = renderRichI18n("前缀 `glossary` 后缀");
+    expect(view).toHaveLength(3);
+    expect(view[0]).toBe("前缀 ");
+    expect(view[1].type).toBe("code");
+    expect(view[1].props.children).toBe("glossary");
+    expect(view[2]).toBe(" 后缀");
+  });
+
+  it("keeps a code segment containing * intact next to bold", () => {
+    const view = renderRichI18n(
+      "元字符 `. + * ? ( ) [ ] \\ | ^ $` 需转义，**软注入**生效"
+    );
+    expect(view).toHaveLength(5);
+    expect(view[0]).toBe("元字符 ");
+    expect(view[1].type).toBe("code");
+    // 代码段内部的 * 不被 ** 分支误拆。
+    expect(view[1].props.children).toBe(". + * ? ( ) [ ] \\ | ^ $");
+    expect(view[2]).toBe(" 需转义，");
+    expect(view[3].type).toBe("strong");
+    expect(view[3].props.children).toBe("软注入");
+    expect(view[4]).toBe("生效");
+  });
+});
+
+// i18n 守卫（全语言覆盖 / 反孤儿 / 负样本）扫描的源文件集合。
+// 新增引用 terminology_playground* 键的文件必须同步加入，否则守卫 2 会把该文件里
+// 引用的键误报成孤儿。
+const GUARD_SOURCE_FILES = ["TerminologyPlayground.js", "Playground.js"];
+
+// 页面 i18n 键的匹配式：裸键 terminology_playground（i18n.js 定义、Playground.js 引用）
+// 与带后缀的 terminology_playground_xxx 都要覆盖 —— 旧写法强制要求尾部下划线，
+// 裸键既不参与 7 语言覆盖断言也不进孤儿检查，是守卫盲区。
+const PLAYGROUND_KEY_PATTERN =
+  /["'](terminology_playground(?:_[a-z0-9_]+)?)["']/g;
+
+describe("TerminologyPlayground", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    mockRulesList.length = 0;
+    mockRulesList.push({ pattern: "*", terms: "" });
+    mockResolvedTransApis.length = 0;
+    mockClient.isWeb = false;
+    mockMatchRule.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.error.mockReset();
+    mockAlert.success.mockReset();
+    mockAlert.error.mockReset();
+    mockAlert.warning.mockReset();
+    mockApiTranslate.mockReset();
+    mockTranboxSetting.toLang = "zh-CN";
+    window.localStorage.removeItem("kt-playground-ai-api-slug");
+    window.localStorage.removeItem("kt-playground-ai-to-lang");
+  });
+
+  test("covers every page copy key in all supported UI languages", () => {
+    // 从实际组件提取翻译键，防止后续新增文案时只补中文而遗漏其他语言。
+    const sourceFiles = GUARD_SOURCE_FILES.map((fileName) =>
+      fs.readFileSync(path.join(__dirname, fileName), "utf8")
+    );
+    const keys = new Set();
+    for (const sourceFile of sourceFiles) {
+      for (const match of sourceFile.matchAll(PLAYGROUND_KEY_PATTERN)) {
+        keys.add(match[1]);
+      }
+    }
+    expect(keys.size).toBeGreaterThan(0);
+    // 裸键也必须进入覆盖集合（守卫盲区回归锁）。
+    expect(keys.has("terminology_playground")).toBe(true);
+
+    for (const key of keys) {
+      for (const [language] of UI_LANGS) {
+        expect(I18N[key]?.[language]).toEqual(expect.any(String));
+        expect(I18N[key][language]).not.toBe("");
+      }
+    }
+  });
+
+  test("has no orphaned terminology_playground i18n keys", () => {
+    // 反向守卫：I18N 中定义的所有 terminology_playground* key（含裸键）都必须被源码引用，
+    // 防止本次 PR 遗留死 key（无用途的 key 必须删除而非保留）。
+    const sourceText = GUARD_SOURCE_FILES.map((fileName) =>
+      fs.readFileSync(path.join(__dirname, fileName), "utf8")
+    ).join("\n");
+    const referenced = new Set();
+    for (const match of sourceText.matchAll(PLAYGROUND_KEY_PATTERN)) {
+      referenced.add(match[1]);
+    }
+
+    const definedKeys = Object.keys(I18N).filter((key) =>
+      key.startsWith("terminology_playground")
+    );
+    const orphans = definedKeys.filter((key) => !referenced.has(key));
+    expect(orphans).toEqual([]);
+  });
+
+  test("has no bare Chinese literals left in the component source", () => {
+    // 负样本守卫：组件源码不得残留裸中文字面量（包括 i18n fallback 之外的 JSX 文本、
+    // 三元分支、logger 文案等）。两遍剔除先 formatI18n 后 i18n，避免 4a 之前 4b 吃掉内层。
+    const source = fs.readFileSync(
+      path.join(__dirname, "TerminologyPlayground.js"),
+      "utf8"
+    );
+    const stripped = source
+      // 1. 块注释（含 JSX {/* */}）
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      // 2. 整行注释
+      .replace(/^\s*\/\/.*$/gm, "")
+      // 3. 行尾注释（避开 https:// 与字符串内的 //）
+      .replace(/([^:'"`\\])\/\/[^\n"'`]*$/gm, "$1")
+      // 4a. formatI18n(i18n, "key", "中文", ...) —— 必须先于 4b，否则 4b 先吃掉里层
+      .replace(
+        /formatI18n\(\s*i18n\s*,\s*"[a-z0-9_]+"\s*,\s*(["'`])(?:\\.|(?!\1)[\s\S])*?\1/g,
+        "formatI18n(KEY"
+      )
+      // 4b. i18n("key", "中文")
+      .replace(
+        /\bi18n\(\s*"[a-z0-9_]+"\s*,\s*(["'`])(?:\\.|(?!\1)[\s\S])*?\1/g,
+        "i18n(KEY"
+      );
+    const leftovers = stripped.match(/[\u4e00-\u9fa5]+/g) || [];
+    expect(leftovers).toEqual([]);
+  });
+
+  test("loads the active rule terms on mount and shows the generated example", async () => {
+    const { container, root } = renderPlayground({
+      rule: { pattern: "example.com", terms: "API,接口;APIKey,应用编程接口" },
+    });
+    await flushEffects();
+
+    // 输入框初始值来自当前匹配规则，不持久化到设置。
+    // 「当前生效规则」字段已删除（在扩展页 URL 上匹配网站规则永无命中），不再断言 pattern 文本；
+    // 规则加载成功与否由输入框回填值与例句生成结果表达。
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value).toBe("API,接口;APIKey,应用编程接口");
+
+    // 例句直接展示在本地术语区（生成的首个自然文本）。
+    const exampleText = container.querySelector(
+      '[data-testid="terminology-example-text"]'
+    );
+    expect(exampleText).not.toBeNull();
+    expect(exampleText.textContent).toContain("APIKey");
+
+    // 例句旁紧凑徽标显示通过（4 类冲突组合均无异常）。
+    const status = container.querySelector(
+      '[data-testid="terminology-example-status"]'
+    );
+    expect(status).not.toBeNull();
+    expect(status.textContent).toContain("通过");
+
+    // 通过时不应输出 error 日志，只输出 info 摘要。
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "[TermPlayground]",
+      expect.objectContaining({
+        failCount: 0,
+        totalCaseCount: 2, // 1 对冲突 × 2 方向
+        uniqueConflictPairs: 1,
+      })
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("default-fills the conflict matrix sample and generates an example when rules have no terms", async () => {
+    const { container, root } = renderPlayground({
+      rule: { pattern: "example.com", terms: "" },
+    });
+    await flushEffects();
+    // 规则术语为空 → 自动填入 8 个冲突矩阵示例术语
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value.split(";")).toHaveLength(8);
+    // 例句自动生成
+    const exampleText = container.querySelector(
+      '[data-testid="terminology-example-text"]'
+    );
+    expect(exampleText).not.toBeNull();
+    expect(exampleText.textContent).toContain("React");
+    act(() => root.unmount());
+  });
+
+  test("regenerates the example on mount when a non-empty touched draft is restored", async () => {
+    // 模拟 localStorage 回填场景：父级 termDraftTouched=true（已有草稿，不覆盖用户输入），
+    // 但术语非空时挂载后仍需自动生成例句（此前 computed 为 null，例句不显示）。
+    const { container, root } = renderPlayground(
+      { rule: null },
+      {
+        initialTermsDraft: "SQL,结构化查询;API,接口",
+        initialTermDraftTouched: true,
+      }
+    );
+    await flushEffects();
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    // 用户草稿原样保留，不被规则/示例覆盖。
+    expect(textarea.value).toBe("SQL,结构化查询;API,接口");
+    const exampleText = container.querySelector(
+      '[data-testid="terminology-example-text"]'
+    );
+    expect(exampleText).not.toBeNull();
+    expect(exampleText.textContent.length).toBeGreaterThan(0);
+    act(() => root.unmount());
+  });
+
+  test("skips the mount-time compute when a touched draft is empty (no wasted compute)", async () => {
+    // touched=true 但术语为空：挂载时不执行空算（空算产不出例句，纯浪费），
+    // 以 mockLogger.info 未被调用为证（成功路径 runCompute 必然写 info 日志）。
+    mockLogger.info.mockClear();
+    const { container, root } = renderPlayground(
+      { rule: null },
+      { initialTermsDraft: "", initialTermDraftTouched: true }
+    );
+    await flushEffects();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="terminology-example-text"]')
+    ).toBeNull();
+    act(() => root.unmount());
+  });
+
+  test("debounces recompute while typing and updates the example after the delay", async () => {
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "SQL,结构化查询" },
+    });
+    await flushEffects();
+    const exampleText = () =>
+      container.querySelector('[data-testid="terminology-example-text"]')
+        ?.textContent || "";
+
+    // 输入变化后 300ms 内仍展示旧结果。
+    await enterTerms(container, "GPT;GPTs,智能体集合", { waitDebounce: false });
+    expect(exampleText()).toContain("SQL");
+
+    // 防抖到期后重算，例句更新为包含新术语（GPTs）的文本。
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    expect(exampleText()).toContain("GPTs");
+    expect(
+      container.querySelector('[data-testid="terminology-example-status"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("cancels pending debounce tasks when unmounting", async () => {
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "SQL,结构化查询" },
+    });
+    await flushEffects();
+    mockLogger.info.mockClear();
+
+    // 输入新值后立即卸载（300ms 防抖任务尚未执行）。
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    ).set;
+    act(() => {
+      setter.call(textarea, "GPT;GPTs,智能体集合");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() => root.unmount());
+
+    // 卸载时取消防抖：窗口过后不得再触发重算（无新增日志调用）。
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  test("does not overwrite user edits with the async initial rule load", async () => {
+    // 初始规则加载保持 pending，直到用户输入之后才完成。
+    let resolveMatch;
+    const { container, root } = renderPlayground({
+      matchRuleImpl: () =>
+        new Promise((resolve) => {
+          resolveMatch = resolve;
+        }),
+    });
+
+    // 异步加载尚未完成时，用户已编辑输入。
+    await enterTerms(container, "SQL,结构化查询");
+
+    // 异步加载此刻才完成：不得覆盖用户已编辑内容。
+    await act(async () => {
+      resolveMatch({ pattern: "example.com", terms: "API,接口" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value).toBe("SQL,结构化查询");
+    // 未应用异步加载的规则（不切换规则名、不覆盖输入与结果）。
+    expect(container.textContent).not.toContain("example.com");
+    expect(
+      container.querySelector('[data-testid="terminology-example-text"]')
+        .textContent
+    ).toContain("SQL");
+
+    act(() => root.unmount());
+  });
+
+  test("shows failed assertion via example status and logs full detail", async () => {
+    const { container, root } = renderPlayground({
+      // 正则术语插进自然模板后不能自匹配 → 首个用例断言失败。
+      rule: { pattern: "*", terms: "API\\.\\d+,版本" },
+    });
+    await flushEffects();
+
+    // 例句旁徽标显示异常。
+    const status = container.querySelector(
+      '[data-testid="terminology-example-status"]'
+    );
+    expect(status).not.toBeNull();
+    expect(status.textContent).toContain("异常");
+
+    // 点击「测试」：弹出红色（error）Snackbar，含一行失败原因。
+    const testButton = container.querySelector(
+      '[data-testid="terminology-run-test"]'
+    );
+    act(() => {
+      testButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mockAlert.error).toHaveBeenCalled();
+    const errorBox = mockAlert.error.mock.calls.at(-1)[0];
+    const texts = errorBox.props.children
+      .map((c) => c.props.children)
+      .join("|");
+    expect(texts).toContain("未被命中");
+
+    // logger.error 输出完整 issue（type/message/detail）。
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "[TermPlayground]",
+      expect.any(Array)
+    );
+    const issues = mockLogger.error.mock.calls.at(-1)[1];
+    expect(Array.isArray(issues)).toBe(true);
+    expect(issues.length).toBeGreaterThan(0);
+    for (const issue of issues) {
+      expect(issue).toHaveProperty("type");
+      expect(issue).toHaveProperty("message");
+      expect(issue).toHaveProperty("detail");
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("test button runs local replacement on the example and shows a success snackbar", async () => {
+    const { container, root, setText, setActiveTab } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口;APIKey,应用编程接口" },
+    });
+    await flushEffects();
+
+    // 不发送原文到翻译页签（本地术语仅整页生效）；用「测试」按钮触发本地替换。
+    const testButton = container.querySelector(
+      '[data-testid="terminology-run-test"]'
+    );
+    act(() => {
+      testButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // 绿色成功 Snackbar：提示"测试通过"并展示例句与替换后结果。
+    expect(mockAlert.success).toHaveBeenCalled();
+    expect(mockAlert.error).not.toHaveBeenCalled();
+    const successBox = mockAlert.success.mock.calls.at(-1)[0];
+    const texts = successBox.props.children
+      .map((c) => c.props.children)
+      .join("|");
+    expect(texts).toContain("测试通过");
+    expect(texts).toContain("替换后");
+
+    // 不再切换标签页 / 不再写文本（旧 send-to-tab 逻辑已移除）。
+    expect(setActiveTab).not.toHaveBeenCalled();
+    expect(setText).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("rejects illegal term segments: error alert with reasons, no success summary", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+    // 非法正则 + 尾巴逗号：整体按非法输入拒绝，不生成"替换测试成功"摘要。
+    await enterTerms(container, "bad[re,x\nAPI,接口;");
+
+    const invalidAlert = container.querySelector(
+      '[data-testid="terminology-invalid"]'
+    );
+    expect(invalidAlert).not.toBeNull();
+    // 诊断消息含非法段的原始内容与原因（含段号）。
+    expect(invalidAlert.textContent).toContain("bad[re");
+    expect(invalidAlert.textContent).toContain("第 1 段");
+    expect(
+      container.querySelector('[data-testid="terminology-invalid-state"]')
+    ).not.toBeNull();
+    // v4：文案不得暗示任一错误禁用所有合法术语，而应区分"被拒绝条目"与"仍可应用的合法条目"。
+    const invalidState = container.querySelector(
+      '[data-testid="terminology-invalid-state"]'
+    );
+    expect(invalidState.textContent).toContain("合法术语");
+    expect(invalidState.textContent).not.toContain("未生成测试用例");
+    // 区分"被拒绝条目"与"仍可应用的合法条目"：合法术语 API 在非法状态下被列出
+    expect(invalidState.textContent).toContain("「API」");
+    expect(invalidState.textContent).not.toContain("「bad[re」");
+    // 有致命非法段时不展示例句（无有效替换结果可测）。
+    expect(
+      container.querySelector('[data-testid="terminology-example"]')
+    ).toBeNull();
+    // 完整诊断仍走控制台。
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "[TermPlayground] fatal invalid term segments in input:",
+      expect.any(Array)
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("rejects pure zero-width term segments: error alert with zero-width diagnostic copy, no success summary", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+    // 纯零宽模式 (?=x)：统一计划 Task 2 起为致命诊断 zero-width-matching-pattern，
+    // UI 经 formatFatalDiagnostic 渲染新 i18n 键（七语言，此处 zh 渲染）。
+    await enterTerms(container, "(?=x),Y\nAPI,接口;");
+
+    const invalidAlert = document.querySelector(
+      '[data-testid="terminology-invalid"]'
+    );
+    expect(invalidAlert).not.toBeNull();
+    // 新诊断文案：含段号、原始段内容与零宽原因
+    expect(invalidAlert.textContent).toContain("第 1 段");
+    expect(invalidAlert.textContent).toContain("(?=x),Y");
+    expect(invalidAlert.textContent).toContain("不消费任何字符");
+    // 合法术语仍被区分列出（与 empty-matching 同一语义：只拒绝非法段）
+    const invalidState = document.querySelector(
+      '[data-testid="terminology-invalid-state"]'
+    );
+    expect(invalidState).not.toBeNull();
+    expect(invalidState.textContent).toContain("「API」");
+    expect(invalidState.textContent).not.toContain("「(?=x),Y」");
+
+    // 点「测试」：致命输入只弹错误提示，绝不产生"测试通过"成功摘要。
+    const testButton = document.querySelector(
+      '[data-testid="terminology-run-test"]'
+    );
+    act(() => {
+      testButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mockAlert.success).not.toHaveBeenCalled();
+    expect(mockAlert.error).toHaveBeenCalled();
+
+    // 有致命非法段时不展示例句。
+    expect(
+      document.querySelector('[data-testid="terminology-example"]')
+    ).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("warns about unescaped regex metacharacters while still computing valid inputs", async () => {
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "Dr.whob,神经病" },
+    });
+    await flushEffects();
+
+    // 元字符警告可见，且提示转义示例。
+    const metaWarning = container.querySelector(
+      '[data-testid="terminology-meta-warning"]'
+    );
+    expect(metaWarning).not.toBeNull();
+    expect(metaWarning.textContent).toContain("Dr.whob");
+    expect(metaWarning.textContent).toContain("反斜杠");
+    // 非致命：仍正常生成例句并显示通过徽标（Dr.whob 正则命中自然句）。
+    expect(
+      container.querySelector('[data-testid="terminology-example-status"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("web mode shows the CORS limitation note only when isWeb is true", async () => {
+    mockClient.isWeb = true;
+    const view = renderPlayground({ rule: null });
+    await flushEffects();
+    expect(
+      view.container.querySelector('[data-testid="terminology-web-note"]')
+    ).not.toBeNull();
+    expect(view.container.textContent).toContain("GM.xmlHttpRequest");
+    act(() => view.root.unmount());
+
+    mockClient.isWeb = false;
+    const utils = renderPlayground({ rule: null });
+    await flushEffects();
+    expect(
+      utils.container.querySelector('[data-testid="terminology-web-note"]')
+    ).toBeNull();
+    act(() => utils.root.unmount());
+  });
+
+  test("falls back to the global rule when the active rule fails to load", async () => {
+    mockRulesList.length = 0;
+    mockRulesList.push({ pattern: "*", terms: "React;ReactNative" });
+    const { container, root } = renderPlayground({
+      matchRuleImpl: () => Promise.reject(new Error("storage failed")),
+    });
+    await flushEffects();
+
+    // 「当前生效规则」字段已删除（在扩展页 URL 上匹配网站规则永无命中，纯噪音）；
+    // 回退行为改由 loadError 提示与术语加载结果表达。
+    expect(container.textContent).toContain("已回退到全局规则");
+    expect(container.textContent).not.toContain("当前生效规则");
+    // 回退术语仍生成例句并通过（类型 4：都无译文）。
+    expect(
+      container.querySelector('[data-testid="terminology-example-status"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("sample button loads the fixed 4-type diagnostic sample (8 terms, 4 unique conflict pairs)", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    // 点击"填入冲突矩阵 4 类示例"按钮。
+    const sampleButton = container.querySelector(
+      '[data-testid="terminology-sample"]'
+    );
+    act(() => {
+      sampleButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+
+    // 输入框被填充为 8 个术语（4 组独立冲突对）。
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value.split(";")).toHaveLength(8);
+
+    // 生成例句并显示通过徽标。
+    expect(
+      container.querySelector('[data-testid="terminology-example-status"]')
+    ).not.toBeNull();
+    // 摘要统计正确。
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "[TermPlayground]",
+      expect.objectContaining({
+        uniqueConflictPairs: 4,
+        totalCaseCount: 8,
+        conflictPairCount: 8,
+        failCount: 0,
+      })
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("load sample then rotate seed changes the example deterministically and preserves terms draft", async () => {
+    const { container, root, setTermsDraft, setTermDraftTouched, setTermSeed } =
+      renderPlayground({ rule: null });
+    await flushEffects();
+
+    const sampleButton = container.querySelector(
+      '[data-testid="terminology-sample"]'
+    );
+    act(() => {
+      sampleButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    const exampleText = () =>
+      container.querySelector('[data-testid="terminology-example-text"]')
+        ?.textContent || "";
+    const before = exampleText();
+
+    // "换一个例句"按钮：递增显式 seed 并在有限模板集合内轮换例句。
+    const rotateButton = container.querySelector(
+      '[data-testid="terminology-rotate-seed"]'
+    );
+    let after = null;
+    for (let attempt = 0; attempt < 8; attempt++) {
+      act(() => {
+        rotateButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 350));
+      });
+      after = exampleText();
+      if (after !== before) break;
+    }
+    // seed 提升到父级：setTermSeed 被调用且 seed 标签更新为数字。
+    expect(setTermSeed).toHaveBeenCalled();
+    const seedLabel = container.querySelector(
+      '[data-testid="terminology-seed"]'
+    ).textContent;
+    expect(Number.isNaN(Number(seedLabel))).toBe(false);
+    // 换句仍保留用户草稿（术语输入不被覆盖）。
+    expect(
+      container.querySelector(
+        '[data-testid="terminology-terms-input"] textarea'
+      ).value
+    ).toContain("APIKey");
+    // 轮换后在有限模板集合内换出了不同例句。
+    expect(after === before).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("test button shows an error snackbar when the input is rejected", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+    // 空源术语（,abc）为致命非法输入：不生成例句，测试给出红色提示。
+    await enterTerms(container, ",abc;API,接口");
+
+    const testButton = container.querySelector(
+      '[data-testid="terminology-run-test"]'
+    );
+    act(() => {
+      testButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mockAlert.error).toHaveBeenCalled();
+    expect(mockAlert.success).not.toHaveBeenCalled();
+    expect(mockAlert.error.mock.calls.at(-1)[0]).toContain("非法术语段");
+
+    act(() => root.unmount());
+  });
+
+  /**
+   * 构造一个带 clientY/pointerId 的通用指针事件。
+   *
+   * @param {string} type 事件类型（如 pointerdown/pointermove）。
+   * @param {Object} opts 可选的 clientY 与 pointerId。
+   * @returns {Event} 可被 React 与 jsdom 识别的指针事件。
+   */
+  function makePointerEvent(type, { clientY = 0, pointerId = 1 } = {}) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clientY", { value: clientY });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  /**
+   * 收集当前 document.styleSheets 中所有 CSS 规则。
+   *
+   * @returns {Array<CSSRule>} 全部规则（跨源样式表读取失败时跳过）。
+   */
+  function collectRules() {
+    return Array.from(document.styleSheets).flatMap((sheet) => {
+      try {
+        return Array.from(sheet.cssRules);
+      } catch {
+        return [];
+      }
+    });
+  }
+
+  /**
+   * 取出 emotion 为某元素注入的全部规则文本（按元素自身的 css-* 类名匹配）。
+   *
+   * 用于区分 MUI Stack 的两种 spacing 实现：useFlexGap 走 `gap`，
+   * 默认实现走 `& > :not(style) ~ :not(style) { margin-left }`（wrap 后第二行
+   * 零垂直间距 + 首元素左偏移的根因）。
+   *
+   * @param {HTMLElement} el 目标元素。
+   * @returns {string} 命中该元素 emotion 类名的全部规则 cssText 拼接。
+   */
+  function ownRuleText(el) {
+    const classes = [...el.classList].filter((name) => name.startsWith("css-"));
+    return collectRules()
+      .filter(
+        (rule) =>
+          rule.selectorText &&
+          classes.some((name) => rule.selectorText.includes(`.${name}`))
+      )
+      .map((rule) => rule.cssText)
+      .join("\n");
+  }
+
+  test("effect-check table uses SVG icons instead of emoji for the feature markers", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+      result: {
+        trText: "数据管道已就绪",
+        srLang: "en",
+        srCode: "en",
+        isSame: false,
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    // 整容器级 emoji 守卫（未跑测试的静态渲染态）。
+    for (const glyph of ["✅", "❌", "⚠️", "➖"]) {
+      expect(container.textContent).not.toContain(glyph);
+    }
+
+    // 顶部对照表已移除，跑完测试后生效检测表才是页面上唯一带图标的表格。
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    for (const glyph of ["✅", "❌", "⚠️", "➖"]) {
+      expect(container.textContent).not.toContain(glyph);
+    }
+    // 命中/未命中用 MUI SVG 图标（Check/Close）表达。
+    const tableIcons = [
+      ...container.querySelectorAll(
+        '[data-testid="terminology-tab-root"] table svg'
+      ),
+    ];
+    expect(tableIcons.length).toBeGreaterThanOrEqual(1);
+
+    act(() => root.unmount());
+  });
+
+  test("top comparison matrix, its more toggle and the API-level term preview are gone", async () => {
+    // 移动端收敛：顶部三行对照表 + 「更多」折叠 + 接口级 AI 术语原文展开块整体移除
+    // （完整对照留在 preview/专业术语.md）。
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        aiTerms: "zorp,数据管道",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "openai" },
+    });
+    await flushEffects();
+
+    for (const testid of [
+      "terminology-info-table",
+      "terminology-details-toggle",
+      "terminology-details",
+    ]) {
+      expect(container.querySelector(`[data-testid="${testid}"]`)).toBeNull();
+    }
+    // 接口级术语原文不得在发请求前被展开显示。
+    expect(container.textContent).not.toContain("接口级 AI 术语");
+    // 首个板块即「接口选择」区。
+    const panels = [
+      ...container.querySelectorAll('[data-testid="terminology-tab-root"] > *'),
+    ];
+    expect(panels[0].getAttribute("data-testid")).toBe(
+      "terminology-api-selector"
+    );
+    expect(panels[0].textContent).toContain("接口选择");
+
+    act(() => root.unmount());
+  });
+
+  test("AI test result area uses MUI icons instead of emoji for delivery states", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+      result: {
+        trText: "数据管道已就绪",
+        srLang: "en",
+        srCode: "en",
+        isSame: false,
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const resultArea = container.querySelector(
+      '[data-testid="terminology-ai-result"]'
+    );
+    for (const glyph of ["✅", "❌", "⚠️", "➖"]) {
+      expect(resultArea.textContent).not.toContain(glyph);
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("renders the API selector with available interfaces and defaults to the rule apiSlug", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI 兼容",
+        apiType: "OpenAI",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: {
+        pattern: "*",
+        terms: "API,接口;APIKey,应用编程接口",
+        apiSlug: "openai",
+      },
+    });
+    await flushEffects();
+
+    const select = container.querySelector(
+      '[data-testid="terminology-api-select"]'
+    );
+    expect(select).not.toBeNull();
+    // 默认选中规则 apiSlug（openai）。
+    expect(select.textContent).toContain("OpenAI 兼容");
+
+    // disabled 接口被过滤。
+    expect(select.textContent).not.toContain("（未配置）");
+
+    act(() => root.unmount());
+  });
+
+  test("fills API runtime defaults (placeholder) so selector does not crash", async () => {
+    // 缺 placeholder 的条目：fillApiDefaults 必须补上，否则 placeholder.split 崩溃。
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "openai" },
+    });
+    await flushEffects();
+    // 无崩溃，选择器渲染成功。
+    expect(
+      container.querySelector('[data-testid="terminology-api-select"]')
+    ).not.toBeNull();
+    expect(container.textContent).toContain("OpenAI");
+    act(() => root.unmount());
+  });
+
+  test("P3: touched 草稿页签往返后仍恢复规则元数据（默认接口回落规则 apiSlug）", async () => {
+    // 列表顺序：首项 Microsoft，规则 apiSlug=openai（第二项）。
+    // 若 activeRuleData 未恢复，默认逻辑只能选首项 Microsoft —— 即 P3 元数据丢失。
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI 兼容",
+        apiType: "OpenAI",
+      })
+    );
+    const { container, root } = renderPlayground(
+      { rule: { pattern: "*", terms: "API,接口", apiSlug: "openai" } },
+      {
+        initialTermsDraft: "SQL,结构化查询",
+        initialTermDraftTouched: true,
+      }
+    );
+    await flushEffects();
+
+    // 草稿不被规则覆盖（touched 只阻止覆盖 termsDraft）。
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value).toBe("SQL,结构化查询");
+    // 规则元数据按规则身份恢复：默认接口取规则 apiSlug=openai，而不是列表首项。
+    const select = container.querySelector(
+      '[data-testid="terminology-api-select"]'
+    );
+    expect(select.textContent).toContain("OpenAI 兼容");
+    expect(select.textContent).not.toContain("未配置");
+
+    act(() => root.unmount());
+  });
+
+  test("P3: 异步规则加载晚于用户编辑时，草稿保留但规则元数据仍写回", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI 兼容",
+        apiType: "OpenAI",
+      })
+    );
+    let resolveMatch;
+    const { container, root } = renderPlayground({
+      matchRuleImpl: () =>
+        new Promise((resolve) => {
+          resolveMatch = resolve;
+        }),
+    });
+
+    // 规则加载 pending 期间用户编辑（hasUserEdited + termDraftTouched 都就位）。
+    await enterTerms(container, "GPT;GPTs,智能体集合");
+
+    // 异步加载此刻才完成：不得覆盖草稿，但 activeRuleData（规则 apiSlug）仍写回。
+    await act(async () => {
+      resolveMatch({ pattern: "example.com", terms: "API,接口", apiSlug: "openai" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    expect(textarea.value).toBe("GPT;GPTs,智能体集合");
+    // 默认接口按恢复的规则 apiSlug=openai 选择，证明元数据没有因用户编辑被丢弃。
+    const select = container.querySelector(
+      '[data-testid="terminology-api-select"]'
+    );
+    expect(select.textContent).toContain("OpenAI 兼容");
+
+    act(() => root.unmount());
+  });
+
+  test("API selector desc and note use caption-family sizing with a scaled Alert icon", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      })
+    );
+    const { root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+
+    const panel = queryTestid("terminology-api-selector");
+    // 标题与说明拉开字号层级：subtitle2(14px) 标题 + caption(12px) 说明，
+    // 说明段不得再用 body2（与标题同 14px、只差字重）。
+    /* eslint-disable-next-line testing-library/no-node-access -- Typography variant 只体现在类名上。 */
+    const desc = panel.querySelector(".MuiTypography-caption");
+    expect(desc).not.toBeNull();
+    expect(desc.textContent).toContain("不支持 AI 专业术语");
+    /* eslint-disable-next-line testing-library/no-node-access -- 同上。 */
+    expect(panel.querySelector(".MuiTypography-body2")).toBeNull();
+
+    // note 走 caption 族排版：字号用 rem（随主题 htmlFontSize 缩放，不是硬编码 px），
+    // 且 Alert 图标同步缩小（MUI 硬编码 22px，不缩会与 12px 正文失衡）。
+    const note = queryTestid("terminology-api-machine-note");
+    expect(note.textContent).toContain("AI 专业术语无法生效");
+    const noteCss = ownRuleText(note);
+    expect(noteCss).toMatch(/font-size:\s*0\.75rem/);
+    expect(noteCss).toMatch(/\.MuiAlert-icon\s*\{[^}]*font-size:\s*1rem/);
+
+    act(() => root.unmount());
+  });
+
+  test("shows machine-translation limitation note and blocks AI test for machine APIs", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+    await enterTerms(container, "API,接口;APIKey,应用编程接口");
+
+    // 机器翻译接口提示：不支持 AI 专业术语。
+    expect(
+      container.querySelector('[data-testid="terminology-api-machine-note"]')
+    ).not.toBeNull();
+
+    // 点击测试按钮：被阻止并弹 warning。
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mockAlert.warning).toHaveBeenCalled();
+    expect(mockApiTranslate).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("switching the API selector updates the limitation note", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        apiType: "OpenAI",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "openai" },
+    });
+    await flushEffects();
+    // 默认选中 openai → AI 提示。
+    expect(
+      container.querySelector('[data-testid="terminology-api-ai-note"]')
+    ).not.toBeNull();
+
+    // 只验证默认提示正确；MUI Select 下拉菜单在 jsdom 中不渲染选项，
+    // 切换接口的功能验证通过 integration/manual 测试覆盖。
+    act(() => root.unmount());
+  });
+
+  test("runs a real AI translation test on an AI interface and shows request/response", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        apiType: "OpenAI",
+        aiTerms: "component,组件",
+      })
+    );
+    mockApiTranslate.mockResolvedValue({
+      trText: "请检查 API 和 APIKey 配置。",
+      srLang: "en",
+      srCode: "en",
+      isSame: false,
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: {
+        pattern: "*",
+        terms: "API,接口;APIKey,应用编程接口",
+        aiTerms: "API,接口2",
+      },
+    });
+    await flushEffects();
+    await enterTerms(container, "API,接口;APIKey,应用编程接口");
+    // 在 AI 术语输入框输入测试值。
+    act(() => {
+      setAiTermsDraft("API,Application Programming Interface");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // apiTranslate 被调用，且关闭缓存/池化。
+    expect(mockApiTranslate).toHaveBeenCalled();
+    const callArgs = mockApiTranslate.mock.calls.at(-1)[0];
+    expect(callArgs.useCache).toBe(false);
+    expect(callArgs.usePool).toBe(false);
+    // 提示词已展开：systemPrompt 非空且包含聚合翻译提示词头。
+    expect(callArgs.apiSetting.systemPrompt).toBeTruthy();
+    expect(callArgs.apiSetting.systemPrompt).toContain(
+      "Act as a translation API"
+    );
+    // 仅强制非流式：useStream=false，但保留接口原始 useBatchFetch（AI 接口默认 true）。
+    expect(callArgs.apiSetting.useStream).toBe(false);
+    expect(callArgs.apiSetting.useBatchFetch).toBe(true);
+    // glossary 包含用户输入的值（优先于规则级/接口级）。
+    expect(callArgs.glossary).toBeTruthy();
+    expect(callArgs.glossary["API"]).toBe("Application Programming Interface");
+    // 接口级 AI 术语也被合并。
+    expect(callArgs.glossary["component"]).toBe("组件");
+
+    // 请求原文来自 AI 术语例句（不含本地占位符 {1}/{2}）。
+    const requestText = container.querySelector(
+      '[data-testid="terminology-ai-request-text"]'
+    );
+    expect(requestText.textContent).not.toMatch(/\{\d+\}/);
+    expect(requestText.textContent).toContain("API");
+    // 请求原文展示区显示的即 AI 例句内容。
+    expect(callArgs.text).toBe(requestText.textContent);
+    // 返回译文展示。
+    expect(
+      container.querySelector('[data-testid="terminology-ai-response-text"]')
+        .textContent
+    ).toContain("请检查");
+
+    act(() => root.unmount());
+  });
+
+  test("AI test captures apiTranslate errors into a Snackbar and result area", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslate.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+    await enterTerms(container, "API,接口");
+    // AI 术语例句为空时会先阻止；这里先填入 AI 术语确保走到真实请求。
+    act(() => {
+      setAiTermsDraft("API,接口");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    expect(mockAlert.error).toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-error"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-error"]')
+        .textContent
+    ).toContain("401");
+
+    act(() => root.unmount());
+  });
+
+  test("QwenMT interface shows native-term note and is allowed for AI testing", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "qwenmt",
+        apiName: "QwenMT",
+        apiType: "QwenMT",
+      })
+    );
+    mockApiTranslate.mockResolvedValue({
+      trText: "检查 API 配置。",
+      srLang: "en",
+      srCode: "en",
+      isSame: false,
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+    await enterTerms(container, "API,接口");
+    // AI 术语例句为空时会先阻止；这里先填入 AI 术语确保走到真实请求。
+    act(() => {
+      setAiTermsDraft("API,接口");
+    });
+
+    // QwenMT 提示原生术语支持。
+    expect(
+      container.querySelector('[data-testid="terminology-api-qwenmt-note"]')
+    ).not.toBeNull();
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+    // 未被阻止：apiTranslate 被调用。
+    expect(mockApiTranslate).toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("AI terms input automatically generates an independent example (no local terms needed)", async () => {
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: { pattern: "*", terms: "" },
+    });
+    await flushEffects();
+
+    // 无 AI 术语时：不展示 AI 例句。
+    expect(
+      container.querySelector('[data-testid="terminology-ai-example"]')
+    ).toBeNull();
+
+    // 输入 AI 术语后自动生成例句（不依赖本地术语库）。
+    act(() => {
+      setAiTermsDraft("API,接口\nAPIKey,应用编程接口");
+    });
+    const aiExample = container.querySelector(
+      '[data-testid="terminology-ai-example"]'
+    );
+    expect(aiExample).not.toBeNull();
+    expect(aiExample.textContent).toContain("API");
+
+    act(() => root.unmount());
+  });
+
+  test("AI test is blocked with a hint when AI terms are empty", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+    await enterTerms(container, "API,接口");
+
+    // AI 术语为空：无 AI 例句。
+    expect(
+      container.querySelector('[data-testid="terminology-ai-example"]')
+    ).toBeNull();
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+    expect(mockAlert.error).toHaveBeenCalled();
+    expect(mockAlert.error.mock.calls.at(-1)[0]).toContain(
+      "请先输入 AI 专业术语"
+    );
+    expect(mockApiTranslate).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  test("AI sample button fills default AI terms and generates an example", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    const sampleButton = container.querySelector(
+      '[data-testid="terminology-ai-sample"]'
+    );
+    act(() => {
+      sampleButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const aiTextarea = container.querySelector(
+      '[data-testid="terminology-ai-terms-input"] textarea'
+    );
+    expect(aiTextarea.value).toContain("zorp,数据管道");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-example"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("AI rotate seed button rotates the AI example deterministically", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    // 先填入 AI 术语，确保有例句可轮换。
+    act(() => {
+      container
+        .querySelector('[data-testid="terminology-ai-sample"]')
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const aiExampleText = () =>
+      container.querySelector('[data-testid="terminology-ai-example"]')
+        ?.textContent || "";
+    const before = aiExampleText();
+
+    const rotateButton = container.querySelector(
+      '[data-testid="terminology-ai-rotate-seed"]'
+    );
+    let after = null;
+    for (let attempt = 0; attempt < 8; attempt++) {
+      act(() => {
+        rotateButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      after = aiExampleText();
+      if (after !== before) break;
+    }
+    // 在有限模板集合内换出了不同例句。
+    expect(after === before).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("AI test sends the AI example text as the request original (no local placeholders)", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslate.mockResolvedValue({
+      trText: "翻译结果",
+      srLang: "en",
+      srCode: "en",
+      isSame: false,
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("API,接口");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    const callArgs = mockApiTranslate.mock.calls.at(-1)[0];
+    // 请求原文来自 AI 术语例句，不含本地占位符 {1}。
+    expect(callArgs.text).not.toMatch(/\{\d+\}/);
+    expect(callArgs.text).toContain("API");
+    // 请求原文展示区显示的即 AI 例句。
+    const requestText = container.querySelector(
+      '[data-testid="terminology-ai-request-text"]'
+    );
+    expect(requestText.textContent).toBe(callArgs.text);
+
+    act(() => root.unmount());
+  });
+
+  // ── AI 测试请求/响应双样式展示（Task 4） ──
+
+  /** 在 AI 术语输入框填入草稿（父级持有 state，直接驱动）。 */
+  function fillAiTerms(container, setAiTermsDraft, value) {
+    act(() => {
+      setAiTermsDraft(value);
+    });
+    return container;
+  }
+
+  /** 点击「测试」并等待完成。 */
+  async function runAiTest(container) {
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+  }
+
+  /** 通过下拉把接口选择器切到指定 slug（复用 MUI Select 的 jsdom 交互模式）。 */
+  async function selectApiBySlug(container, slug) {
+    const combobox = container.querySelector(
+      '[data-testid="terminology-api-select"] [role="combobox"]'
+    );
+    await act(async () => {
+      combobox.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll('[role="option"]')]
+        .find((option) => option.getAttribute("data-value") === slug)
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  /** 批量 JSON 用户消息构造器：segments[0].text 显式包含术语 key（防子串判定回归的契约）。 */
+  const batchUserMsgContent = (extra = {}) =>
+    JSON.stringify({
+      targetLanguage: "zh-CN",
+      segments: [
+        {
+          id: 0,
+          text: "Please make sure the zorp is configured correctly before deploying.",
+        },
+      ],
+      glossary: { zorp: "数据管道" },
+      ...extra,
+    });
+
+  /** 注入 mock 请求/响应数据的工厂函数 */
+  function mockApiTranslateWithCapture({
+    reqUrl = "https://api.openai.com/v1/chat/completions",
+    reqHeaders = { "Content-Type": "application/json" },
+    reqBody = { model: "gpt-4", messages: [{ role: "system", content: "" }] },
+    respBody = { choices: [{ message: { content: "测试翻译结果" } }] },
+    result = {
+      trText: "测试翻译结果",
+      srLang: "en",
+      srCode: "en",
+      isSame: false,
+    },
+    ...rest
+  } = {}) {
+    mockApiTranslate.mockImplementation((opts = {}) => {
+      const { capture } = opts;
+      if (capture?.onRequest) {
+        // reqUserMsg 用 in 判断而非解构默认值：Custom 用例要显式传 undefined（未捕获）。
+        const userMsg =
+          "reqUserMsg" in rest
+            ? rest.reqUserMsg
+            : { role: "user", content: "test" };
+        capture.onRequest(
+          reqUrl,
+          {
+            method: "POST",
+            headers: reqHeaders,
+            body:
+              typeof reqBody === "string" ? reqBody : JSON.stringify(reqBody),
+          },
+          userMsg
+        );
+      }
+      if (capture?.onResponse) {
+        capture.onResponse(respBody);
+      }
+      return Promise.resolve(result);
+    });
+  }
+
+  test("1. 摘要默认：显示软提示词、提示词标签、译文；不出现原始 JSON 容器", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        systemPrompt: defaultSystemPrompt,
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: {
+        model: "gpt-4",
+        messages: [{ role: "system", content: "test" }],
+      },
+      result: {
+        trText: "测试翻译结果",
+        srLang: "zh",
+        srCode: "zh",
+        isSame: false,
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 软提示词包含造词 key
+    const softGlossary = container.querySelector(
+      '[data-testid="terminology-ai-soft-glossary"]'
+    );
+    expect(softGlossary).not.toBeNull();
+    expect(softGlossary.textContent).toContain("zorp");
+
+    // 提示词标签（JSON 聚合翻译提示词）
+    const promptLabel = container.querySelector(
+      '[data-testid="terminology-ai-prompt-label"]'
+    );
+    expect(promptLabel).not.toBeNull();
+    expect(promptLabel.textContent).toContain("JSON 聚合翻译提示词");
+
+    // 响应摘要含译文字段
+    const responseText = container.querySelector(
+      '[data-testid="terminology-ai-response-text"]'
+    );
+    expect(responseText).not.toBeNull();
+    expect(responseText.textContent).toContain("测试翻译结果");
+
+    // 不出现原始 JSON 容器
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("2. 原始 JSON 切换 + 图标互换：点 toggle 出现 JSON 内容，图标在 DataObject/Subject 间切换", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 请求侧 toggle
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    expect(reqToggle).not.toBeNull();
+
+    // 初始 DataObjectIcon
+    expect(
+      reqToggle.querySelector('[data-testid="DataObjectIcon"]')
+    ).not.toBeNull();
+
+    // 点 toggle 切到原始 JSON
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const reqJson = container.querySelector(
+      '[data-testid="terminology-ai-req-json"]'
+    );
+    expect(reqJson).not.toBeNull();
+    expect(reqJson.textContent).toContain("gpt-4");
+
+    // 图标变为 SubjectIcon
+    expect(
+      reqToggle.querySelector('[data-testid="SubjectIcon"]')
+    ).not.toBeNull();
+
+    // 再点切回摘要
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).toBeNull();
+    expect(
+      reqToggle.querySelector('[data-testid="DataObjectIcon"]')
+    ).not.toBeNull();
+
+    // 响应侧同理
+    const respToggle = container.querySelector(
+      '[data-testid="terminology-ai-resp-toggle"]'
+    );
+    expect(respToggle).not.toBeNull();
+    expect(
+      respToggle.querySelector('[data-testid="DataObjectIcon"]')
+    ).not.toBeNull();
+
+    act(() => {
+      respToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const respJson = container.querySelector(
+      '[data-testid="terminology-ai-resp-json"]'
+    );
+    expect(respJson).not.toBeNull();
+    expect(
+      respToggle.querySelector('[data-testid="SubjectIcon"]')
+    ).not.toBeNull();
+
+    act(() => {
+      respToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).toBeNull();
+    expect(
+      respToggle.querySelector('[data-testid="DataObjectIcon"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("3. 打码：请求头 Authorization 中的完整 Key 被隐藏", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqHeaders: { Authorization: "Bearer sk-abcdefghijklmnop" },
+      reqBody: { model: "gpt-4", messages: [] },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 切到原始 JSON 视图
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const reqJson = container.querySelector(
+      '[data-testid="terminology-ai-req-json"]'
+    );
+
+    // 含打码标记
+    expect(reqJson.textContent).toContain("****");
+    // 不含完整 Key
+    expect(reqJson.textContent).not.toContain("sk-abcdefghijklmnop");
+
+    act(() => root.unmount());
+  });
+
+  test("4. 主题/滚动：原始 JSON 内容在面板滚动区内，无硬编码 hex 背景", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: { model: "gpt-4", messages: [] },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 切到原始 JSON 视图
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const reqJson = container.querySelector(
+      '[data-testid="terminology-ai-req-json"]'
+    );
+    expect(reqJson).not.toBeNull();
+
+    // 面板滚动区存在且包含 JSON 内容（Task 2.3：滚动由外层 scroll 区统一管理）
+    const reqScroll = container.querySelector(
+      '[data-testid="terminology-ai-req-scroll"]'
+    );
+    expect(reqScroll).not.toBeNull();
+    expect(reqScroll.contains(reqJson)).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  test("5. 只读 + 无复制：请求/响应面板内不含 textarea/input/editable，无复制按钮", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: { model: "gpt-4", messages: [] },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 请求/响应面板内无可编辑元素
+    const resultArea = container.querySelector(
+      '[data-testid="terminology-ai-result"]'
+    );
+    expect(
+      resultArea.querySelectorAll("textarea, input, [contenteditable]").length
+    ).toBe(0);
+
+    // 无复制按钮
+    const allButtons = resultArea.querySelectorAll("button");
+    const copyButtons = [...allButtons].filter((btn) => {
+      const label = btn.getAttribute("aria-label") || "";
+      const testid = btn.getAttribute("data-testid") || "";
+      return (
+        label.includes("copy") ||
+        label.includes("复制") ||
+        testid.includes("copy")
+      );
+    });
+    expect(copyButtons.length).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  test("6. 截断：超长请求体在原始 JSON 视图中被截断并标记", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const longSystemContent = "A".repeat(500);
+    mockApiTranslateWithCapture({
+      reqBody: {
+        model: "gpt-4",
+        messages: [{ role: "system", content: longSystemContent }],
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    act(() => {
+      setAiTermsDraft("zorp,数据管道");
+    });
+
+    const aiTestButton = container.querySelector(
+      '[data-testid="terminology-ai-run-test"]'
+    );
+    act(() => {
+      aiTestButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushEffects();
+
+    // 切到原始 JSON 视图
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const reqJson = container.querySelector(
+      '[data-testid="terminology-ai-req-json"]'
+    );
+
+    // 不含 500 个连续 A
+    expect(reqJson.textContent).not.toContain("A".repeat(500));
+    // 含截断标记
+    expect(reqJson.textContent).toContain("[已省略");
+
+    act(() => root.unmount());
+  });
+
+  test("restores the persisted AI test interface over the rule default", async () => {
+    window.localStorage.setItem("kt-playground-ai-api-slug", "openai");
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI 兼容",
+        apiType: "OpenAI",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "Microsoft" },
+    });
+    await flushEffects();
+
+    // 恢复值 openai 优先于规则默认 Microsoft。
+    const select = container.querySelector(
+      '[data-testid="terminology-api-select"]'
+    );
+    expect(select.textContent).toContain("OpenAI 兼容");
+
+    act(() => root.unmount());
+  });
+
+  test("clears the persisted interface when it no longer exists and falls back to defaults", async () => {
+    window.localStorage.setItem("kt-playground-ai-api-slug", "deleted-api");
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      })
+    );
+    // Select 首帧渲染必须完成有效性归一化，绝不允许把失效恢复值直接塞给 MUI，
+    // 否则必报一次 out-of-range 控制台 warning（AGENTS.md 无 warning 验收标准）。
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "Microsoft" },
+    });
+    await flushEffects();
+
+    // 失效恢复值被清除，回落规则默认接口。
+    const select = container.querySelector(
+      '[data-testid="terminology-api-select"]'
+    );
+    expect(select.textContent).toContain("Microsoft");
+    expect(window.localStorage.getItem("kt-playground-ai-api-slug")).toBeNull();
+    // 首帧即向 MUI Select 传递合法 value，零 out-of-range 警告。
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("out-of-range")
+    );
+    warnSpy.mockRestore();
+
+    act(() => root.unmount());
+  });
+
+  test("persists the manually selected AI test interface to localStorage", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "Microsoft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      }),
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        apiType: "OpenAI",
+      })
+    );
+    const { container, root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口", apiSlug: "Microsoft" },
+    });
+    await flushEffects();
+
+    // 打开单选下拉并选中 openai：localStorage 写入新 slug。
+    const combobox = container.querySelector(
+      '[data-testid="terminology-api-select"] [role="combobox"]'
+    );
+    await act(async () => {
+      combobox.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll('[role="option"]')]
+        .find((option) => option.getAttribute("data-value") === "openai")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(window.localStorage.getItem("kt-playground-ai-api-slug")).toBe(
+      "openai"
+    );
+
+    act(() => root.unmount());
+  });
+
+  // ── Task 8 新增护栏用例（R1/R2/R3/R4/D2–D7） ──
+
+  test("R1: AI example text covers every entered term", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture();
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道\nquzzle,缓存节点");
+    await runAiTest(container);
+
+    // 例句同时包含两个术语原词（此前只取 cases[0]，quzzle 物理上不可能被替换）。
+    const requestText = container.querySelector(
+      '[data-testid="terminology-ai-request-text"]'
+    );
+    expect(requestText.textContent).toContain("zorp");
+    expect(requestText.textContent).toContain("quzzle");
+    const callArgs = mockApiTranslate.mock.calls.at(-1)[0];
+    expect(callArgs.text).toContain("zorp");
+    expect(callArgs.text).toContain("quzzle");
+
+    act(() => root.unmount());
+  });
+
+  test("R2: interface-level aiTerms is not re-injected and cannot override user input", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        aiTerms: "zorp,接口的值",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,我的值");
+    await runAiTest(container);
+
+    const callArgs = mockApiTranslate.mock.calls.at(-1)[0];
+    expect(callArgs.apiSetting.aiTerms).toBe("");
+    expect(callArgs.glossary["zorp"]).toBe("我的值");
+
+    act(() => root.unmount());
+  });
+
+  test("Task5: glossary key-values are visible in the expanded user message panel", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const userMsgJson = container.querySelector(
+      '[data-testid="terminology-ai-usermsg-json"]'
+    );
+    expect(userMsgJson).not.toBeNull();
+    expect(userMsgJson.textContent).toContain("zorp");
+    expect(userMsgJson.textContent).toContain("数据管道");
+
+    act(() => root.unmount());
+  });
+
+  test("D2: delivery column shows 已发出 with glossary and 未发出 without (segments still contain the term)", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    // 有 glossary → delivered。
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+      result: {
+        trText: "数据管道已就绪",
+        srLang: "en",
+        srCode: "en",
+        isSame: false,
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    // 去掉 glossary 但 segments[0].text 显式包含 zorp → 仍必须 missing（防子串判定回归）。
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content: JSON.stringify({
+          targetLanguage: "zh-CN",
+          segments: [
+            {
+              id: 0,
+              text: "Please make sure the zorp is configured correctly before deploying.",
+            },
+          ],
+        }),
+      },
+      result: {
+        trText: "数据管道已就绪",
+        srLang: "en",
+        srCode: "en",
+        isSame: false,
+      },
+    });
+    await runAiTest(container);
+    // 子串守卫：例句里明明有 zorp，但没注入 glossary 就不能误判为已发出。
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("missing");
+
+    act(() => root.unmount());
+  });
+
+  test("D2: mismatch shows 值不一致 with the actual injected value highlighted in orange", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content: batchUserMsgContent({ glossary: { zorp: "其它值" } }),
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const chip = container.querySelector(
+      '[data-testid="terminology-ai-delivery-zorp"]'
+    );
+    expect(chip.getAttribute("data-state")).toBe("mismatch");
+    expect(chip.textContent).toContain("其它值");
+    // 橙色：mismatch 行的 Chip 用 warning 色。
+    expect(chip.className).toContain("MuiChip-colorWarning");
+
+    act(() => root.unmount());
+  });
+
+  test("D2: uncaptured requests render 未捕获 for all terms", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    // 不走 capture：rawRequest 为 null。
+    mockApiTranslate.mockResolvedValue({
+      trText: "x",
+      srLang: "en",
+      srCode: "en",
+      isSame: false,
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("uncaptured");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-usermsg-json"]')
+        .textContent
+    ).toContain("未捕获到提示词");
+
+    act(() => root.unmount());
+  });
+
+  test("nobatch path: channel/label/已发出 when {{glossary}} line present, 未发出 after removal", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        useBatchFetch: false,
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content:
+          "Translate the text.\n- zorp: 数据管道\n\nText: Please make sure the zorp is configured correctly before deploying.",
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    expect(
+      container.querySelector('[data-testid="terminology-ai-inject-channel"]')
+        .textContent
+    ).toContain("非批量 {{glossary}} 占位符");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-prompt-label"]')
+        .textContent
+    ).toContain("非批量翻译提示词");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    // 删掉该行（R4 现场证据）→ missing。
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content:
+          "Translate the text.\n\nText: Please make sure the zorp is configured correctly before deploying.",
+      },
+    });
+    await runAiTest(container);
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("missing");
+
+    act(() => root.unmount());
+  });
+
+  test("QwenMT: native server-side terms channel with label '不使用翻译提示词'", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "qwenmt",
+        apiName: "QwenMT",
+        apiType: "QwenMT",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: {
+        model: "qwen-mt-turbo",
+        messages: [
+          {
+            role: "user",
+            content:
+              "Please make sure the zorp is configured correctly before deploying.",
+          },
+        ],
+        translation_options: {
+          source_lang: "auto",
+          target_lang: "zh-CN",
+          terms: [{ source: "zorp", target: "数据管道" }],
+        },
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    expect(
+      container.querySelector('[data-testid="terminology-ai-prompt-label"]')
+        .textContent
+    ).toContain("不使用翻译提示词");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-inject-channel"]')
+        .textContent
+    ).toContain("服务端原生术语 translation_options.terms");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    act(() => root.unmount());
+  });
+
+  test("Custom API: declared as non-injecting, user message uncaptured, all deliveries 未发出", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "custom",
+        apiName: "自定义",
+        apiType: "Custom",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: {
+        texts: [
+          "Please make sure the zorp is configured correctly before deploying.",
+        ],
+        from: "auto",
+        to: "zh-CN",
+      },
+      reqUserMsg: undefined,
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    expect(
+      container.querySelector('[data-testid="terminology-ai-inject-channel"]')
+        .textContent
+    ).toContain("自定义接口：不注入提示词与术语");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-usermsg-json"]')
+        .textContent
+    ).toContain("未捕获到提示词");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("missing");
+
+    act(() => root.unmount());
+  });
+
+  test("Gemini generateContent parts form expands and delivers 已发出", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "gemini",
+        apiName: "Gemini",
+        apiType: "Gemini",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqUrl:
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent?key=x",
+      reqBody: {
+        systemInstruction: { parts: [{ text: "sys" }] },
+        contents: [],
+      },
+      reqUserMsg: { role: "user", parts: [{ text: batchUserMsgContent() }] },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const userMsgJson = container.querySelector(
+      '[data-testid="terminology-ai-usermsg-json"]'
+    );
+    expect(userMsgJson.textContent).toContain("数据管道");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    act(() => root.unmount());
+  });
+
+  test("Gemini Interactions content array form expands and delivers 已发出", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "gemini",
+        apiName: "Gemini",
+        apiType: "Gemini",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqUrl: "https://generativelanguage.googleapis.com/v1beta/interactions",
+      reqBody: { system_instruction: "sys", input: [] },
+      reqUserMsg: {
+        type: "user_input",
+        content: [{ type: "text", text: batchUserMsgContent() }],
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const userMsgJson = container.querySelector(
+      '[data-testid="terminology-ai-usermsg-json"]'
+    );
+    expect(userMsgJson.textContent).toContain("数据管道");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    act(() => root.unmount());
+  });
+
+  test.each([
+    [
+      "camelCase systemInstruction object",
+      {
+        systemInstruction: { parts: [{ text: "A".repeat(500) }] },
+        contents: [],
+      },
+    ],
+    [
+      "snake_case system_instruction string",
+      { system_instruction: "A".repeat(500), input: [] },
+    ],
+  ])(
+    "D6: system prompt truncated at 80 chars for %s",
+    async (_label, reqBody) => {
+      mockResolvedTransApis.push(
+        mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+      );
+      mockApiTranslateWithCapture({
+        reqBody,
+        reqUserMsg: { role: "user", content: batchUserMsgContent() },
+      });
+      const { container, root, setAiTermsDraft } = renderPlayground({
+        rule: null,
+      });
+      await flushEffects();
+      fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+      await runAiTest(container);
+
+      const reqToggle = container.querySelector(
+        '[data-testid="terminology-ai-req-toggle"]'
+      );
+      act(() => {
+        reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      const reqJson = container.querySelector(
+        '[data-testid="terminology-ai-req-json"]'
+      );
+      // 字段被识别才会截断出「已省略 420 字符」；若落到 GENERIC_MAX(1200)，500 字符不会截断。
+      expect(reqJson.textContent).toContain("已省略 420 字符");
+
+      act(() => root.unmount());
+    }
+  );
+
+  test("D7: a term named 'key' stays plaintext in the expanded user message", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content: JSON.stringify({
+          targetLanguage: "zh-CN",
+          segments: [
+            {
+              id: 0,
+              text: "Please make sure the key is configured correctly before deploying.",
+            },
+          ],
+          glossary: { key: "密钥" },
+        }),
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "key,密钥");
+    await runAiTest(container);
+
+    const userMsgJson = container.querySelector(
+      '[data-testid="terminology-ai-usermsg-json"]'
+    );
+    expect(userMsgJson.textContent).toContain("密钥");
+    expect(userMsgJson.textContent).not.toContain("****");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-key"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    act(() => root.unmount());
+  });
+
+  test("empty-value term: delivered 已发出 and hit column shows 不翻译（空值）", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: {
+        role: "user",
+        content: JSON.stringify({
+          targetLanguage: "zh-CN",
+          segments: [
+            {
+              id: 0,
+              text: "Please make sure the zorp is configured correctly before deploying.",
+            },
+          ],
+          glossary: { zorp: "" },
+        }),
+      },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp");
+    await runAiTest(container);
+
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+    const resultArea = container.querySelector(
+      '[data-testid="terminology-ai-result"]'
+    );
+    expect(resultArea.textContent).toContain("不翻译（空值）");
+
+    act(() => root.unmount());
+  });
+
+  test("D4: switching the selector after a run keeps every snapshot-derived conclusion", async () => {
+    window.localStorage.removeItem("kt-playground-ai-api-slug");
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" }),
+      mockResolvedApi({
+        apiSlug: "msft",
+        apiName: "Microsoft",
+        apiType: "Microsoft",
+      })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: { pattern: "*", terms: "", apiSlug: "openai" },
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const titleBefore =
+      container.querySelector('[data-testid="terminology-ai-result"] h6')
+        ?.textContent ||
+      [
+        ...container.querySelectorAll(
+          '[data-testid="terminology-ai-result"] .MuiTypography-root'
+        ),
+      ]
+        .map((el) => el.textContent)
+        .find((t) => t.includes("测试结果"));
+    expect(titleBefore).toContain("OpenAI");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-inject-channel"]')
+        .textContent
+    ).toContain("批量 JSON glossary 字段");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    // 切到机器翻译接口：结果区全部结论保持不变（只读请求时快照）。
+    await selectApiBySlug(container, "msft");
+    const titleAfter = [
+      ...container.querySelectorAll(
+        '[data-testid="terminology-ai-result"] .MuiTypography-root'
+      ),
+    ]
+      .map((el) => el.textContent)
+      .find((t) => t.includes("测试结果"));
+    expect(titleAfter).toContain("OpenAI");
+    expect(titleAfter).toBe(titleBefore);
+    expect(
+      container.querySelector('[data-testid="terminology-ai-inject-channel"]')
+        .textContent
+    ).toContain("批量 JSON glossary 字段");
+    expect(
+      container.querySelector('[data-testid="terminology-ai-prompt-label"]')
+        .textContent
+    ).toContain("JSON 聚合翻译提示词");
+    expect(
+      container
+        .querySelector('[data-testid="terminology-ai-delivery-zorp"]')
+        .getAttribute("data-state")
+    ).toBe("delivered");
+
+    act(() => root.unmount());
+  });
+
+  // ── §B UI 细化新用例（Task 4.3） ──
+
+  test("AI help section: collapsed by default, expands on click, collapses on second click", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    const moreBtn = container.querySelector(
+      '[data-testid="terminology-ai-help-more"]'
+    );
+    expect(moreBtn.textContent).toBe("更多");
+
+    // Collapse 折叠时子节点仍在 DOM（height:0），但祖先 .MuiCollapse-root 带 MuiCollapse-hidden。
+    const collapseRoot = container
+      .querySelector('[data-testid="terminology-ai-help-detail"]')
+      .closest(".MuiCollapse-root");
+    expect(collapseRoot.className).toContain("MuiCollapse-hidden");
+
+    // 点击展开
+    act(() => {
+      moreBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(moreBtn.textContent).toBe("收起");
+    expect(collapseRoot.className).not.toContain("MuiCollapse-hidden");
+
+    act(() => root.unmount());
+  });
+
+  test("side-by-side layout: req and resp columns exist with md=6 grid class", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const reqCol = container.querySelector(
+      '[data-testid="terminology-ai-req-col"]'
+    );
+    const respCol = container.querySelector(
+      '[data-testid="terminology-ai-resp-col"]'
+    );
+    expect(reqCol).not.toBeNull();
+    expect(respCol).not.toBeNull();
+    expect(reqCol.className).toContain("MuiGrid-grid-md-6");
+    expect(respCol.className).toContain("MuiGrid-grid-md-6");
+
+    act(() => root.unmount());
+  });
+
+  test("default: no maxHeight on panel containers, scroll areas not in auto overflow", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    // 外层 Box（Grid item 的第一个子元素）初始无 maxHeight
+    const reqPanel = container.querySelector(
+      '[data-testid="terminology-ai-req-col"] > div'
+    );
+    const respPanel = container.querySelector(
+      '[data-testid="terminology-ai-resp-col"] > div'
+    );
+    expect(reqPanel.style.maxHeight).toBe("");
+    expect(respPanel.style.maxHeight).toBe("");
+
+    // 滚动区初始 overflowY 不是 auto（U2 默认不滚动契约）
+    const reqScroll = container.querySelector(
+      '[data-testid="terminology-ai-req-scroll"]'
+    );
+    const respScroll = container.querySelector(
+      '[data-testid="terminology-ai-resp-scroll"]'
+    );
+    expect(reqScroll.style.overflowY).not.toBe("auto");
+    expect(respScroll.style.overflowY).not.toBe("auto");
+
+    act(() => root.unmount());
+  });
+
+  test("help text uses caption variant, not body2", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    // 常显说明段使用 caption 字号/字重（Task 1.1：body2 → caption 降级）。
+    const helpText = container.querySelector(
+      '[data-testid="terminology-ai-terms"] .MuiTypography-caption'
+    );
+    expect(helpText).not.toBeNull();
+    expect(helpText.className).toContain("MuiTypography-caption");
+    expect(helpText.className).not.toContain("MuiTypography-body2");
+
+    act(() => root.unmount());
+  });
+
+  test("U9: side toggle independence — req and resp toggles do not affect each other", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    // 初始：两侧都是摘要视图
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).toBeNull();
+
+    // 只点左侧 → 左侧切 JSON，右侧仍是摘要
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).toBeNull();
+
+    // 点右侧 → 两侧都是 JSON
+    const respToggle = container.querySelector(
+      '[data-testid="terminology-ai-resp-toggle"]'
+    );
+    act(() => {
+      respToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).not.toBeNull();
+
+    // 点回左侧 → 左侧变回摘要，右侧仍是 JSON
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-req-json"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="terminology-ai-resp-json"]')
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  test("C4: the expanded prompt panel is summary-view only (hidden in raw JSON view)", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqBody: {
+        model: "gpt-4",
+        messages: [
+          { role: "system", content: "sys" },
+          { role: "user", content: batchUserMsgContent() },
+        ],
+      },
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    // 摘要视图：面板在，且 glossary 明文可见。
+    const panel = container.querySelector(
+      '[data-testid="terminology-ai-usermsg-json"]'
+    );
+    expect(panel).not.toBeNull();
+    expect(panel.textContent).toContain("数据管道");
+
+    // 切原始 JSON：面板必须消失（否则同一份内容在同一视图出现两次）。
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    act(() => {
+      reqToggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="terminology-ai-usermsg-json"]')
+    ).toBeNull();
+
+    // 补偿：body 里的用户消息被就地反转义成对象，所以 glossary 仍然可读，
+    // 且不应出现 JSON 字符串转义后的 \" 序列。
+    const reqJson = container.querySelector(
+      '[data-testid="terminology-ai-req-json"]'
+    );
+    expect(reqJson.textContent).toContain("数据管道");
+    expect(reqJson.textContent).not.toContain('\\"targetLanguage\\"');
+    // 系统提示词不参与展开（仍按 role==="system" 走 SYSTEM_PROMPT_MAX 分支）。
+    expect(reqJson.textContent).toContain("sys");
+
+    act(() => root.unmount());
+  });
+
+  test("Task 2.2 structure: header toggle is not inside the scroll area", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const reqScroll = container.querySelector(
+      '[data-testid="terminology-ai-req-scroll"]'
+    );
+    const reqToggle = container.querySelector(
+      '[data-testid="terminology-ai-req-toggle"]'
+    );
+    expect(reqScroll.contains(reqToggle)).toBe(false);
+
+    const respScroll = container.querySelector(
+      '[data-testid="terminology-ai-resp-scroll"]'
+    );
+    const respToggle = container.querySelector(
+      '[data-testid="terminology-ai-resp-toggle"]'
+    );
+    expect(respScroll.contains(respToggle)).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  // ── AI 测试目标语言下拉 + 持久化（本计划 Task 1/2/4） ──
+
+  /* eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- jsdom 交互模式与全文件既有写法一致；render() 未用 TL，screen 不可用。 */
+  function queryTestid(testid) {
+    return document.querySelector(`[data-testid="${testid}"]`);
+  }
+
+  /** 通过下拉把 AI 测试目标语言切到指定语言代码（复用接口选择器的 jsdom 交互模式）。 */
+  async function selectAiToLang(code) {
+    /* eslint-disable-next-line testing-library/prefer-screen-queries, testing-library/no-node-access -- 同上，jsdom 交互模式。 */
+    const combobox = queryTestid("terminology-ai-target-lang").querySelector(
+      '[role="combobox"]'
+    );
+    await act(async () => {
+      combobox.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll('[role="option"]')]
+        .find((option) => option.getAttribute("data-value") === code)
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  /** 读取目标语言下拉的当前值（MUI Select 的隐藏原生 input）。 */
+  function aiToLangValue() {
+    /* eslint-disable-next-line testing-library/prefer-screen-queries, testing-library/no-node-access -- MUI 隐藏 input 无语义角色，只能类名定位。 */
+    return queryTestid("terminology-ai-target-lang").querySelector(
+      ".MuiSelect-nativeInput"
+    ).value;
+  }
+
+  test("target language dropdown sits on its own row after the button row and defaults to the global toLang", async () => {
+    const { root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    const select = queryTestid("terminology-ai-target-lang");
+    expect(select).not.toBeNull();
+    // 未持久化时默认 = 全局 tranboxSetting.toLang（与下拉引入前行为一致）。
+    expect(aiToLangValue()).toBe("zh-CN");
+    // 选项来自 OPT_LANGS_TO_REVERSED（中文名在前），与全站目标语言下拉一致。
+    expect(select.textContent).toContain("简体中文 - Simplified Chinese");
+
+    // 第一行：填入示例 / 换一个例句 / 测试 三按钮同一 Stack。
+    const stack = queryTestid("terminology-ai-run-test").parentElement;
+    expect(
+      [...stack.children].map((el) => el.getAttribute("data-testid"))
+    ).toEqual([
+      "terminology-ai-sample",
+      "terminology-ai-rotate-seed",
+      "terminology-ai-run-test",
+    ]);
+
+    // 第二行：目标语言下拉是按钮行的下一个兄弟，独立成行且带 mt:2 间隔（16px，
+    // 真机反馈 mt:1 的 8px 贴得太近）、宽 200。
+    expect(stack.nextElementSibling).toBe(select);
+    const selectCss = ownRuleText(select);
+    expect(selectCss).toMatch(/width:\s*200px/);
+    expect(selectCss).toMatch(/margin-top:\s*16px/);
+
+    // 折行根因修复：操作区 Stack 必须走 flex gap，而不是 sibling margin-left。
+    const stackCss = ownRuleText(stack);
+    expect(stackCss).toMatch(/gap:\s*8px/);
+    expect(stackCss).not.toMatch(/margin-left/);
+
+    // 本地术语操作区同一缺陷一并修复。
+    const localStack = queryTestid("terminology-run-test").parentElement;
+    const localStackCss = ownRuleText(localStack);
+    expect(localStackCss).toMatch(/gap:\s*8px/);
+    expect(localStackCss).not.toMatch(/margin-left/);
+
+    act(() => root.unmount());
+  });
+
+  describe("with a non-Chinese global target language", () => {
+    beforeEach(() => {
+      mockTranboxSetting.toLang = "ja";
+    });
+
+    test("falls back to the global toLang when nothing is persisted", async () => {
+      const { root } = renderPlayground({ rule: null });
+      await flushEffects();
+
+      expect(aiToLangValue()).toBe("ja");
+
+      act(() => root.unmount());
+    });
+
+    test("prefers a valid persisted language over the global toLang", async () => {
+      window.localStorage.setItem("kt-playground-ai-to-lang", "ko");
+      const { root } = renderPlayground({ rule: null });
+      await flushEffects();
+
+      expect(aiToLangValue()).toBe("ko");
+
+      act(() => root.unmount());
+    });
+
+    test("clears an invalid persisted language and falls back to the global toLang", async () => {
+      window.localStorage.setItem("kt-playground-ai-to-lang", "not-a-lang");
+      const { root } = renderPlayground({ rule: null });
+      await flushEffects();
+
+      expect(aiToLangValue()).toBe("ja");
+      // 脏值不得永久留存（对齐接口选择的失效清理语义）。
+      expect(
+        window.localStorage.getItem("kt-playground-ai-to-lang")
+      ).toBeNull();
+
+      act(() => root.unmount());
+    });
+  });
+
+  test("persists the manually selected target language and restores it after a remount", async () => {
+    const { root } = renderPlayground({ rule: null });
+    await flushEffects();
+
+    await selectAiToLang("ja");
+    expect(aiToLangValue()).toBe("ja");
+    expect(window.localStorage.getItem("kt-playground-ai-to-lang")).toBe("ja");
+
+    // 刷新（卸载 + 重新挂载）后回读持久化值。
+    act(() => root.unmount());
+    const { root: remountedRoot } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    expect(aiToLangValue()).toBe("ja");
+
+    act(() => remountedRoot.unmount());
+  });
+
+  test("AI test request uses the selected target language, keeps fromLang auto", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture();
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,データパイプライン");
+
+    await selectAiToLang("ja");
+    await runAiTest(container);
+
+    const callArgs = mockApiTranslate.mock.calls.at(-1)[0];
+    expect(callArgs.toLang).toBe("ja");
+    // 源语言仍交给模型自动识别（例句正文恒为英文模板）。
+    expect(callArgs.fromLang).toBe("auto");
+
+    act(() => root.unmount());
+  });
+
+  test("AI example area labels the source language as English", async () => {
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    const sourceLang = queryTestid("terminology-ai-source-lang");
+    expect(sourceLang).not.toBeNull();
+    // 复用全局 from_lang 文案 + OPT_LANGS_MAP 的纯语言名。
+    expect(sourceLang.textContent).toContain("原文语言");
+    expect(sourceLang.textContent).toContain("English");
+    expect(sourceLang.textContent).not.toContain("English - English");
+
+    act(() => root.unmount());
+  });
+
+  test("response summary shows the target language actually sent", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture();
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    await selectAiToLang("ja");
+    await runAiTest(container);
+
+    const resultToLang = queryTestid("terminology-ai-result-to-lang");
+    expect(resultToLang).not.toBeNull();
+    expect(resultToLang.textContent).toContain("目标语言");
+    expect(resultToLang.textContent).toContain("Japanese");
+    expect(resultToLang.textContent).toContain("ja");
+
+    act(() => root.unmount());
+  });
+
+  // ── 窄屏适配（本计划 Task 5） ──
+
+  test("every table is wrapped in a horizontally scrollable container", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    mockApiTranslateWithCapture({
+      reqUserMsg: { role: "user", content: batchUserMsgContent() },
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    const tables = [...document.querySelectorAll("table")];
+    // 解析术语表 + 生效检测表（顶部矩阵对照表已移除）。
+    expect(tables).toHaveLength(2);
+    for (const table of tables) {
+      expect(window.getComputedStyle(table.parentElement).overflowX).toBe(
+        "auto"
+      );
+      // minWidth 是"真滚动"的必要条件：width:100% 的表格永远不会溢出包裹层，
+      // 只会压缩换行，overflowX:auto 形同虚设。
+      expect(table.style.minWidth).not.toBe("");
+      expect(table.style.minWidth).not.toBe("auto");
+      expect(parseInt(table.style.minWidth, 10)).toBeGreaterThanOrEqual(480);
+    }
+
+    act(() => root.unmount());
+  });
+
+  test("info cards stack to a single column on narrow screens", async () => {
+    const { root } = renderPlayground({
+      rule: { pattern: "*", terms: "API,接口" },
+    });
+    await flushEffects();
+
+    const card = document
+      .querySelector('[data-testid="terminology-seed"]')
+      .closest(".MuiGrid-item");
+    expect(card.className).toContain("MuiGrid-grid-xs-12");
+    expect(card.className).toContain("MuiGrid-grid-sm-6");
+    expect(card.className).toContain("MuiGrid-grid-md-3");
+
+    act(() => root.unmount());
+  });
+
+  // ── 连续测试轮次隔离 / 取消复位 / 失败轮请求面板（本计划 Task 1/3/6/7） ──
+
+  /**
+   * 排入「下一轮」AI 测试的 mock 实现（mockImplementationOnce，按 FIFO 消费）。
+   * 每轮请求体的 model、用户消息与响应体都带 label 标记，用来断言轮次数据不串。
+   * deferred=true 时返回受控句柄：settle() 注入 capture 后 resolve，fail(err) 直接 reject，
+   * 便于在 pending 态做断言（真实 apiTranslate 在单测中被 mock，无法用它复现请求层污染）。
+   */
+  function queueAiRound({
+    label,
+    trText = `译文-${label}`,
+    srLang = "en",
+    srCode = "en",
+    isSame = false,
+    deferred = false,
+  }) {
+    const handle = { settle: null, fail: null };
+    const result = { trText, srLang, srCode, isSame };
+    const emitCapture = (capture) => {
+      capture?.onRequest?.(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model: `gpt-4-${label}`,
+            messages: [
+              { role: "system", content: "sys" },
+              { role: "user", content: `用户消息-${label}` },
+            ],
+          }),
+        },
+        { role: "user", content: `用户消息-${label}` }
+      );
+      capture?.onResponse?.({
+        marker: `响应体-${label}`,
+        choices: [{ message: { content: trText } }],
+      });
+    };
+    mockApiTranslate.mockImplementationOnce((opts = {}) => {
+      if (!deferred) {
+        emitCapture(opts.capture);
+        return Promise.resolve(result);
+      }
+      return new Promise((resolve, reject) => {
+        handle.settle = () => {
+          emitCapture(opts.capture);
+          resolve(result);
+        };
+        handle.fail = (error) => reject(error);
+      });
+    });
+    return handle;
+  }
+
+  /** 点击指定 testid 的元素（不等待异步完成，供 pending 态断言）。 */
+  function clickTestid(testid) {
+    act(() => {
+      queryTestid(testid).dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+  }
+
+  /** 把请求/响应面板都切到原始 JSON 视图（视图偏好跨轮保留，D4）。 */
+  function showBothRawViews() {
+    clickTestid("terminology-ai-req-toggle");
+    clickTestid("terminology-ai-resp-toggle");
+  }
+
+  test("连续三轮 AI 测试：摘要与原始 JSON 同源，pending 期间结果区隐藏，不累计上一轮内容", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+
+    // ── 第一轮 ──
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    queueAiRound({ label: "r1", srLang: "en", srCode: "en", isSame: false });
+    await runAiTest(container);
+
+    // 摘要视图：例句、译文、语言三项都来自第一轮。
+    expect(queryTestid("terminology-ai-request-text").textContent).toContain(
+      "zorp"
+    );
+    expect(queryTestid("terminology-ai-response-text").textContent).toBe(
+      "译文-r1"
+    );
+    const respSummary = queryTestid("terminology-ai-resp-scroll").textContent;
+    expect(respSummary).toContain("语言：en（en）");
+    expect(respSummary).toContain("同语言：否");
+
+    // 切原始 JSON：与摘要同源于同一份状态对象，标记同为 r1。
+    showBothRawViews();
+    expect(queryTestid("terminology-ai-req-json").textContent).toContain(
+      "gpt-4-r1"
+    );
+    expect(queryTestid("terminology-ai-resp-json").textContent).toContain(
+      "响应体-r1"
+    );
+
+    // ── 换一个例句：只换例句，已有结果保持显示且不折叠（D1） ──
+    clickTestid("terminology-ai-rotate-seed");
+    expect(queryTestid("terminology-ai-result")).not.toBeNull();
+    expect(queryTestid("terminology-ai-req-json").textContent).toContain(
+      "gpt-4-r1"
+    );
+    expect(queryTestid("terminology-ai-resp-json").textContent).toContain(
+      "响应体-r1"
+    );
+
+    // ── 第二轮：受控 pending，断言 testing 态结果区整体隐藏（D2/D3 的可观测等价） ──
+    fillAiTerms(container, setAiTermsDraft, "quzzle,缓存节点");
+    const round2 = queueAiRound({
+      label: "r2",
+      srLang: "zh",
+      srCode: "zh-CN",
+      isSame: true,
+      deferred: true,
+    });
+    clickTestid("terminology-ai-run-test");
+    expect(queryTestid("terminology-ai-result")).toBeNull();
+    expect(queryTestid("terminology-ai-error")).toBeNull();
+    expect(queryTestid("terminology-ai-run-test").disabled).toBe(true);
+
+    await act(async () => {
+      round2.settle();
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    // 视图偏好未被重置（D4），JSON 只含第二轮内容。
+    const req2 = queryTestid("terminology-ai-req-json").textContent;
+    const resp2 = queryTestid("terminology-ai-resp-json").textContent;
+    expect(req2).toContain("gpt-4-r2");
+    expect(req2).not.toContain("gpt-4-r1");
+    expect(resp2).toContain("响应体-r2");
+    expect(resp2).not.toContain("响应体-r1");
+
+    // 切回摘要：例句/译文/语言全部轮换到第二轮，不残留第一轮。
+    showBothRawViews();
+    const req2Summary = queryTestid("terminology-ai-request-text").textContent;
+    expect(req2Summary).toContain("quzzle");
+    expect(req2Summary).not.toContain("zorp");
+    expect(queryTestid("terminology-ai-response-text").textContent).toBe(
+      "译文-r2"
+    );
+    const resp2Summary = queryTestid("terminology-ai-resp-scroll").textContent;
+    expect(resp2Summary).toContain("语言：zh（zh-CN）");
+    expect(resp2Summary).toContain("同语言：是");
+
+    // ── 第三轮：换例句后再测，JSON 不为空且不累计前两轮 ──
+    clickTestid("terminology-ai-rotate-seed");
+    queueAiRound({ label: "r3" });
+    await runAiTest(container);
+    showBothRawViews();
+    const req3 = queryTestid("terminology-ai-req-json").textContent;
+    const resp3 = queryTestid("terminology-ai-resp-json").textContent;
+    expect(req3.trim()).not.toBe("");
+    expect(req3).toContain("gpt-4-r3");
+    expect(req3).not.toContain("gpt-4-r1");
+    expect(req3).not.toContain("gpt-4-r2");
+    expect(resp3).toContain("响应体-r3");
+    expect(resp3).not.toContain("响应体-r1");
+    expect(resp3).not.toContain("响应体-r2");
+
+    act(() => root.unmount());
+  });
+
+  test("非批量接口连续三轮同样不串轮次", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        useBatchFetch: false,
+      })
+    );
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    for (const label of ["n1", "n2", "n3"]) {
+      queueAiRound({ label });
+      await runAiTest(container);
+      expect(queryTestid("terminology-ai-response-text").textContent).toBe(
+        `译文-${label}`
+      );
+    }
+    // 非批量路径也保留原始 useBatchFetch，不被测试入口篡改。
+    expect(mockApiTranslate.mock.calls.at(-1)[0].apiSetting.useBatchFetch).toBe(
+      false
+    );
+
+    showBothRawViews();
+    const reqJson = queryTestid("terminology-ai-req-json").textContent;
+    expect(reqJson).toContain("gpt-4-n3");
+    expect(reqJson).not.toContain("gpt-4-n1");
+    expect(reqJson).not.toContain("gpt-4-n2");
+
+    act(() => root.unmount());
+  });
+
+  test("Task3: 测试入口强制 useContext:false，历史上下文不进入任何一轮请求", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({
+        apiSlug: "openai",
+        apiName: "OpenAI",
+        useContext: true,
+        contextSize: 3,
+      })
+    );
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    for (const label of ["c1", "c2", "c3"]) {
+      queueAiRound({ label });
+      await runAiTest(container);
+      // 每一轮都显式关闭上下文（getMsgHistory 单例因此不被读取）。
+      expect(mockApiTranslate.mock.calls.at(-1)[0].apiSetting.useContext).toBe(
+        false
+      );
+      // 接口原始配置未被就地修改，只有本次请求的副本被覆盖。
+      expect(mockResolvedTransApis[0].useContext).toBe(true);
+    }
+
+    // 第 2/3 轮展示的请求体只含本轮用户消息，不含上一轮例句文本。
+    showBothRawViews();
+    const reqJson = queryTestid("terminology-ai-req-json").textContent;
+    expect(reqJson).toContain("用户消息-c3");
+    expect(reqJson).not.toContain("用户消息-c1");
+    expect(reqJson).not.toContain("用户消息-c2");
+
+    act(() => root.unmount());
+  });
+
+  test("Task6: 失败轮仍可查看已捕获的请求 JSON，但不出现生效检测表", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    // 先触发 onRequest 再 reject：真实路径上 capture.onRequest 在 fetchData 之前执行。
+    mockApiTranslate.mockImplementation((opts = {}) => {
+      opts.capture?.onRequest?.(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model: "gpt-4-err",
+            messages: [{ role: "user", content: "用户消息-err" }],
+          }),
+        },
+        { role: "user", content: "用户消息-err" }
+      );
+      return Promise.reject(new Error("HTTP 401 Unauthorized"));
+    });
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+    await runAiTest(container);
+
+    // 错误提示与结果区并存：请求列在，响应列固定展示「未捕获到响应」。
+    expect(queryTestid("terminology-ai-error").textContent).toContain("401");
+    expect(queryTestid("terminology-ai-req-col")).not.toBeNull();
+    expect(queryTestid("terminology-ai-resp-scroll").textContent).toContain(
+      "未捕获到响应"
+    );
+    // 失败轮没有可摘要的译文，响应侧不给摘要↔JSON 开关。
+    expect(queryTestid("terminology-ai-resp-toggle")).toBeNull();
+
+    // 请求 JSON 视图非空，含本轮真实请求体。
+    clickTestid("terminology-ai-req-toggle");
+    const reqJson = queryTestid("terminology-ai-req-json");
+    expect(reqJson).not.toBeNull();
+    expect(reqJson.textContent).toContain("gpt-4-err");
+    expect(reqJson.textContent).toContain("用户消息-err");
+
+    // 不对失败轮做「已发出」结论：检测表与启发式说明都不出现。
+    expect(queryTestid("terminology-ai-delivery-zorp")).toBeNull();
+    const resultArea = queryTestid("terminology-ai-result").textContent;
+    expect(resultArea).not.toContain("术语表贡献与生效检测");
+    expect(resultArea).not.toContain("启发式参考");
+    // 软术语块仍列出术语，但不带会说反话的状态 Chip（失败轮请求其实已捕获）。
+    clickTestid("terminology-ai-req-toggle");
+    const softGlossary = queryTestid("terminology-ai-soft-glossary");
+    expect(softGlossary.textContent).toContain("zorp");
+    expect(softGlossary.querySelectorAll(".MuiChip-root")).toHaveLength(0);
+
+    act(() => root.unmount());
+  });
+
+  test("Task7: 取消 AI 测试后状态复位，按钮解锁且可立即发起下一轮", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    const pending = queueAiRound({ label: "cancel", deferred: true });
+    clickTestid("terminology-ai-run-test");
+    expect(queryTestid("terminology-ai-run-test").disabled).toBe(true);
+    expect(queryTestid("terminology-ai-run-test").textContent).toContain(
+      "测试中"
+    );
+    expect(queryTestid("terminology-ai-cancel")).not.toBeNull();
+
+    clickTestid("terminology-ai-cancel");
+    await act(async () => {
+      pending.fail(
+        new DOMException("The operation was aborted.", "AbortError")
+      );
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    // 复位为初始无结果态：按钮解锁、文案回到「测试」、取消按钮卸载、结果/错误区都不残留。
+    expect(queryTestid("terminology-ai-run-test").disabled).toBe(false);
+    expect(queryTestid("terminology-ai-run-test").textContent).not.toContain(
+      "测试中"
+    );
+    expect(queryTestid("terminology-ai-cancel")).toBeNull();
+    expect(queryTestid("terminology-ai-result")).toBeNull();
+    expect(queryTestid("terminology-ai-error")).toBeNull();
+    // 主动取消不算失败，不弹错误 Snackbar。
+    expect(mockAlert.error).not.toHaveBeenCalled();
+
+    // 解锁路径：立刻发起下一轮并正常拿到结果。
+    queueAiRound({ label: "after-cancel" });
+    await runAiTest(container);
+    expect(queryTestid("terminology-ai-result")).not.toBeNull();
+    expect(queryTestid("terminology-ai-response-text").textContent).toBe(
+      "译文-after-cancel"
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("Task7: 取消后即使请求继续 resolve 也不落 done 态", async () => {
+    mockResolvedTransApis.push(
+      mockResolvedApi({ apiSlug: "openai", apiName: "OpenAI" })
+    );
+    const { container, root, setAiTermsDraft } = renderPlayground({
+      rule: null,
+    });
+    await flushEffects();
+    fillAiTerms(container, setAiTermsDraft, "zorp,数据管道");
+
+    const pending = queueAiRound({ label: "late", deferred: true });
+    clickTestid("terminology-ai-run-test");
+    clickTestid("terminology-ai-cancel");
+    // 取消后迟到的成功响应：signal.aborted 早退分支同样复位状态。
+    await act(async () => {
+      pending.settle();
+      await Promise.resolve();
+    });
+    await flushEffects();
+
+    expect(queryTestid("terminology-ai-result")).toBeNull();
+    expect(queryTestid("terminology-ai-error")).toBeNull();
+    expect(queryTestid("terminology-ai-run-test").disabled).toBe(false);
+
+    act(() => root.unmount());
+  });
+
+  test("no custom resize handles remain; both term textareas use native resize:vertical", async () => {
+    const { container, root } = renderPlayground({ rule: null });
+    await flushEffects();
+    // 回归护栏：组件树中不应出现任何自定义缩放手柄 testid。
+    expect(
+      container.querySelector('[data-testid$="-resize-handle"]')
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid$="-resize-notch"]')
+    ).toBeNull();
+    // 术语库输入框与 AI 术语输入框的 textarea 声明原生 vertical 缩放样式。
+    const termsTextarea = container.querySelector(
+      '[data-testid="terminology-terms-input"] textarea'
+    );
+    const aiTextarea = container.querySelector(
+      '[data-testid="terminology-ai-terms-input"] textarea'
+    );
+    for (const textarea of [termsTextarea, aiTextarea]) {
+      expect(textarea).not.toBeNull();
+    }
+
+    act(() => root.unmount());
+  });
+});
+
+test("C1 Red：maskForDisplay 对零 own 键非纯对象返回类型标签而非空对象 {}", () => {
+  // 原型非 Object.prototype、own 可枚举键为空（等价原生 Response 的形态）。
+  class FakeResponse {}
+  // 旧实现展开得 {}，丢失类型信息 → Red；新实现诚实呈现类型标签。
+  expect(maskForDisplay(new FakeResponse())).toEqual({
+    __type: "FakeResponse",
+    ownKeys: 0,
+  });
+  // 纯对象完全不变。
+  expect(maskForDisplay({ ok: true, status: 200 })).toEqual({
+    ok: true,
+    status: 200,
+  });
+  // 数组完全不变。
+  expect(maskForDisplay([{ a: 1 }])).toEqual([{ a: 1 }]);
+  // 带 own 可枚举键的类实例：E1 窄门闸不吞掩码内容（green-to-green 锁定）。
+  class WithOwnKey {
+    constructor() {
+      this.token = "secret";
+    }
+  }
+  // own 键 "token" 命中 SENSITIVE_KEYS → 掩码路径 val.slice(0, 4) + "****"。
+  expect(maskForDisplay(new WithOwnKey())).toEqual({ token: "secr****" });
+});

--- a/src/views/Selection/TranForm.js
+++ b/src/views/Selection/TranForm.js
@@ -37,6 +37,38 @@ import { isSameTranslationLanguage } from "../../libs/language";
 /**
  * 翻译交互核心表单组件 (集成源/目标语言选择、多引擎翻译、词典展示、汉典展示、语言检测与文本输入)
  */
+
+// ─── 接口多选本地持久化（可选）───────────────────────────────────────────────
+// 仅当宿主显式传入 apiSlugsStorageKey 时启用（Playground 等），普通 Selection/TranForm
+// 不传 key 时行为完全不变。读取/写入全程异常降级：localStorage 不可用、脏 JSON、
+// 非数组、非字符串元素都视为"无可恢复值"，回落既有默认逻辑。
+// 有效存储的 [] 表示用户显式未选择接口（合法状态）；过滤后没有任何有效 slug 且非
+// 显式空选择则视为无可恢复值，走默认逻辑。
+function readStoredApiChoice(storageKey) {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw === null) return { status: "none" };
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return { status: "none" };
+    if (parsed.some((slug) => typeof slug !== "string")) {
+      return { status: "none" };
+    }
+    // 去重：重复 slug 视为同一选择。
+    const slugs = [...new Set(parsed)];
+    return { status: "restored", slugs, isEmpty: slugs.length === 0 };
+  } catch {
+    return { status: "none" };
+  }
+}
+
+function writeStoredApiChoice(storageKey, slugs) {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(slugs));
+  } catch {
+    // localStorage 不可用：静默降级，仅丢失跨刷新留存，不影响页面使用。
+  }
+}
+
 export default function TranForm({
   text,
   setText,
@@ -58,6 +90,7 @@ export default function TranForm({
   isPlaygound = false,
   autoFocusInput = true,
   syncExternalTextWhileEditing = false,
+  apiSlugsStorageKey = undefined,
 }) {
   const i18n = useI18n();
 
@@ -82,6 +115,15 @@ export default function TranForm({
     loading: false,
   });
   const inputRef = useRef(null);
+  // 待恢复的本地持久化接口选择（对应当前 storageKey 渲染期只读一次）。
+  // 哨兵语义：undefined = 未初始化（渲染期读取一次的唯一时机）；null = 已处理。
+  // 处理终态置 null 而非 undefined，避免渲染期读取条件被终态重新武装——否则
+  // 每个处理周期确定性重读 localStorage，且后续 effect 会携带陈旧快照再次执行
+  // 恢复分支，回退用户在窗口期内做出的选择。
+  const pendingApiSlugsRestoreRef = useRef(undefined);
+  if (apiSlugsStorageKey && pendingApiSlugsRestoreRef.current === undefined) {
+    pendingApiSlugsRestoreRef.current = readStoredApiChoice(apiSlugsStorageKey);
+  }
 
   const detectionKey = useMemo(
     () => `${langDetector}\u0000${text}`,
@@ -209,6 +251,36 @@ export default function TranForm({
     return apiSlugs.filter((slug) => validSlugs.has(slug));
   }, [apiSlugs, optApis]);
 
+  // 本地持久化接口选择恢复（apiSlugsStorageKey 可选）。
+  // 在 initApiSlugs 同步 effect 之后声明，保证恢复值胜出且标记为用户选择（不再被外部 prop 覆盖）。
+  // 异步 transApis 尚未就绪（optApis 为空）时保持 pending，待其到达后重新过滤恢复。
+  useEffect(() => {
+    const pending = pendingApiSlugsRestoreRef.current;
+    if (!pending) return; // 无 key / 非 Playground 宿主：保持既有行为
+    if (pending.status === "none") {
+      pendingApiSlugsRestoreRef.current = null; // 无可恢复值：回落默认逻辑
+      return;
+    }
+    if (optApis.length === 0) return; // 等异步 transApis 到达后再过滤
+    pendingApiSlugsRestoreRef.current = null;
+
+    const validSlugs = new Set(optApis.map((api) => api.key));
+    const filtered = pending.slugs.filter((slug) => validSlugs.has(slug));
+
+    if (pending.isEmpty) {
+      // 有效存储 [] = 用户显式未选择接口：保持空选择，不被默认值覆盖
+      setHasUserChangedApiSlugs(true);
+      setApiSlugs([]);
+    } else if (filtered.length > 0) {
+      // 恢复仍在启用的有效接口
+      setHasUserChangedApiSlugs(true);
+      setApiSlugs(filtered);
+    }
+    // 过滤后无有效 slug 且非显式空选择 → 无可恢复值，走既有默认逻辑
+    // (optional chaining safe; deps: optApis only)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optApis]);
+
   // 默认词典覆盖英文单词和单个汉字：英文走 Bing/有道，单字走汉典。
   const defaultDictAvailable =
     (isWord && OPT_DICT_MAP.has(enDict)) || isSingleChineseChar(text);
@@ -282,6 +354,10 @@ export default function TranForm({
                   onChange={(e) => {
                     setHasUserChangedApiSlugs(true);
                     setApiSlugs(e.target.value);
+                    // 仅在宿主显式提供 storageKey 时写回（空数组 = 用户显式清空）。
+                    if (apiSlugsStorageKey) {
+                      writeStoredApiChoice(apiSlugsStorageKey, e.target.value);
+                    }
                   }}
                 >
                   {optApis.map(({ key, name }) => (

--- a/src/views/Selection/TranForm.test.js
+++ b/src/views/Selection/TranForm.test.js
@@ -544,3 +544,265 @@ describe("TranForm input focus and external text synchronization", () => {
     act(() => root.unmount());
   });
 });
+
+describe("TranForm API selection persistence (apiSlugsStorageKey)", () => {
+  const TEST_STORAGE_KEY = "kt-test-tranform-api-slugs";
+  const mockApis = [
+    { apiSlug: "google", apiName: "Google", apiType: "Google" },
+    { apiSlug: "openai", apiName: "OpenAI", apiType: "OpenAI" },
+    { apiSlug: "deepl", apiName: "DeepL", apiType: "DeepL", isDisabled: true },
+  ];
+
+  beforeEach(() => {
+    apiDict.mockReset();
+    tryDetectLang.mockResolvedValue("en");
+    document.body.innerHTML = "";
+    window.localStorage.removeItem(TEST_STORAGE_KEY);
+  });
+
+  test("P4 Red: 用户多选接口后写入 storageKey，并在重新挂载后恢复选择", async () => {
+    // 第一次挂载：无持久化值，从 prop initApiSlugs=[] 启动
+    const view = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: [],
+      transApis: mockApis,
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    });
+    await flushEffects();
+
+    // 初始没有 TranCont
+    expect(view.container.querySelectorAll('[data-testid="tran-cont"]')).toHaveLength(0);
+
+    // 用户在下拉菜单勾选 openai
+    const apiSlugsInput = view.container.querySelector('input[name="apiSlugs"]');
+    const apiSlugsButton = apiSlugsInput
+      .closest(".MuiInputBase-root")
+      .querySelector('[role="combobox"], [role="button"], [aria-haspopup="listbox"]');
+    await act(async () => {
+      apiSlugsButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll('[role="option"]')]
+        .find((option) => option.getAttribute("data-value") === "openai")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    // 第一次已出现 openai
+    expect(
+      [...view.container.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["openai"]);
+
+    // 卸载组件（模拟页签切换 / 路由跳转）
+    act(() => view.root.unmount());
+    document.body.innerHTML = "";
+
+    // localStorage 中已写入
+    expect(window.localStorage.getItem(TEST_STORAGE_KEY)).toBe(
+      JSON.stringify(["openai"])
+    );
+
+    // 第二次挂载（即使 prop apiSlugs 仍传空数组，也从 storageKey 恢复）
+    const utils = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: [],
+      transApis: mockApis,
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    });
+    await flushEffects();
+
+    // 重新挂载后恢复了用户选择的 openai
+    expect(
+      [...utils.container.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["openai"]);
+
+    act(() => utils.root.unmount());
+  });
+
+  test("P4: 存储中存在非法 JSON、非数组或脏值时异常降级，回落既有默认行为", async () => {
+    // 损坏值
+    window.localStorage.setItem(TEST_STORAGE_KEY, "invalid-json{{");
+    const { container, root } = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: ["google"],
+      transApis: mockApis,
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    });
+    await flushEffects();
+
+    // 无崩溃，保持 prop 默认的 google
+    expect(
+      [...container.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["google"]);
+
+    act(() => root.unmount());
+  });
+
+  test("P4: 存储中的已删除或已禁用接口被自动过滤", async () => {
+    // 存储中含：已禁用的 deepl 与已删除的 ghost
+    window.localStorage.setItem(
+      TEST_STORAGE_KEY,
+      JSON.stringify(["openai", "deepl", "ghost"])
+    );
+    const { container, root } = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: [],
+      transApis: mockApis,
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    });
+    await flushEffects();
+
+    // 只恢复有效的 openai，已禁用的 deepl 与不存在的 ghost 被过滤
+    expect(
+      [...container.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["openai"]);
+
+    act(() => root.unmount());
+  });
+
+  test("P4: 有效存储空数组 [] 表示用户显式未选择，不被 prop 默认值覆盖", async () => {
+    window.localStorage.setItem(TEST_STORAGE_KEY, JSON.stringify([]));
+    const { container, root } = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: ["google"], // prop 默认传 google
+      transApis: mockApis,
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    });
+    await flushEffects();
+
+    // 用户显式选空 → 不展示任何翻译引擎
+    expect(container.querySelectorAll('[data-testid="tran-cont"]')).toHaveLength(0);
+
+    act(() => root.unmount());
+  });
+
+  test("P4: 未传 apiSlugsStorageKey 时不读写 localStorage，保持既有行为", async () => {
+    // 即使 localStorage 中有该键，未传 prop 也绝不读取
+    window.localStorage.setItem(TEST_STORAGE_KEY, JSON.stringify(["openai"]));
+    const { container, root } = renderTranForm({
+      simpleStyle: false,
+      apiSlugs: ["google"],
+      transApis: mockApis,
+      // 无 apiSlugsStorageKey
+    });
+    await flushEffects();
+
+    // 仍使用 prop 的 google，不使用存储的 openai
+    expect(
+      [...container.querySelectorAll('[data-testid="tran-cont"]')].map((el) =>
+        el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["google"]);
+
+    act(() => root.unmount());
+  });
+
+  test("Fix3 Red：恢复 pending 恰好读取一次 storage 且不回退用户窗口期内选择", async () => {
+    // 前置（防假绿 Red）：必须预置有效可恢复选择——旧实现的确定性重读依赖
+    // 恢复分支实际执行 setApiSlugs 触发重渲染；无预置时置 null 无 setState，
+    // 计数恒 1，断言在坏代码上也绿。
+    window.localStorage.setItem(TEST_STORAGE_KEY, JSON.stringify(["alpha"]));
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    const keyReads = () =>
+      getItemSpy.mock.calls.filter(([key]) => key === TEST_STORAGE_KEY).length;
+
+    const firstGenApis = [
+      { apiSlug: "alpha", apiName: "Alpha", apiType: "OpenAI" },
+      { apiSlug: "beta", apiName: "Beta", apiType: "OpenAI" },
+    ];
+    const baseProps = {
+      text: "library",
+      setText: jest.fn(),
+      apiSlugs: [],
+      fromLang: "en",
+      toLang: "zh-CN",
+      toLang2: "-",
+      transApis: firstGenApis,
+      simpleStyle: false,
+      langDetector: "-",
+      enDict: "Bing",
+      enSug: "-",
+      aiDictApiSlug: "-",
+      apiSlugsStorageKey: TEST_STORAGE_KEY,
+    };
+    // 不解构 container：DOM 查询走 document.body（eslint-plugin-testing-library
+    // 对 renderTranForm——名称含 "render" 子串——返回的 container 变量查询
+    // 会被 no-container 误报，body 级查询为既有豁免先例）。
+    const { root } = renderTranForm(baseProps);
+    await flushEffects();
+
+    // 断言 1：挂载完成恢复恰好读取一次 storage（旧实现渲染期条件被终态
+    // 重新武装 → 确定性重读 → 计数 2 → Red）。
+    expect(keyReads()).toBe(1);
+    expect(
+      [...document.body.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["alpha"]);
+
+    // 用户经真实 Select 改选为恰好 ["beta"]（恢复后 alpha 已选中：
+    // 先加选 beta，再取消 alpha）。
+    const apiSlugsInput = document.body.querySelector('input[name="apiSlugs"]');
+    const apiSlugsButton = apiSlugsInput
+      .closest(".MuiInputBase-root")
+      .querySelector(
+        '[role="combobox"], [role="button"], [aria-haspopup="listbox"]'
+      );
+    await act(async () => {
+      apiSlugsButton.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true })
+      );
+      await Promise.resolve();
+    });
+    const clickOption = async (slug) => {
+      await act(async () => {
+        [...document.body.querySelectorAll('[role="option"]')]
+          .find((option) => option.getAttribute("data-value") === slug)
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+    };
+    await clickOption("beta");
+    await clickOption("alpha");
+
+    expect(
+      [...document.body.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["beta"]);
+
+    // 断言 2（双断言缺一不可）：二代 transApis（新数组引用，仍含 alpha 与
+    // beta）重渲染后，恢复既不得重读 storage，也不得把用户选择回退为
+    // 渲染期陈旧快照。
+    const secondGenApis = [
+      { apiSlug: "alpha", apiName: "Alpha", apiType: "OpenAI" },
+      { apiSlug: "beta", apiName: "Beta", apiType: "OpenAI" },
+    ];
+    // act 回调内以具名中转函数重渲染（同 no-unnecessary-act 子串匹配规避）。
+    const mountWithApis = (apis) => {
+      root.render(<TranForm {...baseProps} transApis={apis} />);
+    };
+    act(() => {
+      mountWithApis(secondGenApis);
+    });
+    await flushEffects();
+
+    expect(keyReads()).toBe(1);
+    expect(
+      [...document.body.querySelectorAll('[data-testid="tran-cont"]')].map(
+        (el) => el.getAttribute("data-api-slug")
+      )
+    ).toEqual(["beta"]);
+
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
## 概述

重构专业术语（Glossary/Terms）本地正则替换引擎，修复多处长短词冲突与边界情况，并在 Options 设置页新增「专业术语 Playground」可视化测试台，支持本地无网络即时演算断言与真实 AI 接口提示词注入诊断。

## 主要改动

1. **术语替换核心引擎重构** (`src/libs/terms.js`, `termTestUtils.js`)：
   - 规范化术语解析流程（支持每行 / 分号分隔键值对），增加未转义正则元字符告警与非法段致命诊断。
   - 重构替换算法，基于冲突矩阵正确处理包含关系、重叠匹配与长词优先替换。
   - 增加 `scripts/test-term-replace.js` CLI 诊断脚本与丰富的单元测试。

2. **专业术语测试台** (`src/views/Options/TerminologyPlayground.js`, `Playground.js`)：
   - 设置页增加「专业术语」专属测试页签，支持例句自动轮换、本地替换前后对比与结构化断言展示。
   - 提供真实 AI 接口联动测试：捕获并展示实际发送的请求体与响应摘要，可视化检测 AI 对 glossary 的遵循情况。
   - 适配浅色/深色主题，支持全键盘与屏幕阅读器无障碍属性。

3. **多语言与附带修复** (`src/config/i18n.js`, `translatorManager.js`, `inputTranslate.js`, `apis/`)：
   - 为 Playground 全量补齐 7 种 UI 语言文案（中、英、繁、日、韩、土、越）。
   - 修复 `translatorManager` 运行时热更新与实例复活问题。
   - 修复 `inputTranslate` 中的定时器清理与变体透传逻辑。
   - 增强 AI 接口的 system prompt 对 glossary 的指令约束。

## 测试与验证

- 对应单元测试全部通过（`terms.test.js`, `termTestUtils.test.js`, `TerminologyPlayground.test.js` 88/88, `Playground.test.js`, `translator.test.js` 等）。
- 代码已通过 Prettier 格式化检查。
- `pnpm build:firefox` 构建验证通过。

## 关联与依赖

- 独立 PR，不依赖其他分支，可单独合入。

---
**ai专业术语例1**
<img width="1660" height="827" alt="Screenshot 2026-08-23 at 16-30-38 KISS Translator - Open-source minimalist bilingual translation" src="https://github.com/user-attachments/assets/23a59c44-7d1a-4b19-ae5e-c1f7ced5c4a2" />

---
**ai专业术语例2**
<img width="1660" height="697" alt="Screenshot 2026-08-23 at 16-31-16 KISS Translator - Open-source minimalist bilingual translation" src="https://github.com/user-attachments/assets/f3be3a62-9fa0-4469-bc40-e5e9194ba1b7" />

---

已测试的端点有`/chat` `/message`下的 聚合/非聚合翻译