### PR TITLE
🐛 fix(apis): 修复跨协议上下文历史写入与轮次截断

### DIFF
--- a/src/apis/history.js
+++ b/src/apis/history.js
@@ -24,6 +24,57 @@ const MsgHistory = (maxSize = DEFAULT_CONTEXT_SIZE) => {
   };
 
   /**
+   * 成对写入一轮 user/assistant 对话，并按完整轮次维护队列长度。
+   * 守卫不满足（缺 userMsg、非 assistant 角色、正文为空或非字符串）时整对不写，
+   * 绝不留下孤立 user。仅持久化 {role, content} 两字段，响应其余字段不进入历史。
+   * 污染历史（role 交替破坏或混入非标准条目）走逐条截断回退通道，不改写既有条目。
+   */
+  const addPair = (userMsg, assistantMsg) => {
+    if (
+      !userMsg ||
+      assistantMsg?.role !== "assistant" ||
+      typeof assistantMsg?.content !== "string" ||
+      assistantMsg.content.length === 0
+    ) {
+      return;
+    }
+    const finalAssistantMsg = {
+      role: assistantMsg.role,
+      content: assistantMsg.content,
+    };
+    // 先于容量取整执行：存量头部孤立 assistant（旧逐条截断遗留）总能被清理
+    while (messages[0]?.role === "assistant") {
+      messages.shift();
+    }
+    const k = Math.floor(maxSize / 2);
+    if (k < 1) {
+      return;
+    }
+    // 干净谓词仅按 role 交替判定，content 形态不参与路由
+    const isCleanHistory = messages.every(
+      (m, i) => m?.role === (i % 2 === 0 ? "user" : "assistant")
+    );
+    if (isCleanHistory) {
+      if (messages.length % 2 === 1) {
+        // 干净序列下奇数长度只可能是尾部孤立 user（防御性，现行写入点不可达）
+        messages.pop();
+      }
+      messages.push(userMsg, finalAssistantMsg);
+      while (messages.length > 2 * k) {
+        // 从最旧完整轮次成对删除，避免奇数容量产生孤立 assistant
+        messages.splice(0, 2);
+      }
+    } else {
+      // 污染回退：追加不静默失败，按 add 同款逐条截断保持容量有界
+      messages.push(userMsg, finalAssistantMsg);
+      const extra = messages.length - maxSize;
+      if (extra > 0) {
+        messages.splice(0, extra);
+      }
+    }
+  };
+
+  /**
    * 克隆并获取当前存留的所有历史消息数组
    */
   const getAll = () => {
@@ -39,6 +90,7 @@ const MsgHistory = (maxSize = DEFAULT_CONTEXT_SIZE) => {
 
   return {
     add,
+    addPair,
     getAll,
     clear,
   };

--- a/src/apis/history.test.js
+++ b/src/apis/history.test.js
@@ -1,0 +1,171 @@
+import { getMsgHistory, clearMsgHistory } from "./history";
+
+const user = (content) => ({ role: "user", content });
+const assistant = (content) => ({ role: "assistant", content });
+
+describe("MsgHistory addPair", () => {
+  // 实例容量在首次创建后锁存（getMsgHistory 忽略同 slug 的第二次 maxSize），
+  // 每个用例使用独立 slug，避免跨用例假红/假绿。
+  const usedSlugs = [];
+  const makeHistory = (maxSize) => {
+    const slug = `addpair-test-${usedSlugs.length}`;
+    usedSlugs.push(slug);
+    return getMsgHistory(slug, maxSize);
+  };
+
+  afterEach(() => {
+    usedSlugs.forEach((slug) => clearMsgHistory(slug));
+    usedSlugs.length = 0;
+  });
+
+  test("空历史写入一对 → [user, assistant]", () => {
+    const history = makeHistory(10);
+    history.addPair(user("u1"), assistant("a1"));
+    expect(history.getAll()).toEqual([user("u1"), assistant("a1")]);
+  });
+
+  test("maxSize=3 两轮 → 只留最新一对（奇数容量向下取整轮）", () => {
+    const history = makeHistory(3);
+    history.addPair(user("u1"), assistant("a1"));
+    history.addPair(user("u2"), assistant("a2"));
+    expect(history.getAll()).toEqual([user("u2"), assistant("a2")]);
+  });
+
+  test("偶数容量 maxSize=4 → 保留两对，最旧完整对先删", () => {
+    const history = makeHistory(4);
+    history.addPair(user("u1"), assistant("a1"));
+    history.addPair(user("u2"), assistant("a2"));
+    history.addPair(user("u3"), assistant("a3"));
+    expect(history.getAll()).toEqual([
+      user("u2"),
+      assistant("a2"),
+      user("u3"),
+      assistant("a3"),
+    ]);
+  });
+
+  test("干净前缀尾部孤立 user → 丢弃后追加，不以孤立 assistant 开头", () => {
+    const history = makeHistory(10);
+    history.add(user("u1"), assistant("a1"), user("u2"));
+    history.addPair(user("u3"), assistant("a3"));
+    expect(history.getAll()).toEqual([
+      user("u1"),
+      assistant("a1"),
+      user("u3"),
+      assistant("a3"),
+    ]);
+  });
+
+  test("maxSize=1 no-op：不写入、不报错，预置头部孤立 assistant 仍被清理", () => {
+    const history = makeHistory(1);
+    history.add(assistant("孤儿"));
+    history.addPair(user("u1"), assistant("a1"));
+    expect(history.getAll()).toEqual([]);
+  });
+
+  test("maxSize=0 no-op：列表恒空，与旧 add 的恒空语义观测等价", () => {
+    // 「maxSize=0 + 预置头部孤儿」经公开 API 不可构造：add 在 maxSize=0 实例上
+    // push 后立即被 splice 清空（history.js add 逐条截断），messages 闭包私有、
+    // 容量锁存不可变更。本用例只钉空列表 no-op 不抛错；maxSize=1 × 孤儿另有用例。
+    const history = makeHistory(0);
+    history.addPair(user("u1"), assistant("a1"));
+    expect(history.getAll()).toEqual([]);
+  });
+
+  test("遗留逐条截断稳态头部孤立 assistant [a,u,a] → 清理后按干净路径追加", () => {
+    const history = makeHistory(3);
+    history.add(assistant("a0"), user("u1"), assistant("a1"));
+    history.addPair(user("u2"), assistant("a2"));
+    expect(history.getAll()).toEqual([user("u2"), assistant("a2")]);
+  });
+
+  test("头部连续多个孤立 assistant → 全部丢弃", () => {
+    const history = makeHistory(10);
+    history.add(assistant("x"), assistant("y"), user("u1"), assistant("a1"));
+    history.addPair(user("u2"), assistant("a2"));
+    expect(history.getAll()).toEqual([
+      user("u1"),
+      assistant("a1"),
+      user("u2"),
+      assistant("a2"),
+    ]);
+  });
+
+  test("污染历史走逐条回退：追加成功、既有条目不改写、长度有界", () => {
+    const history = makeHistory(3);
+    const kept = assistant("a1");
+    history.add(user("u1"), { type: "thought", text: "t" }, kept);
+    history.addPair(user("u2"), assistant("a2"));
+    const all = history.getAll();
+    expect(all).toHaveLength(3);
+    // 头部逐条截断镜像 add 语义；保留下来的旧条目是原对象引用，未被改写
+    expect(all[0]).toBe(kept);
+    expect(all).toEqual([assistant("a1"), user("u2"), assistant("a2")]);
+  });
+
+  test("污染回退遗留的头部孤立 assistant → 下一轮 addPair 自愈", () => {
+    const history = makeHistory(3);
+    history.add(user("u1"), { type: "thought" }, assistant("a1"));
+    history.addPair(user("u2"), assistant("a2"));
+    expect(history.getAll()).toEqual([
+      assistant("a1"),
+      user("u2"),
+      assistant("a2"),
+    ]);
+    history.addPair(user("u3"), assistant("a3"));
+    expect(history.getAll()).toEqual([user("u3"), assistant("a3")]);
+  });
+
+  test("role 交替但 content 非字符串的历史 → 走干净快路径，不清洗条目", () => {
+    const history = makeHistory(4);
+    const weirdUser = { role: "user", content: { parts: ["x"] } };
+    const weirdAssistant = { role: "assistant", content: null };
+    history.add(weirdUser, weirdAssistant);
+    history.addPair(user("u2"), assistant("a2"));
+    expect(history.getAll()).toEqual([
+      weirdUser,
+      weirdAssistant,
+      user("u2"),
+      assistant("a2"),
+    ]);
+  });
+
+  test("assistantMsg 携带额外字段 → 仅持久化 {role, content} 两字段", () => {
+    const history = makeHistory(10);
+    history.addPair(user("u1"), {
+      role: "assistant",
+      content: "a1",
+      reasoning_content: "思考过程",
+      tool_calls: [{ id: "t" }],
+    });
+    expect(history.getAll()).toEqual([
+      user("u1"),
+      { role: "assistant", content: "a1" },
+    ]);
+  });
+
+  test.each([
+    ["userMsg 缺失", null, assistant("a")],
+    ["role 非 assistant", user("u"), { role: "model", content: "a" }],
+    ["role 缺失", user("u"), { content: "a" }],
+    ["content 空串", user("u"), assistant("")],
+    ["content 非字符串", user("u"), assistant(null)],
+  ])("守卫失败分支：%s → 整对不写且不改既有列表", (_name, u, a) => {
+    const history = makeHistory(10);
+    history.add(user("旧"), assistant("历史"));
+    const before = history.getAll();
+    history.addPair(u, a);
+    expect(history.getAll()).toEqual(before);
+  });
+
+  test("守卫失败 + 预置头部孤儿 → 整对不写、孤儿原样留存（守卫先于头部修复）", () => {
+    const history = makeHistory(10);
+    const orphan = assistant("孤儿");
+    history.add(orphan);
+    // content 空串：守卫失败分支。若实现把头部修复误置于守卫之前，孤儿会被清掉、本用例炸红。
+    history.addPair(user("u1"), assistant(""));
+    const all = history.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toBe(orphan);
+  });
+});

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -1664,33 +1664,57 @@ export const parseTransRes = async (
     case OPT_TRANS_OPENROUTER:
     case OPT_TRANS_ORCAROUTER:
       modelMsg = res?.choices?.[0]?.message;
-      if (history && userMsg && modelMsg) {
-        history.add(userMsg, {
-          role: modelMsg.role,
-          content: modelMsg.content,
-        });
+      if (history && userMsg) {
+        // 成对写入与轮次截断守卫统一内聚在 addPair：空正文/非 assistant role 整对不写
+        history.addPair(userMsg, modelMsg);
       }
       return parseAIRes(modelMsg?.content, useBatchFetch);
     case OPT_TRANS_GEMINI:
+      // Gemini Interactions steps may include thought items.
+      // Their context replay semantics are outside this history-correctness fix.
       if (history && Array.isArray(res?.steps)) {
         history.clear();
         history.add(...res.steps);
       } else {
+        // Gemini generateContent 路径行为未变更：modelMsg 可为 undefined，由既有守卫拦截。
         modelMsg = res?.candidates?.[0]?.content;
         if (history && userMsg && modelMsg) {
           history.add(userMsg, modelMsg);
         }
       }
       return parseAIRes(geminiResponseText(res), useBatchFetch);
-    case OPT_TRANS_CLAUDE:
-      modelMsg = { role: res?.role, content: res?.content?.text };
-      if (history && userMsg && modelMsg) {
-        history.add(userMsg, {
-          role: modelMsg.role,
-          content: modelMsg.content,
-        });
+    case OPT_TRANS_CLAUDE: {
+      // 历史上下文取值必须做形态归一化，原因有三：
+      // 1. 形态防御：响应 content 存在多种形态 —— Anthropic 标准的块数组
+      //    [{type:"text",text:"…"}]、第三方实现可能返回的纯字符串、以及单对象
+      //    {type:"text",text:"…"}。只写 .map(...) 会在字符串形态上抛 TypeError
+      //    让整页翻译崩溃，只写 content?.text 又取不到块数组里的文本，故三分支全覆盖。
+      // 2. 网关现实：Claude 模型价格昂贵且平台随意封号，实际拿来翻译的机会很少；
+      //    现实中这个 /messages 接口多由第三方开源网关模拟 Claude Message 协议提供，
+      //    并不能真实代表 Anthropic 原装 Claude 的体验，响应形态更需要宽容。
+      // 3. 历史教训：本行旧写法是 res?.content?.text —— 块数组没有 .text 属性，
+      //    于是开启「智能上下文」时写进历史的 assistant 条目全是空壳 {role:"assistant"}，
+      //    上下文功能对 Claude 实际失效。2026-08 由用户抓包发现并修复。
+      // 取全部文本块拼接而非只取 [0]：历史上下文应完整保留模型输出，
+      // 与下方解析译文只取首块（最小变更）是两种用途。
+      // 是否写入历史由 addPair 的统一守卫裁决：role 缺失或无可用文本的响应
+      // 整对不写，与其它协议分支语义一致；多块拼接/thinking-first 的统一语义
+      // 不在本修复范围内。
+      const pickClaudeText = (c) =>
+        Array.isArray(c)
+          ? c
+              .map((b) => b?.text)
+              .filter(Boolean)
+              .join("")
+          : typeof c === "string"
+            ? c
+            : (c?.text ?? "");
+      modelMsg = { role: res?.role, content: pickClaudeText(res?.content) };
+      if (history && userMsg) {
+        history.addPair(userMsg, modelMsg);
       }
       return parseAIRes(res?.content?.[0]?.text ?? "", useBatchFetch);
+    }
     case OPT_TRANS_CLOUDFLAREAI:
       return [[res?.result?.translated_text]];
     case OPT_TRANS_OLLAMA:
@@ -1703,11 +1727,8 @@ export const parseTransRes = async (
       //   modelMsg?.content.replace(/<think>[\s\S]*<\/think>/i, "");
       // }
 
-      if (history && userMsg && modelMsg) {
-        history.add(userMsg, {
-          role: modelMsg.role,
-          content: modelMsg.content,
-        });
+      if (history && userMsg) {
+        history.addPair(userMsg, modelMsg);
       }
       return parseAIRes(modelMsg?.content, useBatchFetch);
     case OPT_TRANS_CUSTOMIZE:
@@ -2194,7 +2215,8 @@ async function* handleTranslateStreamInternal(
         parts: [{ text: fullContent }],
       });
     } else {
-      history.add(userMsg, {
+      // 流式非 Gemini 分支与非流式挂载点共用 addPair 守卫：空正文整对不写
+      history.addPair(userMsg, {
         role: "assistant",
         content: fullContent,
       });

--- a/src/apis/trans.translate.test.js
+++ b/src/apis/trans.translate.test.js
@@ -24,12 +24,14 @@ import {
   DEFAULT_API_LIST,
   GEMINI_GENERATE_CONTENT_URL,
   GEMINI_INTERACTIONS_URL,
+  OPT_TRANS_CLAUDE,
   OPT_TRANS_DEEPSEEK,
   OPT_TRANS_GEMINI,
   OPT_TRANS_GEMINI_2,
   OPT_TRANS_GOOGLE_2,
   OPT_TRANS_GOOGLE_CLOUD,
   OPT_TRANS_MICROSOFT,
+  OPT_TRANS_OLLAMA,
   OPT_TRANS_OPENAI,
   OPT_TRANS_OPENROUTER,
   OPT_TRANS_QWENMT,
@@ -72,6 +74,12 @@ async function collectAsyncGenerator(generator) {
 describe("handleTranslate", () => {
   afterEach(() => {
     clearMsgHistory(OPT_TRANS_GEMINI);
+    // Claude 上下文用例共用同一个按 apiSlug 缓存的历史单例，必须逐例清空。
+    clearMsgHistory(OPT_TRANS_CLAUDE);
+    // 跨协议上下文历史用例（Chat 家族 / Ollama）同样按 slug 锁存单例，逐例清空。
+    clearMsgHistory(OPT_TRANS_OPENAI);
+    clearMsgHistory(OPT_TRANS_OLLAMA);
+    clearMsgHistory(OPT_TRANS_GEMINI_2);
     jest.clearAllMocks();
     jest.restoreAllMocks();
   });
@@ -1335,6 +1343,550 @@ describe("handleTranslate", () => {
       { id: 0, result: ["你好世界", "en"] },
       { id: 1, result: ["早上好", "en"] },
     ]);
+  });
+
+  // ── Claude 历史上下文取值形态归一化 ──
+
+  /**
+   * 跑两轮 Claude 非流式请求：第一轮响应用给定 content 形态，
+   * 返回第二轮请求体里的 messages（含第一轮写入的历史条目）与两轮抛出的错误。
+   *
+   * 第一轮 content 形态不含 content[0].text 时（纯字符串 / 单对象 / 缺失），
+   * 译文解析路径 parseAIRes 拿到空串 → runNonStream 抛
+   * "translate got an unexpected result"，错误照常收集供用例断言"不是 TypeError"。
+   * 译文只取首块、历史取全部 text 块：首块不可解析时译文抛错而历史可能照写；
+   * 完全无可用文本的轮经 addPair 守卫拦截、整对不写历史。
+   */
+  async function runClaudeContextRounds(firstContent) {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_CLAUDE),
+      useStream: false,
+      useBatchFetch: false,
+      useContext: true,
+      contextSize: 10,
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+    };
+    fetchData
+      .mockResolvedValueOnce({ role: "assistant", content: firstContent })
+      .mockResolvedValueOnce({
+        role: "assistant",
+        content: [{ type: "text", text: "第二轮译文" }],
+      });
+
+    const errors = [];
+    for (const text of ["first", "second"]) {
+      try {
+        await collectAsyncGenerator(
+          handleTranslate([text], {
+            from: "en",
+            to: "zh-CN",
+            fromLang: "English",
+            toLang: "Chinese",
+            langMap: () => "",
+            glossary: "",
+            apiSetting,
+            usePool: false,
+          })
+        );
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    expect(fetchData).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchData.mock.calls[1][1].body);
+    return { messages: secondBody.messages, errors };
+  }
+
+  test("Claude 历史：标准块数组的模型文本写入历史（旧写法为空壳）", async () => {
+    const { messages, errors } = await runClaudeContextRounds([
+      { type: "text", text: "你好" },
+    ]);
+
+    expect(errors).toEqual([]);
+    // [第一轮 user, 第一轮 assistant（历史）, 第二轮 user]
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    expect(messages[1]).toEqual({ role: "assistant", content: "你好" });
+    expect(messages[2].role).toBe("user");
+  });
+
+  test("Claude 历史：多个文本块按顺序拼接，不丢后续块", async () => {
+    const { messages, errors } = await runClaudeContextRounds([
+      { type: "text", text: "A" },
+      { type: "text", text: "B" },
+    ]);
+
+    expect(errors).toEqual([]);
+    expect(messages[1]).toEqual({ role: "assistant", content: "AB" });
+  });
+
+  test("Claude 历史：纯字符串 content 不抛 TypeError 且原样入历史", async () => {
+    const { messages, errors } = await runClaudeContextRounds("纯字符串译文");
+
+    // 只允许译文解析路径的空结果错误，绝不能是 .map 打在字符串上的 TypeError。
+    for (const error of errors) {
+      expect(error.name).not.toBe("TypeError");
+    }
+    expect(messages[1]).toEqual({
+      role: "assistant",
+      content: "纯字符串译文",
+    });
+  });
+
+  test("Claude 历史：单对象 content 取其 text，不把整个对象塞进历史", async () => {
+    const { messages, errors } = await runClaudeContextRounds({
+      type: "text",
+      text: "单对象",
+    });
+
+    for (const error of errors) {
+      expect(error.name).not.toBe("TypeError");
+    }
+    expect(messages[1]).toEqual({ role: "assistant", content: "单对象" });
+  });
+
+  test("Claude 历史：content 缺失时整对不写历史", async () => {
+    const { messages, errors } = await runClaudeContextRounds(undefined);
+
+    // 只允许译文解析路径的空结果错误，绝不能是 TypeError。
+    for (const error of errors) {
+      expect(error.name).not.toBe("TypeError");
+    }
+    expect(errors).toHaveLength(1);
+    // round 1 无可用文本 → 整对不写（防实现退化为只跳 assistant 保留 user 的孤立形态）
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  // ── 跨协议上下文历史契约：Chat（含 GEMINI_2）/ Ollama / Claude 统一 addPair ──
+
+  const openaiRes = (content, extra = {}) => ({
+    choices: [{ message: { role: "assistant", content, ...extra } }],
+  });
+
+  async function runTranslateRounds(apiSetting, texts) {
+    const errors = [];
+    for (const text of texts) {
+      try {
+        await collectAsyncGenerator(
+          handleTranslate([text], {
+            from: "en",
+            to: "zh-CN",
+            fromLang: "English",
+            toLang: "Chinese",
+            langMap: () => "",
+            glossary: "",
+            apiSetting,
+            usePool: false,
+          })
+        );
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    return { errors };
+  }
+
+  /**
+   * 跑 N 轮非流式翻译（显式 useStream:false + useBatchFetch:false + useContext:true），
+   * 返回每轮请求体与收集到的错误。逐轮 try/catch 收集，畸形轮不中断后续轮次。
+   */
+  async function runNonStreamContextRounds(apiType, responses, update = {}) {
+    const apiSetting = {
+      ...getApiSetting(apiType),
+      useStream: false,
+      useBatchFetch: false,
+      useContext: true,
+      contextSize: 10,
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+      ...update,
+    };
+    for (const response of responses) {
+      fetchData.mockResolvedValueOnce(response);
+    }
+
+    const { errors } = await runTranslateRounds(
+      apiSetting,
+      ["first", "second", "third"].slice(0, responses.length)
+    );
+
+    expect(fetchData).toHaveBeenCalledTimes(responses.length);
+    const bodies = fetchData.mock.calls.map((call) => JSON.parse(call[1].body));
+    return { bodies, errors };
+  }
+
+  /** mock 一次流式轮：fetchStream 产出事件对象的 JSON 字符串序列（消费端逐条 JSON.parse）。 */
+  const mockStreamRound = (chunks) => {
+    async function* streamChunks() {
+      for (const chunk of chunks) {
+        yield JSON.stringify(chunk);
+      }
+    }
+    fetchStream.mockReturnValueOnce(streamChunks());
+  };
+
+  const claudeTextStream = (text) => [
+    { type: "message_start" },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text },
+    },
+    { type: "message_stop" },
+  ];
+
+  test("Chat 历史：正常响应整对写入第二轮请求体（OPENAI）", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_OPENAI,
+      [openaiRes("你好"), openaiRes("第二轮译文")]
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[1].messages;
+    // [system, 第一轮 user, 第一轮 assistant, 第二轮 user]
+    expect(messages).toHaveLength(4);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2]).toEqual({ role: "assistant", content: "你好" });
+    expect(messages[3].role).toBe("user");
+  });
+
+  test.each([
+    ["content 空串", ""],
+    ["content null", null],
+    ["content 为数组/parts 形态", { parts: ["x"] }],
+  ])(
+    "Chat 历史：第一轮 message.content %s → 整对不写（OPENAI）",
+    async (_name, content) => {
+      const { bodies } = await runNonStreamContextRounds(OPT_TRANS_OPENAI, [
+        openaiRes(content),
+        openaiRes("第二轮译文"),
+      ]);
+
+      const messages = bodies[1].messages;
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("system");
+      expect(messages[1].role).toBe("user");
+      expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+    }
+  );
+
+  test("Chat 历史：缺 assistant role → 整对不写（OPENAI）", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_OPENAI,
+      [{ choices: [{ message: { content: "你好" } }] }, openaiRes("第二轮译文")]
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(2);
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  test("Chat 历史：contextSize=3 多轮只留完整轮次，不以孤立 assistant 开头（OPENAI）", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_OPENAI,
+      [openaiRes("一"), openaiRes("二"), openaiRes("三")],
+      { contextSize: 3 }
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[2].messages;
+    expect(messages).toHaveLength(4);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2]).toEqual({ role: "assistant", content: "二" });
+    expect(messages[3].role).toBe("user");
+  });
+
+  test("Chat 历史：响应 message 额外字段不进入历史（OPENAI）", async () => {
+    const { bodies } = await runNonStreamContextRounds(OPT_TRANS_OPENAI, [
+      openaiRes("你好", {
+        reasoning_content: "思考",
+        tool_calls: [{ id: "t" }],
+      }),
+      openaiRes("第二轮译文"),
+    ]);
+
+    const messages = bodies[1].messages;
+    expect(messages[2]).toEqual({ role: "assistant", content: "你好" });
+  });
+
+  test("Chat 历史：GEMINI_2 走共享 case，第二轮请求体按 genGemini2 形状（system 首位）", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_GEMINI_2,
+      [openaiRes("你好"), openaiRes("第二轮译文")]
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(4);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2]).toEqual({ role: "assistant", content: "你好" });
+    expect(messages[3].role).toBe("user");
+  });
+
+  test("Ollama 历史：正常正文进第二轮请求体", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_OLLAMA,
+      [openaiRes("你好"), openaiRes("第二轮译文")]
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(4);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2]).toEqual({ role: "assistant", content: "你好" });
+    expect(messages[3].role).toBe("user");
+  });
+
+  test.each([
+    ["content 空串", ""],
+    ["content null", null],
+  ])("Ollama 历史：第一轮 %s → 整对不写（非流式）", async (_name, content) => {
+    const { bodies } = await runNonStreamContextRounds(OPT_TRANS_OLLAMA, [
+      openaiRes(content),
+      openaiRes("第二轮译文"),
+    ]);
+
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  test("Ollama 历史：响应缺 message → 不写历史", async () => {
+    const { bodies } = await runNonStreamContextRounds(OPT_TRANS_OLLAMA, [
+      { choices: [] },
+      openaiRes("第二轮译文"),
+    ]);
+
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(2);
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  test("Ollama 历史：默认容量只留完整轮次，不以孤立 assistant 开头", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_OLLAMA,
+      [openaiRes("一"), openaiRes("二"), openaiRes("三")],
+      { contextSize: 3 }
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[2].messages;
+    expect(messages).toHaveLength(4);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[2]).toEqual({ role: "assistant", content: "二" });
+    expect(messages[3].role).toBe("user");
+  });
+
+  test("Ollama 流式：空 delta 轮整对不写，round 2 体恰为 [system, u2]、round 3 体含 round 2 完整对", async () => {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_OLLAMA),
+      useStream: true,
+      useBatchFetch: false,
+      useContext: true,
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+    };
+    // round 1 只有 role delta、无文本 content → fullContent 恒空 → 整对不写
+    mockStreamRound([{ choices: [{ delta: { role: "assistant" } }] }]);
+    mockStreamRound([
+      { choices: [{ delta: { content: "你" } }] },
+      { choices: [{ delta: { content: "好" } }] },
+    ]);
+    mockStreamRound([{ choices: [{ delta: { content: "第三轮" } }] }]);
+
+    const { errors } = await runTranslateRounds(apiSetting, [
+      "first",
+      "second",
+      "third",
+    ]);
+
+    expect(fetchStream).toHaveBeenCalledTimes(3);
+    expect(errors).toEqual([]);
+    // round 2 请求体恰为 [system, u2]（整对原子性，防"只跳 assistant 保留 user"退化）
+    const secondBody = JSON.parse(fetchStream.mock.calls[1][1].body);
+    expect(secondBody.messages).toHaveLength(2);
+    expect(secondBody.messages[0].role).toBe("system");
+    expect(secondBody.messages[1].role).toBe("user");
+    expect(
+      secondBody.messages.filter((m) => m.role === "assistant")
+    ).toHaveLength(0);
+    // round 3 请求体含 round 2 完整对，不以孤立 assistant 开头
+    const thirdBody = JSON.parse(fetchStream.mock.calls[2][1].body);
+    expect(thirdBody.messages).toHaveLength(4);
+    expect(thirdBody.messages[0].role).toBe("system");
+    expect(thirdBody.messages[1].role).toBe("user");
+    expect(thirdBody.messages[2]).toEqual({
+      role: "assistant",
+      content: "你好",
+    });
+    expect(thirdBody.messages[3].role).toBe("user");
+  });
+
+  test("Claude 历史：响应缺 role → 整对不写历史", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_CLAUDE,
+      [
+        { content: [{ type: "text", text: "你好" }] },
+        { role: "assistant", content: [{ type: "text", text: "第二轮译文" }] },
+      ]
+    );
+
+    expect(errors).toEqual([]);
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  test("Claude 历史：content 为非文本类型 → 整对不写历史", async () => {
+    const { bodies, errors } = await runNonStreamContextRounds(
+      OPT_TRANS_CLAUDE,
+      [
+        { role: "assistant", content: 123 },
+        { role: "assistant", content: [{ type: "text", text: "第二轮译文" }] },
+      ]
+    );
+
+    // 译文解析空结果错误照抛，但历史整对不写
+    expect(errors).toHaveLength(1);
+    const messages = bodies[1].messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(0);
+  });
+
+  test("OPENAI 流式：空 delta 轮整对不写历史，第二轮请求体恰为 [system, user]", async () => {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_OPENAI),
+      useStream: true,
+      useBatchFetch: false,
+      useContext: true,
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+    };
+    // round 1 只有 role delta、无文本 content → fullContent 恒空 → 整对不写
+    mockStreamRound([{ choices: [{ delta: { role: "assistant" } }] }]);
+    mockStreamRound([
+      { choices: [{ delta: { content: "你" } }] },
+      { choices: [{ delta: { content: "好" } }] },
+    ]);
+
+    const { errors } = await runTranslateRounds(apiSetting, [
+      "first",
+      "second",
+    ]);
+
+    // 空 delta 轮零抛错：防异常短路后断言空洞通过
+    expect(errors).toEqual([]);
+    expect(fetchStream).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchStream.mock.calls[1][1].body);
+    expect(secondBody.messages).toHaveLength(2);
+    expect(secondBody.messages[0].role).toBe("system");
+    expect(secondBody.messages[1].role).toBe("user");
+    expect(
+      secondBody.messages.filter((m) => m.role === "assistant")
+    ).toHaveLength(0);
+  });
+
+  test("Claude 流式：content_block_delta 文本累积进历史，第二轮请求体携带完整首轮对", async () => {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_CLAUDE),
+      useStream: true,
+      useBatchFetch: false,
+      useContext: true,
+      contextSize: 10,
+      // CLAUDE 默认条目为 realtime 渲染，会产生 partialText 中间产出；钉死 disabled 使结果断言确定。
+      streamRenderMode: "disabled",
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+    };
+    mockStreamRound(claudeTextStream("你好"));
+    mockStreamRound(claudeTextStream("第二轮"));
+
+    const result = await collectAsyncGenerator(
+      handleTranslate(["first"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting,
+        usePool: false,
+      })
+    );
+    await collectAsyncGenerator(
+      handleTranslate(["second"], {
+        from: "en",
+        to: "zh-CN",
+        fromLang: "English",
+        toLang: "Chinese",
+        langMap: () => "",
+        glossary: "",
+        apiSetting,
+        usePool: false,
+      })
+    );
+
+    expect(fetchStream).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([{ id: 0, result: ["你好"] }]);
+    // Claude messages 无 system 前缀：[第一轮 user, 第一轮 assistant, 第二轮 user]
+    const secondBody = JSON.parse(fetchStream.mock.calls[1][1].body);
+    expect(secondBody.messages).toHaveLength(3);
+    expect(secondBody.messages[1]).toEqual({
+      role: "assistant",
+      content: "你好",
+    });
+    expect(secondBody.messages[2].role).toBe("user");
+  });
+
+  test("Claude 流式：contextSize=3 轮次完整、空文本 delta 轮整对跳过", async () => {
+    const apiSetting = {
+      ...getApiSetting(OPT_TRANS_CLAUDE),
+      useStream: true,
+      useBatchFetch: false,
+      useContext: true,
+      contextSize: 3,
+      streamRenderMode: "disabled",
+      nobatchPrompt: "Translate {{text}}.",
+      nobatchUserPrompt: "",
+    };
+    // round 1 无文本 delta → 不写历史对；round 2/3 正常流式
+    mockStreamRound([
+      { type: "content_block_delta", delta: { type: "text_delta", text: "" } },
+      { type: "message_stop" },
+    ]);
+    mockStreamRound(claudeTextStream("第二轮"));
+    mockStreamRound(claudeTextStream("第三轮"));
+
+    await runTranslateRounds(apiSetting, ["first", "second", "third"]);
+
+    expect(fetchStream).toHaveBeenCalledTimes(3);
+    // round 2 请求体：仅当轮 user（round 1 空轮整对未写，无孤立 user / assistant）
+    const secondBody = JSON.parse(fetchStream.mock.calls[1][1].body);
+    expect(secondBody.messages).toHaveLength(1);
+    expect(secondBody.messages[0].role).toBe("user");
+    // round 3 请求体：round 2 的完整对 + 当轮 user，不以孤立 assistant 开头
+    const thirdBody = JSON.parse(fetchStream.mock.calls[2][1].body);
+    expect(thirdBody.messages).toHaveLength(3);
+    expect(thirdBody.messages[0].role).toBe("user");
+    expect(thirdBody.messages[1]).toEqual({
+      role: "assistant",
+      content: "第二轮",
+    });
+    expect(thirdBody.messages[2].role).toBe("user");
   });
 });
 

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -11,7 +11,7 @@ export const DEFAULT_BATCH_INTERVAL = 400; // 批处理合并请求的等待延�
 export const DEFAULT_BATCH_SIZE = 20; // 每次翻译请求最多合并发送的 DOM 段落数量
 export const DEFAULT_BATCH_LENGTH = 10000; // 每次翻译请求发送的最大字符数限制
 export const DEFAULT_BATCH_CONCURRENCY = 10; // 同时执行的聚合批次数量
-export const DEFAULT_CONTEXT_SIZE = 3; // AI 翻译时保留的上下文会话历史轮数
+export const DEFAULT_CONTEXT_SIZE = 3; // AI 翻译时上下文历史条数上限，按完整 user/assistant 轮次向下取整保留
 
 // --- 翻译内容替换占位符 ---
 export const INPUT_PLACE_URL = "{{url}}"; // 当前网页 URL 占位符
@@ -1531,7 +1531,7 @@ const defaultApi = {
   transAllnow: false, // 是否立即全部翻译
   rootMargin: 2000, // 滚动加载提前触发距离
   useContext: false, // 是否启用智能上下文
-  contextSize: DEFAULT_CONTEXT_SIZE, // 智能上下文保留会话数
+  contextSize: DEFAULT_CONTEXT_SIZE, // 智能上下文历史条数上限（按完整轮次取整）
   temperature: 0.0,
   maxTokens: 20480,
   thinkingMode: "disabled", // 思考模式：auto | enabled | disabled

--- a/src/libs/stream.test.js
+++ b/src/libs/stream.test.js
@@ -16,6 +16,7 @@ import {
   parseStreamingSegments,
 } from "./stream";
 import {
+  OPT_TRANS_CLAUDE,
   OPT_TRANS_EPHONEAI,
   OPT_TRANS_GEMINI,
   OPT_TRANS_ORCAROUTER,
@@ -175,6 +176,34 @@ describe("getStreamDelta", () => {
         OPT_TRANS_GEMINI
       )
     ).toThrow("bad request");
+  });
+
+  test("extracts only text deltas from Claude content_block_delta events", () => {
+    expect(
+      getStreamDelta(
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "你好" },
+        },
+        OPT_TRANS_CLAUDE
+      )
+    ).toBe("你好");
+    // thinking_delta 无 .text 字段，自然排除
+    expect(
+      getStreamDelta(
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "thinking_delta", thinking: "推理过程" },
+        },
+        OPT_TRANS_CLAUDE
+      )
+    ).toBe("");
+    expect(getStreamDelta({ type: "message_start" }, OPT_TRANS_CLAUDE)).toBe(
+      ""
+    );
+    expect(getStreamDelta({ type: "message_stop" }, OPT_TRANS_CLAUDE)).toBe("");
   });
 });
 


### PR DESCRIPTION
## 背景与立项原点

Claude Messages 协议非流式响应的 `content` 是块数组 `[{type:"text",text:"…"}]`，旧代码按 `res?.content?.text` 取值——块数组没有 `.text` 属性，开启「智能上下文」后写入历史的 assistant 条目全是空壳 `{role:"assistant"}`，上下文功能对 Claude 实际失效（用户抓包发现）。本 PR 以该修复为原点，扩大为跨协议上下文历史正确性修复。

## 关于此前已关闭的 #1069

本 PR 取代同一分支上此前的 #1069。该 PR 提交后作者自查发现单 commit 中夹带了与主题无关的内容：2 个 QwenMT 术语机制测试（源分支拆分时混入），以及测试文件中一段面向开发过程的内部备注注释。#1069 未获任何上游评审（0 review、0 评论，关闭前合并状态 clean），关闭系作者主动撤回修正，与上游反馈无关。修正后在同一分支上更新为单一 commit 重新提交：与 #1069 的全部差异仅为删除上述 81 行夹带内容、并同步修订提交说明中的一句表述，核心修复逐字不变。

## 变更内容

1. **Claude 块数组正文归一化**：`pickClaudeText` 三分支（块数组按序拼接 / 纯字符串原样 / 单对象取 `text`）——历史取全部文本块，译文解析仍取首块（最小变更）。
2. **统一写入守卫（非流式 + 流式）**：Chat 家族（12 个 OpenAI 兼容 apiType 共享 case，含 GEMINI_2）、Ollama、Claude 的全部历史挂载点接入 `addPair`——守卫单点内聚（`role === "assistant"` 且 `content` 为非空字符串），不满足时**整对不写、绝不留下孤立 user**；挂载点保留外层 `history`/`userMsg` 判空，两层缺一不可。流式非 Gemini 分支同步接入（Claude 默认流式，默认配置路径同样覆盖）。
3. **轮次截断**：标准 role 历史按完整 user/assistant 轮次维护——`contextSize=3` 保留 1 轮、`contextSize=1` no-op（不携带任何上下文）。**可用上下文量与旧实现一致**：旧逐条截断在任意取值 N 下同样只提供 `floor(N/2)` 个完整轮次（奇数容量时另携带 1 条头部孤立 assistant）；新实现保留同样的 `floor(N/2)` 轮——**用户可见的上下文量没有减少，减少的只是无价值的头部孤立条目**（该条目在要求首条为 user 的端点会引发 400，属预存在缺陷的消除）。数值含义维持“条数上限”（不宣称与设置项文案数值对齐）；污染历史（resHook 注入非标准形状等）走逐条回退通道：追加可用、容量有界、不改写既有条目。
4. **持久化形状**：历史条目 assistant 侧仅存 `{role, content}` 两字段——`reasoning_content`/`tool_calls` 等响应额外字段不进入历史、不回流下一轮请求体（与既有净化写入语义一致）。
5. **注释修正**：`config/api.js` 的 contextSize 注释改为“条数上限 + 按完整轮次取整”口径；Claude case 旧注释中失真论据移除，与新守卫语义对齐；Gemini Interactions/generateContent 加“路径未变更”中性注释（零行为改动）。
6. **测试**：新增 `history.test.js`（守卫 / 轮次截断 / 污染回退 / 自愈 / 边界矩阵）；三协议 + GEMINI_2 第二轮请求体断言；Claude 流式三件套（delta 提取 / 两轮写入 / 轮次截断 / 空正文跳过）；OPENAI/Ollama 流式空 delta 整对不写；空正文/content 缺失 → 整对不写守卫矩阵（Chat、Ollama 参数化，Claude 单列）。

## 覆盖范围（如实界定）

- 共享 case 的 12 个 apiType 经 OPENAI 代表 + GEMINI_2 单列断言覆盖，非逐 apiType 集成验证。
- Gemini 仅注释改动，Interactions steps 与 generateContent 路径行为零变化，不在保证范围。
- Claude 流式 realtime 渲染的覆盖由代码路径同一性保证（`streamRenderMode` 仅控制 UI 中间态 yield，历史写点同路），直接回归用例运行于 `disabled` 模式。
- 字幕单句翻译经 `apiTranslate` 与页面翻译命中同一 `getMsgHistory` slug（预存在），本轮 `addPair` 收紧同样生效——属行为改善（空正文不再污染共享历史），非回归；未为字幕路径单列集成用例。
- 设置项文案（`context_size`，如中文“上下文会话数量(1-20)”）与实际可用水位（`floor(N/2)` 轮次）的偏差为**预存在**（旧实现可用轮次同样为 `floor(N/2)`），未随本 PR 调整；文案口径或语义的进一步对齐宜作为独立的 i18n/行为变更处理。
- i18n 无变化：零新增用户可见字符串，`public/_locales` 与 `src/config/i18n*.js` 零 diff。

## 未纳入与剩余风险（只披露，不宣称已修复）

- 2.3 单请求直调路径的并发交叉窗口（预存在）。
- `getMsgHistory` 实例容量锁存（预存在）。
- resHook 返回非标准 `modelMsg`（官方 hook 帮助示例 `const modelMsg = {}` 即现实来源之一）→ 所属 slug 历史降级走污染回退通道，追加 / 容量仍有界；hook 形状责任在 hook 作者。
- reqHook 透传非标准 `userMsg` → 同类降级，污染条目老化出窗后可自愈。
- 遗留头部孤立 assistant 在严格端点（如 Anthropic）引发 400 循环：预存在缺陷，写侧修复不可达（HTTP 失败在解析前抛错）。
- thinking-first 非对称：本轮译文解析失败、但历史可从后续 text 块照写。

## 验证

- 定向：`history.test.js` 18/18、`trans.translate.test.js` 56/56、`stream.test.js` 23/23。
- 全量：73 套件 / 804 用例，失败集合与改动前基线**完全一致（零新增失败）**——三处既有失败为：`trans.dict.test.js` 的 `handleDict › falls back to default dictionary user prompt for old api settings`；`batchQueue.test.js` 的 `BatchQueue batch concurrency › keeps batches serial by default`；`Layout.test.js` 套件级加载失败（`@streamparser/json` ESM `SyntaxError: Unexpected token 'export'`，经 `src/libs/stream.js` 导入链引入）。三处均已在 base `c95bd46` 树上复跑复现、失败信息逐字一致，与本 PR 无因果（`src/libs/stream.js` 本体零改动）。`prettier --check` 六文件全绿；`git diff --check` 通过；`config/api.js` diff 仅两行注释。
- 基线：`fishjar/kiss-translator@dev`（c95bd46），单 commit。