### PR TITLE
fix(youtube): preserve comment sort menu layout

### DIFF
--- a/src/config/rules.js
+++ b/src/config/rules.js
@@ -200,7 +200,7 @@ const RULES_MAP = {
   },
   "www.youtube.com": {
     rootsSelector: `ytd-page-manager`,
-    ignoreSelector: `aside, button, footer, form, header, pre, mark, nav, #player, #container, .caption-window, .ytp-settings-menu, #kiss-youtube-subtitle-list-container`,
+    ignoreSelector: `aside, button, footer, form, header, pre, mark, nav, #player, #container, .caption-window, .ytp-settings-menu, #kiss-youtube-subtitle-list-container, #sort-menu`,
     selectStyle: `-webkit-line-clamp: unset; max-height: none; height: auto;`,
     parentStyle: `-webkit-line-clamp: unset; max-height: none; height: auto;`,
     grandStyle: `-webkit-line-clamp: unset; max-height: none; height: auto;`,

--- a/src/libs/rules.test.js
+++ b/src/libs/rules.test.js
@@ -1,7 +1,7 @@
 import { checkRules, matchRule, saveRule } from "./rules";
 import { getDisabledSubRules, getRulesWithDefault, setRules } from "./storage";
 import { loadOrFetchSubRules } from "./subRules";
-import { GLOBLA_RULE } from "../config/rules";
+import { BUILTIN_RULES, GLOBLA_RULE } from "../config/rules";
 import { OPT_TRANS_MICROSOFT, OPT_TRANS_TENCENT } from "../config/api";
 
 jest.mock("./storage", () => ({
@@ -27,6 +27,16 @@ jest.mock("./log", () => ({
 
 test("uses Microsoft as the default webpage translator", () => {
   expect(GLOBLA_RULE.apiSlug).toBe(OPT_TRANS_MICROSOFT);
+});
+
+test("protects the YouTube comment sort menu from automatic translation", () => {
+  const youtubeRule = BUILTIN_RULES.find(
+    ({ pattern }) => pattern === "www.youtube.com"
+  );
+
+  expect(youtubeRule?.ignoreSelector.split(",").map((s) => s.trim())).toContain(
+    "#sort-menu"
+  );
 });
 
 test("keeps an explicitly stored Tencent global rule", async () => {


### PR DESCRIPTION
## Summary

- Add YouTube `#sort-menu` to the built-in translation ignore selector.
- Add a regression test that asserts the comment sort menu remains ignored.

## Problem

When webpage translation was enabled on YouTube, the comment sort menu could be translated as part of the page. The hidden dropdown content and SVG icon then received KISS-Translator nodes/layout handling, which caused the menu and its ancestors to become abnormally large and misaligned. Comment body translation itself continued to work.

## Fix

The YouTube rule now treats `#sort-menu` as an ignored subtree. This keeps the native menu DOM and its hidden dropdown out of automatic webpage translation while leaving the surrounding comment text translatable.

## Verification

- `node --check src/config/rules.js`
- `git diff --check`
- `react-app-rewired test --watchAll=false --runInBand src/libs/rules.test.js` (15 passed)
- `react-app-rewired test --watchAll=false --runInBand src/libs/translator.test.js` (104 passed)
- `pnpm run build:chrome` (successful)
- Manual YouTube checks: comment bodies still translate; the sort menu opens/closes normally and appears once; another regular video remains correct. The previously observed live-stream layout issue is intentionally out of scope for this PR.

Fixes #1067
