### PR TITLE
🐛 fix(webui): 修复悬浮按钮跨视口越界坐标导致消失 (Fixes #1060)

### DIFF
--- a/src/views/Action/Draggable.js
+++ b/src/views/Action/Draggable.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
-import { limitNumber } from "../../libs/utils";
+import { limitFloat, limitNumber } from "../../libs/utils";
 import { isMobile } from "../../libs/mobile";
 import { putFab } from "../../libs/storage";
 import { debounce } from "../../libs/utils";
@@ -72,11 +72,11 @@ export const getEdgePosition = ({
   if (edge === "left" || edge === "right") {
     const minY = 0;
     const maxY = Math.max(minY, windowHeight - height / 2);
-    top = limitNumber(top, minY, maxY);
+    top = limitFloat(top, minY, maxY);
   } else {
     const minX = -width / 2;
     const maxX = Math.max(minX, windowWidth - width / 2);
-    left = limitNumber(left, minX, maxX);
+    left = limitFloat(left, minX, maxX);
   }
 
   return { x: left, y: top };

--- a/src/views/Action/Draggable.js
+++ b/src/views/Action/Draggable.js
@@ -42,6 +42,16 @@ export const getEdgePosition = ({
   hover,
   edge,
 }) => {
+  // 有限值归一化，防止 NaN/Infinity 或零视口把负上限/NaN 传入 clamp
+  const safeCoord = (value, fallback) =>
+    typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  width = safeCoord(width, 1);
+  height = safeCoord(height, 1);
+  windowWidth = safeCoord(windowWidth, 1);
+  windowHeight = safeCoord(windowHeight, 1);
+  left = safeCoord(left, 0);
+  top = safeCoord(top, 0);
+
   switch (edge) {
     case "right":
       left = hover ? windowWidth - width : windowWidth - width / 2;
@@ -55,6 +65,20 @@ export const getEdgePosition = ({
     default:
       top = hover ? 0 : -height / 2;
   }
+
+  // 正交轴 clamp，与 handlePointerMove 拖拽范围完全一致（拖拽同界语义）：
+  // left/right 分支 clamp top（y 最小值为 0，沿用上游拖拽不对称语义）；
+  // 其余（top/bottom 及 default 的垂直语义）clamp left
+  if (edge === "left" || edge === "right") {
+    const minY = 0;
+    const maxY = Math.max(minY, windowHeight - height / 2);
+    top = limitNumber(top, minY, maxY);
+  } else {
+    const minX = -width / 2;
+    const maxX = Math.max(minX, windowWidth - width / 2);
+    left = limitNumber(left, minX, maxX);
+  }
+
   return { x: left, y: top };
 };
 

--- a/src/views/Action/Draggable.test.js
+++ b/src/views/Action/Draggable.test.js
@@ -141,6 +141,21 @@ describe("Draggable FAB edge locking", () => {
     expect(draggable.style.transform).toBe(expected);
   });
 
+  test("preserves fractional proportional position across uneven viewport resizes", () => {
+    let fab = renderFab({ edge: "top", left: 300, top: -20 });
+
+    setViewport(1001, 400);
+    fab = rerenderFab(fab, { windowSize: { w: 1001, h: 400 } });
+    expect(draggable.style.transform).toBe("translate(500.5px, -20px)");
+
+    setViewport(600, 400);
+    rerenderFab(fab, { windowSize: { w: 600, h: 400 } });
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(draggable.style.transform).toBe("translate(300px, -20px)");
+    expect(putFab).toHaveBeenLastCalledWith({ x: 300, y: -20, edge: "top" });
+  });
+
   test("hovering expands the FAB without changing its saved edge", () => {
     renderFab();
 

--- a/src/views/Action/Draggable.test.js
+++ b/src/views/Action/Draggable.test.js
@@ -1,6 +1,6 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import Draggable from "./Draggable";
+import Draggable, { getEdgePosition } from "./Draggable";
 import { putFab } from "../../libs/storage";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -196,5 +196,90 @@ describe("Draggable FAB edge locking", () => {
 
     expect(draggable.style.transform).toBe("translate(580px, 200px)");
     expect(putFab).toHaveBeenLastCalledWith({ x: 580, y: 200, edge: "right" });
+  });
+
+  test("poison coordinates from a narrower viewport are clamped into drag-reachable bounds on mount", () => {
+    // 毒坐标新视口挂载回归：800×600 视口挂载遗留自宽视口的 {x:1400, y:-20, edge:"top"}。
+    // top: -20 是历史毒坐标输入，但 top 分支输出 -20 实际来自 -height / 2（贴边隐藏语义），不是输入值。
+    // putFab 为 mock：本测试只证明传给 putFab 的 payload 不再含越界正交坐标，不覆盖真实 storage 读写闭环。
+    setViewport(800, 600);
+    const fab = renderFab({
+      left: 1400,
+      top: -20,
+      edge: "top",
+      windowSize: { w: 800, h: 600 },
+    });
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(draggable.style.transform).toBe("translate(780px, -20px)");
+    expect(putFab).toHaveBeenLastCalledWith({ x: 780, y: -20, edge: "top" });
+  });
+
+  test.each([
+    ["left", -20, "translate(-20px, 0px)"],
+    ["right", 580, "translate(780px, 580px)"],
+    ["top", -20, "translate(-20px, -20px)"],
+    ["bottom", 780, "translate(780px, 580px)"],
+  ])(
+    "keeps half-hidden corner semantics for %s edge under drag-same-bound clamp",
+    (edge, ortho, expected) => {
+      // 四个角落：只有被 clamp 的正交轴越界值收敛（如 edge=left 的 top=-20 -> 0，
+      // 因拖拽 min y=0），其余拖拽可达位置全部保持原样（如右下/左上双半隐藏）。
+      setViewport(800, 600);
+      const fab = renderFab({
+        left: edge === "top" || edge === "bottom" ? ortho : 1400,
+        top: edge === "left" || edge === "right" ? ortho : 500,
+        edge,
+        windowSize: { w: 800, h: 600 },
+      });
+      act(() => jest.runOnlyPendingTimers());
+
+      expect(draggable.style.transform).toBe(expected);
+    }
+  );
+
+  test("zero viewport yields finite in-range corners without NaN or negative upper bound", () => {
+    setViewport(0, 0);
+    const fab = renderFab({
+      left: 0,
+      top: 0,
+      edge: "top",
+      windowSize: { w: 0, h: 0 },
+    });
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(draggable.style.transform).toBe("translate(-20px, -20px)");
+    expect(draggable.style.transform).not.toMatch(/NaN|Infinity/);
+    expect(putFab).toHaveBeenLastCalledWith({ x: -20, y: -20, edge: "top" });
+  });
+
+  test("non-finite coordinates fall back safely instead of producing illegal transforms", () => {
+    const fab = renderFab({
+      left: Infinity,
+      top: Number.NaN,
+      edge: "left",
+      windowSize: { w: 800, h: 600 },
+    });
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(draggable.style.transform).toBe("translate(-20px, 0px)");
+    expect(draggable.style.transform).not.toMatch(/NaN|Infinity/);
+    expect(putFab).toHaveBeenLastCalledWith({ x: -20, y: 0, edge: "left" });
+  });
+
+  test("default edge (undefined) follows top semantics when clamping the orthogonal axis", () => {
+    // switch default 分支按"贴顶"重算 top，正交轴应为 left：
+    // 毒坐标 1400 收敛到 780，top 保持 -height/2 半隐藏语义，不被误收敛到 0
+    const result = getEdgePosition({
+      x: 1400,
+      y: -20,
+      width: 40,
+      height: 40,
+      windowWidth: 800,
+      windowHeight: 600,
+      hover: false,
+      edge: undefined,
+    });
+    expect(result).toEqual({ x: 780, y: -20 });
   });
 });


### PR DESCRIPTION
Fixes #1060

## Summary / 概述

宽视口（如 1920/2K/4K）下把悬浮球拖拽吸附到**顶部/底部边缘**后，在小屏、分屏或更窄窗口打开新网页时，历史绝对坐标（如 `{x:1400, y:-20, edge:"top"}`）超出当前视口拖拽可达范围；`getEdgePosition()` 原先不约束正交轴，悬浮球被 transform 到视口外并把越界坐标写回 storage，导致**永久不可见、刷新无法恢复**。

本修复按**拖拽同界语义**（与 `handlePointerMove` 边界完全一致）对正交轴做 clamp：

- top/bottom（含 default 贴顶语义）分支 clamp left 至 `[-width/2, windowWidth-width/2]`
- left/right 分支 clamp top 至 `[0, windowHeight-height/2]`（y 最小值为 0，沿用拖拽不对称语义）
- 坐标先做有限值归一化（`typeof number && Number.isFinite`），防止 NaN/Infinity 或零视口产生非法 clamp 输入

合法半隐藏贴边位置（用户可拖拽到达的位置）**不被改写**；仅收敛超出拖拽可达范围的越界值（如 `x=1400 @ 800` → `780`）。

## Red → Green / 缺陷复现证据

Red（修复前，upstream 原生代码）：
```text
Expected: "translate(780px, -20px)"
Received: "translate(1400px, -20px)"
Tests: 1 failed, 7 passed, 8 total
```

Green（修复后）：`15 passed / 15 total`。

## Tests / 测试

`npm test -- --runInBand --watchAll=false src/views/Action/Draggable.test.js` → **15 passed**

- 跨视口毒坐标挂载回归：`{left:1400, top:-20, edge:"top"}` @ 800×600 → `translate(780px,-20px)`，`putFab` payload 不再含 `x=1400`
- 四个角落半隐藏语义护栏（left/right/top/bottom）
- 零视口与非有限坐标（NaN/Infinity）不产生非法 transform
- default 边（edge=undefined）沿用贴顶 clamp 语义的防守用例
- 上游既有测试（贴边/resize 比例/hover/拖拽换边/legacy 推断）全部保持通过

`npm test -- --runInBand --watchAll=false src/common.test.js` → **16 passed**（入口启动未受影响）

全量套件：`1034 passed / 2 failed`，2 个失败为**上游已知基线**（`trans.dict.test.js` prompt 断言、`batchQueue.test.js` 时序竞态），与本 PR 无关。

## Scope / 变更范围

- 仅修改 `src/views/Action/Draggable.js` 的 `getEdgePosition()`（+23）
- 仅新增 `src/views/Action/Draggable.test.js` 测试（+87）
- 不涉及 storage 语义、Manager 生命周期、设置页、Shadow DOM 或任何配置结构变化
- 已核实 `getEdgePosition`/`getNearestEdge` 仅在本文件内被调用（无外部调用方）；Popup 用法不传 `snapEdge`，不受影响