### PR TITLE
fix: send stable session IDs with OpenCode Go requests

### DIFF
--- a/custom-api_v2.md
+++ b/custom-api_v2.md
@@ -94,6 +94,32 @@ Hook 中 `Prompt` 类型说明：
 `subtitlePrompt`    // 字幕翻译 System Prompt
 ```
 
+## OpenCode 会话请求头
+
+内置 `OpenCodeGo` 接口会自动添加 `x-opencode-session` 请求头。同一页面、同一接口配置与 URL 的请求复用一个随机 ID，包含聚合、非聚合、流式、字幕及摘要请求。刷新页面或 SPA 地址变化后开始新会话。ID 不包含页面地址、原文或 API Key。
+
+若使用 OpenAI 兼容接口接入 OpenCode，或需要手动指定会话 ID，可在该接口的 `Request Hook` 中填写：
+
+```js
+async (args, req = args.req) => {
+  // 为当前翻译会话指定一个 ID；同一会话内保持不变。
+  const sessionId = "8fd946a1-bb92-4aa6-9766-724c9e435832";
+  const headers = { ...req.headers };
+  // 清除已有的同名请求头，避免因大小写不同发送重复值。
+  for (const name of Object.keys(headers)) {
+    if (name.toLowerCase() === "x-opencode-session") delete headers[name];
+  }
+  headers["x-opencode-session"] = sessionId;
+  return { ...req, headers };
+};
+```
+
+第二个参数 `req`（亦可通过 `args.req` 获取）是已构造好的请求。保留它的 URL、body、method 和 userMsg，只补充请求头即可沿用原有翻译协议，`Response Hook` 无需更改。请勿在每次调用时重新生成随机 ID；开始新的翻译会话时再更换它。
+
+字幕请求不执行 `Request Hook`。需要为字幕手动指定 ID 时，请在“自定义请求头”中配置 JSON，例如 `{"x-opencode-session":"8fd946a1-bb92-4aa6-9766-724c9e435832"}`；内置接口会保留这个显式配置。
+
+参考：[OpenCode Go 对稳定 session ID 的要求](https://opencode.ai/docs/go/#where-can-i-use-it)。
+
 ## 谷歌翻译接口
 
 > 此接口不支持聚合

--- a/src/apis/opencode.js
+++ b/src/apis/opencode.js
@@ -1,0 +1,38 @@
+// 请求在页面侧构建，缓存随页面运行环境销毁；不持久化或发送页面 URL。
+const sessions = new Map();
+let currentPageUrl;
+
+const createSessionId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  // HTTP 页面上 randomUUID 可能不可用，getRandomValues 仍可使用。
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+};
+
+/** 同一页面、同一接口的段落、重试和辅助请求复用会话 ID。 */
+export const getOpenCodeSessionId = ({ apiSlug, url }) => {
+  const pageUrl = globalThis.location?.href || "";
+  // SPA 导航不一定重建脚本运行环境，因此在地址变化时开始新会话。
+  if (pageUrl !== currentPageUrl) {
+    sessions.clear();
+    currentPageUrl = pageUrl;
+  }
+
+  const scope = JSON.stringify([apiSlug, url]);
+  if (!sessions.has(scope)) {
+    sessions.set(scope, createSessionId());
+  }
+  return sessions.get(scope);
+};

--- a/src/apis/trans.js
+++ b/src/apis/trans.js
@@ -87,6 +87,7 @@ import { createSubtitleIndexAligner } from "../libs/subtitleIndexAlign";
 import { kissLog } from "../libs/log";
 import { fetchData, fetchStream } from "../libs/fetch";
 import { getMsgHistory } from "./history";
+import { getOpenCodeSessionId } from "./opencode";
 import { parseBilingualVtt } from "../subtitle/vtt";
 import { getDocInfo } from "../libs/docInfo";
 import {
@@ -1491,6 +1492,17 @@ export const genTransReq = async ({ reqHook, ...args }) => {
   }
   if (customBody?.trim()) {
     Object.assign(body, parseJsonObj(customBody));
+  }
+
+  // OpenCode Go 要求稳定的会话 ID；同时覆盖不执行 hook 的字幕请求。
+  // 自定义请求头大小写不敏感，保留用户显式配置的值。
+  if (
+    apiType === OPT_TRANS_OPENCODEGO &&
+    !Object.keys(headers).some(
+      (name) => name.toLowerCase() === "x-opencode-session"
+    )
+  ) {
+    headers["x-opencode-session"] = getOpenCodeSessionId({ apiSlug, url });
   }
 
   // 执行 request hook

--- a/src/apis/trans.opencode.test.js
+++ b/src/apis/trans.opencode.test.js
@@ -1,0 +1,223 @@
+jest.mock("query-string", () => ({
+  stringify: (obj) => new URLSearchParams(obj).toString(),
+}));
+
+jest.mock("@streamparser/json", () => ({ JSONParser: jest.fn() }));
+
+jest.mock("../libs/fetch", () => ({
+  fetchData: jest.fn(),
+  fetchStream: jest.fn(),
+}));
+
+jest.mock("../libs/docInfo", () => ({ getDocInfo: () => ({}) }));
+
+import {
+  genTransReq,
+  handleTranslate,
+  handleSubtitle,
+  handleSummarize,
+} from "./trans";
+import {
+  DEFAULT_API_LIST,
+  OPT_TRANS_OPENCODEGO,
+  OPT_TRANS_OPENAI,
+} from "../config";
+import { fetchData, fetchStream } from "../libs/fetch";
+
+const { randomUUID, webcrypto } = require("crypto");
+const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+const sessionHeader = "x-opencode-session";
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const getApiSetting = (update = {}) => ({
+  ...DEFAULT_API_LIST.find((api) => api.apiType === OPT_TRANS_OPENCODEGO),
+  key: "test-key",
+  useBatchFetch: false,
+  useStream: false,
+  ...update,
+});
+
+const request = (update = {}) =>
+  genTransReq({
+    ...getApiSetting(),
+    texts: ["hello"],
+    from: "en",
+    to: "zh-CN",
+    fromLang: "en",
+    toLang: "zh-CN",
+    ...update,
+  });
+
+beforeEach(() => {
+  window.history.replaceState({}, "", `/opencode-test-${randomUUID()}`);
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      randomUUID: jest.fn(randomUUID),
+      getRandomValues: jest.fn((bytes) => webcrypto.getRandomValues(bytes)),
+    },
+  });
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+  if (cryptoDescriptor) {
+    Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+  } else {
+    delete globalThis.crypto;
+  }
+});
+
+test("concurrent batches and stream retries share a session without changing the request body", async () => {
+  const requests = await Promise.all([
+    request({ texts: ["first"] }),
+    request({ texts: ["second", "third"], useBatchFetch: true }),
+    request({ useStream: true }),
+    request({ useStream: false }),
+  ]);
+  const ids = requests.map(([, init]) => init.headers[sessionHeader]);
+  expect(ids[0]).toMatch(uuidPattern);
+  expect(new Set(ids).size).toBe(1);
+  expect(globalThis.crypto.randomUUID).toHaveBeenCalledTimes(1);
+  expect(requests[0][1].headers.Authorization).toBe("Bearer test-key");
+  expect(requests[0][1].method).toBe("POST");
+  expect(JSON.parse(requests[2][1].body).stream).toBe(true);
+  expect(JSON.parse(requests[3][1].body).stream).toBe(false);
+  expect(JSON.parse(requests[0][1].body)).not.toHaveProperty("session_id");
+});
+
+test("separates interface configurations, endpoints and SPA pages", async () => {
+  const first = await request();
+  const otherApi = await request({ apiSlug: "other-opencode-go" });
+  const otherUrl = await request({
+    url: "https://proxy.example.com/v1/chat/completions",
+  });
+  const repeated = await request();
+  expect(repeated[1].headers[sessionHeader]).toBe(
+    first[1].headers[sessionHeader]
+  );
+  window.history.replaceState({}, "", "/another-page");
+  const navigated = await request();
+  expect(
+    new Set(
+      [first, otherApi, otherUrl, navigated].map(
+        ([, init]) => init.headers[sessionHeader]
+      )
+    ).size
+  ).toBe(4);
+});
+
+test("creates a stable UUID when randomUUID is unavailable on an HTTP page", async () => {
+  globalThis.crypto.randomUUID = undefined;
+  const first = await request();
+  const repeated = await request();
+  expect(first[1].headers[sessionHeader]).toMatch(uuidPattern);
+  expect(repeated[1].headers[sessionHeader]).toBe(
+    first[1].headers[sessionHeader]
+  );
+  expect(globalThis.crypto.getRandomValues).toHaveBeenCalledTimes(1);
+});
+
+test.each(["x-opencode-session", "X-OpenCode-Session"])(
+  "preserves an explicit %s header without duplicates",
+  async (name) => {
+    const [, init] = await request({
+      customHeader: JSON.stringify({ [name]: "user-session" }),
+    });
+    const entries = Object.entries(init.headers).filter(
+      ([key]) => key.toLowerCase() === sessionHeader
+    );
+    expect(entries).toEqual([[name, "user-session"]]);
+    expect(globalThis.crypto.randomUUID).not.toHaveBeenCalled();
+  }
+);
+
+test("does not add OpenCode headers to other providers", async () => {
+  const [, init] = await request({
+    apiType: OPT_TRANS_OPENAI,
+    url: "https://api.openai.com/v1/chat/completions",
+  });
+  expect(init.headers).not.toHaveProperty(sessionHeader);
+  expect(globalThis.crypto.randomUUID).not.toHaveBeenCalled();
+});
+
+test("the documented hook overrides a session while preserving auth, prompts and stream settings", async () => {
+  const fs = require("fs");
+  const path = require("path");
+  const doc = fs.readFileSync(
+    path.join(__dirname, "../../custom-api_v2.md"),
+    "utf8"
+  );
+  const section = doc
+    .split("## OpenCode 会话请求头")[1]
+    .split("## 谷歌翻译接口")[0];
+  const hook = section.match(/```js\r?\n([\s\S]*?)```/)[1];
+  const options = {
+    useStream: true,
+    customHeader: JSON.stringify({ "X-OpenCode-Session": "old-session" }),
+  };
+  const [url, original, userMsg] = await request(options);
+  const [hookUrl, hooked, hookUserMsg] = await request({
+    ...options,
+    reqHook: hook,
+  });
+  expect(hookUrl).toBe(url);
+  expect(hooked.body).toBe(original.body);
+  expect(hooked.method).toBe(original.method);
+  expect(hookUserMsg).toEqual(userMsg);
+  expect(hooked.headers.Authorization).toBe(original.headers.Authorization);
+  expect(hooked.headers[sessionHeader]).toBe(
+    "8fd946a1-bb92-4aa6-9766-724c9e435832"
+  );
+  expect(hooked.headers).not.toHaveProperty("X-OpenCode-Session");
+});
+
+test("stream fallback preserves the session sent by the streaming request", async () => {
+  fetchStream.mockImplementation(async function* () {
+    throw new Error("stream unavailable");
+  });
+  fetchData.mockResolvedValue({ choices: [{ message: { content: "你好" } }] });
+  const results = [];
+  for await (const item of handleTranslate(["hello"], {
+    apiSetting: getApiSetting({ useStream: true }),
+    from: "en",
+    to: "zh-CN",
+    fromLang: "en",
+    toLang: "zh-CN",
+    langMap: () => "",
+    usePool: false,
+  }))
+    results.push(item);
+  expect(results[0].result[0]).toBe("你好");
+  const streaming = fetchStream.mock.calls[0][1];
+  const fallback = fetchData.mock.calls[0][1];
+  expect(streaming.headers[sessionHeader]).toMatch(uuidPattern);
+  expect(fallback.headers[sessionHeader]).toBe(
+    streaming.headers[sessionHeader]
+  );
+});
+
+test("subtitle and summary requests also carry the session without relying on hooks", async () => {
+  fetchData.mockResolvedValueOnce({
+    choices: [
+      {
+        message: { content: JSON.stringify([{ e: 0, o: "hello", t: "你好" }]) },
+      },
+    ],
+  });
+  const apiSetting = getApiSetting();
+  await handleSubtitle({
+    events: [{ start: 0, end: 1000, text: "hello" }],
+    from: "en",
+    to: "zh-CN",
+    apiSetting,
+  });
+  fetchData.mockResolvedValueOnce({
+    choices: [{ message: { content: "A greeting." } }],
+  });
+  await handleSummarize({ title: "Example", transcript: "hello", apiSetting });
+  const subtitleId = fetchData.mock.calls[0][1].headers[sessionHeader];
+  expect(subtitleId).toMatch(uuidPattern);
+  expect(fetchData.mock.calls[1][1].headers[sessionHeader]).toBe(subtitleId);
+});


### PR DESCRIPTION
OpenCode Go requests currently omit `x-opencode-session`, which can cause the provider to reject them with `MissingSessionID`. Add the header in the shared request builder so normal translation, streaming and fallback, subtitles, dictionary requests, and summaries receive it automatically.

The ID is a random UUID reused for each interface configuration and endpoint within the current page runtime. A page reload or SPA URL change starts a new session. Page URLs, source text, and API keys are not encoded in the ID. HTTP pages without `crypto.randomUUID` use `crypto.getRandomValues` to generate a UUID instead.

Explicit custom session headers are preserved case-insensitively, and request hooks can still override the generated request. Other providers are unaffected. `custom-api_v2.md` includes a tested hook example for manually supplying an ID or using an OpenAI-compatible OpenCode configuration, and explains the custom-header option for subtitles, which skip request hooks.

Validation:

- Installed dependencies with the CI's pnpm 9.14.4 using `--frozen-lockfile`; no dependency or lockfile changes.
- OpenCode, translation, subtitle, and OrcaRouter regression suites: **87 tests passed**, including 9 new OpenCode cases covering concurrent requests, session scope, HTTP fallback, header overrides, the documented hook, stream fallback, subtitles, and summaries.
- All `src/apis` suites: **142 passed, 1 failed**. The existing dictionary test `falls back to default dictionary user prompt for old api settings` expects an outdated Chinese prompt label. The identical failure was reproduced using the unmodified upstream `src/apis/trans.js` from base commit `13828a8`.
- Chrome production build: passed (`REACT_APP_CLIENT=chrome`, `BUILD_PATH=./build/chrome`, `react-app-rewired build`).
- Prettier checks for the changed JavaScript files and `git diff --check`: passed.

No live OpenCode API call was made; request behavior is verified with mocked transport, and the hook runs through KISS's actual Sval interpreter in the regression test.

Provider reference: https://opencode.ai/docs/go/#where-can-i-use-it
