### PR TITLE
feat(ui): 统一网站规则编辑器的 Material 3 界面

### DIFF
--- a/src/hooks/M3Theme.js
+++ b/src/hooks/M3Theme.js
@@ -56,7 +56,7 @@ export default function M3Theme({
       htmlFontSize = 16;
     }
 
-    return createTheme({
+    const themeOptions = {
       palette: {
         mode: resolvedMode,
         primary: { main: color.primary, contrastText: color.onPrimary },
@@ -73,10 +73,22 @@ export default function M3Theme({
         divider: color.outlineVariant,
       },
       shape: { borderRadius: 12 },
-      typography: {
-        htmlFontSize,
-        fontFamily: M3_FONT_FAMILY,
-        button: { textTransform: "none", fontWeight: 650 },
+      typography: (palette) => {
+        const typography =
+          typeof options.typography === "function"
+            ? options.typography(palette)
+            : options.typography;
+        // Resolve conversions before MUI generates sizes for each variant.
+        return {
+          htmlFontSize,
+          fontFamily: M3_FONT_FAMILY,
+          ...typography,
+          button: {
+            textTransform: "none",
+            fontWeight: 650,
+            ...typography?.button,
+          },
+        };
       },
       components: {
         MuiCssBaseline: {
@@ -392,12 +404,14 @@ export default function M3Theme({
         MuiSnackbarContent: {
           styleOverrides: { root: { borderRadius: 8 } },
         },
-        ...options.components,
       },
       ...Object.fromEntries(
-        Object.entries(options).filter(([key]) => key !== "components")
+        Object.entries(options).filter(
+          ([key]) => key !== "components" && key !== "typography"
+        )
       ),
-    });
+    };
+    return createTheme(themeOptions, { components: options.components || {} });
   }, [colors, options, resolvedMode]);
 
   return (

--- a/src/hooks/M3Theme.test.js
+++ b/src/hooks/M3Theme.test.js
@@ -1,9 +1,12 @@
 /* eslint-disable testing-library/no-container, testing-library/no-unnecessary-act */
 import { act } from "react";
 import { createRoot } from "react-dom/client";
+import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
 import { useTheme } from "@mui/material/styles";
 import M3Theme from "./M3Theme";
+import { M3_FONT_FAMILY } from "../styles/m3";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -181,6 +184,114 @@ test("scopes the resolved Material 3 palette to its root", () => {
 
   act(() => root.unmount());
   container.remove();
+});
+
+test.each(["object", "callback"])(
+  "compact %s typography keeps M3 defaults and generates pixel sizes on small-root pages",
+  (kind) => {
+    const originalFontSize = document.documentElement.style.fontSize;
+    document.documentElement.style.fontSize = "10px";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const typography = {
+      pxToRem: (size) => `${size}px`,
+      body1: { fontSize: 14 },
+      body2: { fontSize: 13 },
+      caption: { fontSize: 12 },
+      button: { fontSize: 13 },
+    };
+
+    try {
+      act(() => {
+        root.render(
+          <M3Theme
+            options={{
+              typography: kind === "callback" ? () => typography : typography,
+            }}
+          >
+            <Typography variant="h6">Heading</Typography>
+            <Typography variant="body1" id="compact-body">
+              Body
+            </Typography>
+            <Typography variant="body2" id="compact-detail">
+              Detail
+            </Typography>
+            <Typography variant="caption" id="compact-caption">
+              Caption
+            </Typography>
+            <Button>Action</Button>
+          </M3Theme>
+        );
+      });
+
+      const style = (selector) =>
+        getComputedStyle(container.querySelector(selector));
+      expect(style("h6").fontSize).toBe("20px");
+      expect(style("#compact-body").fontSize).toBe("14px");
+      expect(style("#compact-detail").fontSize).toBe("13px");
+      expect(style("#compact-caption").fontSize).toBe("12px");
+      expect(style("button").fontSize).toBe("13px");
+      expect(style("button").fontFamily.replace(/,\s*/g, ",")).toBe(
+        M3_FONT_FAMILY.replace(/,\s*/g, ",")
+      );
+      expect(style("button").fontWeight).toBe("650");
+      expect(style("button").textTransform).toBe("none");
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      document.documentElement.style.fontSize = originalFontSize;
+    }
+  }
+);
+
+test("partial component options preserve M3 button defaults and focus treatment", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  try {
+    act(() => {
+      root.render(
+        <M3Theme
+          options={{
+            components: {
+              MuiButton: {
+                defaultProps: { size: "small" },
+                styleOverrides: {
+                  root: { minHeight: 32 },
+                  sizeSmall: { fontSize: 12 },
+                },
+              },
+            },
+          }}
+        >
+          <Button>Action</Button>
+          <ThemeProbe />
+        </M3Theme>
+      );
+    });
+
+    const button = getComputedStyle(container.querySelector("button"));
+    expect(button.minHeight).toBe("32px");
+    expect(button.fontSize).toBe("12px");
+    expect(button.borderRadius).toBe("999px");
+    expect(capturedTheme.components.MuiButton.defaultProps).toMatchObject({
+      disableElevation: true,
+      size: "small",
+    });
+    expect(
+      capturedTheme.components.MuiButton.styleOverrides.root[
+        "&.Mui-focusVisible"
+      ]
+    ).toEqual({
+      outline: "3px solid #A8C7FA",
+      outlineOffset: 2,
+    });
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+  }
 });
 
 let capturedTheme;

--- a/src/views/RuleEditor/EditorSelect.js
+++ b/src/views/RuleEditor/EditorSelect.js
@@ -1,42 +1,20 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { TextField } from "@mui/material";
-
-function navigateShadowMenu(event) {
-  const list = event.currentTarget;
-  const root = list.getRootNode();
-  if (
-    !root.host ||
-    !["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)
-  )
-    return;
-  // MUI 5 MenuList reads document.activeElement, which is the shadow host.
-  // Use the actual focused option for navigation inside this shadow tree.
-  const options = [...list.querySelectorAll('[role="option"]')].filter(
-    (option) => option.getAttribute("aria-disabled") !== "true"
-  );
-  if (!options.length) return;
-  const index = options.indexOf(root.activeElement);
-  const next =
-    event.key === "Home"
-      ? 0
-      : event.key === "End"
-        ? options.length - 1
-        : Math.max(
-            0,
-            Math.min(
-              options.length - 1,
-              index + (event.key === "ArrowDown" ? 1 : -1)
-            )
-          );
-  event.preventDefault();
-  event.stopPropagation();
-  options[next].focus();
-}
+import { createMenuKeyDownHandler } from "../../libs/menuFocus";
+import { getEditorPortalContainer } from "./portal";
 
 // Keep the menu in the editor's shadow tree so Emotion styles and page
 // isolation apply to both the field and its popup.
-export default function EditorSelect(props) {
+export default function EditorSelect({ sx, ...props }) {
   const field = useRef(null);
+  const navigateMenu = useMemo(
+    () =>
+      createMenuKeyDownHandler({
+        shadowOnly: true,
+        disableListWrap: true,
+      }),
+    []
+  );
   return (
     <TextField
       {...props}
@@ -44,28 +22,36 @@ export default function EditorSelect(props) {
       select
       fullWidth
       size="small"
+      variant="filled"
+      sx={[
+        { "& .MuiFilledInput-root": { minHeight: 48 } },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       SelectProps={{
         MenuProps: {
-          container: () => {
-            const root = field.current?.getRootNode();
-            return root?.host
-              ? field.current.closest(".notranslate")
-              : document.body;
-          },
+          container: () => getEditorPortalContainer(field.current),
           disableScrollLock: true,
           // The document sees the shadow host as activeElement. MUI's modal
           // focus trap would otherwise pull focus away from the menu options.
           disableEnforceFocus: true,
           disableAutoFocus: true,
-          MenuListProps: { onKeyDownCapture: navigateShadowMenu },
+          MenuListProps: {
+            onKeyDownCapture: navigateMenu,
+            sx: { p: 0.5 },
+          },
           sx: { zIndex: 2147483647 },
           PaperProps: {
+            elevation: 0,
             sx: {
               overscrollBehavior: "contain",
               border: "1px solid",
-              borderColor: "divider",
-              borderRadius: 1.5,
+              borderColor: "var(--kt-linev)",
+              borderRadius: "12px",
+              bgcolor: "var(--kt-sf1)",
+              color: "var(--kt-on)",
+              boxShadow: "var(--kt-shadow-2)",
               "& .MuiMenuItem-root": {
+                minHeight: 40,
                 fontSize: 15,
                 whiteSpace: "normal",
                 overflowWrap: "anywhere",

--- a/src/views/RuleEditor/EditorSelect.test.js
+++ b/src/views/RuleEditor/EditorSelect.test.js
@@ -1,0 +1,75 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { MenuItem } from "@mui/material";
+import EditorSelect from "./EditorSelect";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+test("shadow menus retain the theme scope while navigating, searching and selecting", () => {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const shadow = host.attachShadow({ mode: "open" });
+  const container = document.createElement("div");
+  container.className = "notranslate";
+  shadow.appendChild(container);
+  const root = createRoot(container);
+  const onChange = jest.fn();
+
+  try {
+    act(() =>
+      root.render(
+        <div className="kt-m3-root">
+          <EditorSelect label="Purpose" value="alpha" onChange={onChange}>
+            <MenuItem value="alpha">Alpha</MenuItem>
+            <MenuItem value="blocked" disabled>
+              Blocked
+            </MenuItem>
+            <MenuItem value="beta">Beta</MenuItem>
+            <MenuItem value="bravo">Bravo</MenuItem>
+          </EditorSelect>
+        </div>
+      )
+    );
+    act(() =>
+      shadow
+        .querySelector('[role="combobox"]')
+        .dispatchEvent(
+          new MouseEvent("mousedown", { bubbles: true, button: 0 })
+        )
+    );
+    const themeRoot = container.querySelector(".kt-m3-root");
+    const list = shadow.querySelector('[role="listbox"]');
+    const options = list.querySelectorAll('[role="option"]');
+    const press = (key) =>
+      act(() =>
+        shadow.activeElement.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      );
+
+    expect(list.closest(".kt-m3-root")).toBe(themeRoot);
+    expect(shadow.activeElement).toBe(options[0]);
+    press("ArrowDown");
+    expect(shadow.activeElement).toBe(options[2]);
+    press("Home");
+    expect(shadow.activeElement).toBe(options[0]);
+    press("b");
+    expect(shadow.activeElement).toBe(options[2]);
+    press("b");
+    expect(shadow.activeElement).toBe(options[3]);
+    press("ArrowDown");
+    expect(shadow.activeElement).toBe(options[3]);
+    act(() =>
+      options[3].dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].target.value).toBe("bravo");
+  } finally {
+    act(() => root.unmount());
+    host.remove();
+  }
+});

--- a/src/views/RuleEditor/FloatingPanel.js
+++ b/src/views/RuleEditor/FloatingPanel.js
@@ -1,7 +1,10 @@
 import { useLayoutEffect, useRef, useState } from "react";
-import { Box, ButtonBase, Paper } from "@mui/material";
+import { Box, ButtonBase, Paper, Portal, Typography } from "@mui/material";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import { limitNumber } from "../../libs/utils";
+import { getEditorPortalContainer } from "./portal";
+
+const HEADER_HEIGHT = 56;
 
 // Shared by the editor and inspector; position is independent of page elements.
 export default function FloatingPanel({
@@ -10,6 +13,8 @@ export default function FloatingPanel({
   actions,
   children,
   footer,
+  notification,
+  notificationContainer,
   position,
   onMove,
   onMoveEnd,
@@ -80,132 +85,172 @@ export default function FloatingPanel({
     lastMove.current = null;
   };
   return (
-    <Paper
-      ref={panel}
-      component="aside"
-      aria-label={title}
-      sx={{
-        position: "fixed",
-        zIndex: 2147483647,
-        left,
-        top,
-        width: panelWidth,
-        maxHeight: viewport.h - margin * 2,
-        boxSizing: "border-box",
-        display: "flex",
-        flexDirection: "column",
-        overflow: "hidden",
-        border: "1px solid",
-        borderColor: "divider",
-        borderRadius: 2,
-        boxShadow: "0 12px 48px #0003",
-      }}
-    >
-      <Box
-        component="header"
+    <>
+      <Paper
+        ref={panel}
+        component="aside"
+        aria-label={title}
+        elevation={0}
         sx={{
+          position: "fixed",
+          zIndex: 2147483647,
+          left,
+          top,
+          width: panelWidth,
+          maxHeight: viewport.h - margin * 2,
+          boxSizing: "border-box",
           display: "flex",
-          alignItems: "center",
-          px: 1,
-          borderBottom: "1px solid",
-          borderColor: "divider",
-          flexShrink: 0,
+          flexDirection: "column",
+          overflow: "hidden",
+          border: "1px solid",
+          borderColor: "var(--kt-linev)",
+          borderRadius: "20px",
+          bgcolor: "var(--kt-sf0)",
+          color: "var(--kt-on)",
+          boxShadow: "var(--kt-shadow-2)",
         }}
       >
-        <ButtonBase
-          data-rule-editor-move=""
-          aria-label={moveLabel}
-          title={moveLabel}
-          disableRipple
-          onPointerDown={(event) => {
-            if (event.button !== 0 || event.isPrimary === false) return;
-            event.currentTarget.setPointerCapture(event.pointerId);
-            origin.current = {
-              x: left,
-              y: top,
-              clientX: event.clientX,
-              clientY: event.clientY,
-            };
-          }}
-          onPointerMove={(event) => {
-            if (!origin.current) return;
-            move(
-              origin.current.x + event.clientX - origin.current.clientX,
-              origin.current.y + event.clientY - origin.current.clientY
-            );
-          }}
-          onPointerUp={(event) => {
-            stopDrag();
-            if (event.currentTarget.hasPointerCapture(event.pointerId))
-              event.currentTarget.releasePointerCapture(event.pointerId);
-          }}
-          onPointerCancel={stopDrag}
-          onLostPointerCapture={stopDrag}
-          onKeyDown={(event) => {
-            const directions = {
-              ArrowLeft: [-1, 0],
-              ArrowRight: [1, 0],
-              ArrowUp: [0, -1],
-              ArrowDown: [0, 1],
-            };
-            const direction = directions[event.key];
-            if (!direction) return;
-            event.preventDefault();
-            onMoveEnd?.(
-              move(left + direction[0] * 24, top + direction[1] * 24)
-            );
-          }}
+        <Box
+          component="header"
           sx={{
-            flex: 1,
-            minWidth: 0,
-            justifyContent: "start",
-            py: 1.75,
-            gap: 0.5,
-            cursor: "grab",
-            touchAction: "none",
-            userSelect: "none",
-            fontSize: 18,
-            fontWeight: 700,
-            "&:active": { cursor: "grabbing" },
-            "&.Mui-focusVisible": {
-              outline: "2px solid",
-              outlineColor: "primary.main",
-            },
+            display: "flex",
+            alignItems: "center",
+            minHeight: HEADER_HEIGHT,
+            px: 2,
+            gap: 1,
+            bgcolor: "var(--kt-sf1)",
+            borderBottom: "1px solid",
+            borderColor: "var(--kt-linev)",
+            flexShrink: 0,
           }}
         >
-          <DragIndicatorIcon sx={{ fontSize: 20, color: "text.secondary" }} />
-          {title}
-        </ButtonBase>
-        {actions}
-      </Box>
-      <Box
-        sx={{
-          overflowY: "auto",
-          overscrollBehavior: "contain",
-          minHeight: 0,
-          p: 2,
-          ...bodySx,
-        }}
-      >
-        {children}
-      </Box>
-      {footer && (
+          <ButtonBase
+            data-rule-editor-move=""
+            aria-label={moveLabel}
+            title={moveLabel}
+            disableRipple
+            onPointerDown={(event) => {
+              if (event.button !== 0 || event.isPrimary === false) return;
+              event.currentTarget.setPointerCapture(event.pointerId);
+              origin.current = {
+                x: left,
+                y: top,
+                clientX: event.clientX,
+                clientY: event.clientY,
+              };
+            }}
+            onPointerMove={(event) => {
+              if (!origin.current) return;
+              move(
+                origin.current.x + event.clientX - origin.current.clientX,
+                origin.current.y + event.clientY - origin.current.clientY
+              );
+            }}
+            onPointerUp={(event) => {
+              stopDrag();
+              if (event.currentTarget.hasPointerCapture(event.pointerId))
+                event.currentTarget.releasePointerCapture(event.pointerId);
+            }}
+            onPointerCancel={stopDrag}
+            onLostPointerCapture={stopDrag}
+            onKeyDown={(event) => {
+              const directions = {
+                ArrowLeft: [-1, 0],
+                ArrowRight: [1, 0],
+                ArrowUp: [0, -1],
+                ArrowDown: [0, 1],
+              };
+              const direction = directions[event.key];
+              if (!direction) return;
+              event.preventDefault();
+              onMoveEnd?.(
+                move(left + direction[0] * 24, top + direction[1] * 24)
+              );
+            }}
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              minHeight: 40,
+              justifyContent: "flex-start",
+              px: 0.5,
+              py: 1,
+              ml: -0.5,
+              gap: 1,
+              borderRadius: "8px",
+              cursor: "grab",
+              touchAction: "none",
+              userSelect: "none",
+              "&:active": { cursor: "grabbing" },
+              "&&.Mui-focusVisible": {
+                outline: "none",
+                boxShadow: "inset 0 0 0 3px var(--kt-pri)",
+              },
+            }}
+          >
+            <DragIndicatorIcon
+              sx={{ fontSize: 20, flexShrink: 0, color: "var(--kt-onv)" }}
+            />
+            <Typography
+              component="span"
+              noWrap
+              sx={{ fontSize: 16, lineHeight: 1.5, fontWeight: 650 }}
+            >
+              {title}
+            </Typography>
+          </ButtonBase>
+          {actions}
+        </Box>
         <Box
-          component="footer"
           sx={{
-            p: 2,
-            pt: 1.5,
-            borderTop: "1px solid",
-            borderColor: "divider",
-            flexShrink: 0,
-            maxHeight: viewport.h * 0.55,
             overflowY: "auto",
             overscrollBehavior: "contain",
+            minHeight: 0,
+            p: 2,
+            ...bodySx,
           }}
         >
-          {footer}
+          {children}
         </Box>
+        {footer && (
+          <Box
+            component="footer"
+            sx={{
+              p: 2,
+              bgcolor: "var(--kt-sf1)",
+              borderTop: "1px solid",
+              borderColor: "var(--kt-linev)",
+              flexShrink: 0,
+              maxHeight: viewport.h * 0.55,
+              overflowY: "auto",
+              overscrollBehavior: "contain",
+            }}
+          >
+            {footer}
+          </Box>
+        )}
+      </Paper>
+      {notification && (
+        <Portal
+          container={
+            notificationContainer ||
+            (() => getEditorPortalContainer(panel.current))
+          }
+        >
+          <Box
+            data-rule-editor-notification=""
+            sx={{
+              position: "fixed",
+              zIndex: 2147483647,
+              left: left + 16,
+              top: top + HEADER_HEIGHT + 12,
+              width: Math.max(0, panelWidth - 32),
+              pointerEvents: "none",
+            }}
+          >
+            {notification}
+          </Box>
+        </Portal>
       )}
-    </Paper>
+    </>
   );
 }

--- a/src/views/RuleEditor/index.js
+++ b/src/views/RuleEditor/index.js
@@ -1,11 +1,13 @@
-import { useRef, useSyncExternalStore } from "react";
+import { useRef, useState, useSyncExternalStore } from "react";
 import {
   Alert,
   Autocomplete,
   Box,
   Button,
-  ButtonBase,
+  Card,
+  CardActionArea,
   Chip,
+  CircularProgress,
   Divider,
   Dialog,
   DialogActions,
@@ -14,16 +16,23 @@ import {
   DialogTitle,
   IconButton,
   MenuItem,
+  Snackbar,
   Stack,
+  Switch,
   TextField,
   ToggleButton,
   Typography,
 } from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
 import CloseIcon from "@mui/icons-material/Close";
 import UndoIcon from "@mui/icons-material/Undo";
 import RedoIcon from "@mui/icons-material/Redo";
 import AddIcon from "@mui/icons-material/Add";
-import Theme from "../../hooks/Theme";
+import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import AdsClickRoundedIcon from "@mui/icons-material/AdsClickRounded";
+import CodeRoundedIcon from "@mui/icons-material/CodeRounded";
+import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
+import M3Theme from "../../hooks/M3Theme";
 import { SettingProvider } from "../../hooks/Setting";
 import { useI18n } from "../../hooks/I18n";
 import {
@@ -39,6 +48,7 @@ import {
 import { limitNumber } from "../../libs/utils";
 import FloatingPanel from "./FloatingPanel";
 import EditorSelect from "./EditorSelect";
+import { getEditorPortalContainer } from "./portal";
 import usePanelPosition from "./usePanelPosition";
 import usePanelViewport from "./usePanelViewport";
 
@@ -53,7 +63,7 @@ const MAIN_WIDTH = 448;
 
 const codeStyle = {
   fontFamily: 'Consolas, "SFMono-Regular", monospace',
-  fontSize: 14,
+  fontSize: 13,
   lineHeight: 1.6,
   overflowWrap: "anywhere",
   textTransform: "none",
@@ -64,23 +74,29 @@ const codeStyle = {
 const themeOptions = {
   typography: {
     pxToRem: (size) => `${size}px`,
-    body1: { fontSize: 16 },
-    body2: { fontSize: 15 },
-    caption: { fontSize: 14 },
-    button: { fontSize: 15, textTransform: "none" },
-  },
-  components: {
-    MuiButton: { styleOverrides: { sizeSmall: { fontSize: 14 } } },
-    MuiChip: { styleOverrides: { label: { fontSize: 14 } } },
+    body1: { fontSize: 14 },
+    body2: { fontSize: 13 },
+    caption: { fontSize: 12 },
+    button: { fontSize: 13 },
   },
 };
 const cardStyle = (selected) => ({
   border: "1px solid",
   borderColor: selected ? "primary.main" : "divider",
-  bgcolor: selected ? "action.selected" : "background.paper",
-  borderRadius: 1,
+  bgcolor: selected ? "var(--kt-secc)" : "var(--kt-sf0)",
+  color: selected ? "var(--kt-onsecc)" : "text.primary",
+  borderRadius: "12px",
   overflow: "hidden",
 });
+const cardActionStyle = {
+  minWidth: 0,
+  p: 1.5,
+  textAlign: "left",
+  "&&.Mui-focusVisible": {
+    outline: "none",
+    boxShadow: "inset 0 0 0 3px var(--kt-pri)",
+  },
+};
 
 function CandidateList({ session, state, t }) {
   const busy = state.saving || state.loading;
@@ -109,66 +125,63 @@ function CandidateList({ session, state, t }) {
         </Typography>
       )}
       {state.candidates.map((candidate) => (
-        <ButtonBase
+        <Card
           key={candidate.selector}
-          disabled={busy}
-          aria-pressed={state.input === candidate.selector}
-          onClick={() => {
-            session.setInput(candidate.selector);
-            session.refresh();
-          }}
-          sx={{
-            ...cardStyle(state.input === candidate.selector),
-            display: "block",
-            p: 1.25,
-            textAlign: "left",
-            "&:hover": { bgcolor: "action.hover" },
-            "&.Mui-focusVisible": {
-              outline: "2px solid",
-              outlineColor: "primary.main",
-            },
-          }}
+          variant="outlined"
+          sx={cardStyle(state.input === candidate.selector)}
         >
-          <Stack
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-            gap={1}
+          <CardActionArea
+            disabled={busy}
+            aria-pressed={state.input === candidate.selector}
+            onClick={() => {
+              session.setInput(candidate.selector);
+              session.refresh();
+            }}
+            sx={cardActionStyle}
           >
-            <Typography variant="caption" color="text.secondary">
-              {t(candidate.kind)}
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              gap={1}
+            >
+              <Typography variant="caption" color="text.secondary">
+                {t(candidate.kind)}
+              </Typography>
+              <Chip
+                size="small"
+                aria-live={
+                  state.input === candidate.selector ? "polite" : "off"
+                }
+                label={
+                  state.input === candidate.selector && state.matchIndex
+                    ? `${state.matchIndex} / ${candidate.count}`
+                    : candidate.count
+                }
+              />
+            </Stack>
+            <Typography
+              component="code"
+              sx={{ ...codeStyle, display: "block", mt: 0.5 }}
+            >
+              {candidate.selector}
             </Typography>
-            <Chip
-              size="small"
-              aria-live={state.input === candidate.selector ? "polite" : "off"}
-              label={
-                state.input === candidate.selector && state.matchIndex
-                  ? `${state.matchIndex} / ${candidate.count}`
-                  : candidate.count
-              }
-            />
-          </Stack>
-          <Box sx={{ ...codeStyle, mt: 0.5, color: "primary.main" }}>
-            {candidate.selector}
-          </Box>
-          {candidate.fragile && (
-            <Typography variant="caption" color="warning.main">
-              {t("fragile")}
-            </Typography>
-          )}
-        </ButtonBase>
+            {candidate.fragile && (
+              <Typography variant="caption" color="warning.main">
+                {t("fragile")}
+              </Typography>
+            )}
+          </CardActionArea>
+        </Card>
       ))}
     </Stack>
   );
 }
 
 function Notice({ session, state, t }) {
-  if (!state.notice) return null;
+  if (!state.notice || state.notice === "saved") return null;
   return (
-    <Alert
-      severity={state.notice === "saved" ? "success" : "info"}
-      onClose={() => session.emit({ notice: "" })}
-    >
+    <Alert severity="info" onClose={() => session.emit({ notice: "" })}>
       {t(state.notice)}
       {state.notice === "removed-coverage" && (
         <Button
@@ -194,6 +207,7 @@ function Notice({ session, state, t }) {
 export function Editor({ session }) {
   const state = useSyncExternalStore(session.subscribe, session.getSnapshot);
   const patternField = useRef(null);
+  const [notificationHost, setNotificationHost] = useState(null);
   const i18n = useI18n();
   const t = (key) => i18n(`rule_editor_${key}`, key);
   const viewport = usePanelViewport();
@@ -204,6 +218,7 @@ export function Editor({ session }) {
     y: viewport.y + 24,
   };
   const mainWidth = Math.min(MAIN_WIDTH, viewport.w - 24);
+  const compactFooter = mainWidth < 400;
   const inspectorWidth = Math.min(380, viewport.w - 24);
   const mainX = limitNumber(
     position.x,
@@ -237,13 +252,49 @@ export function Editor({ session }) {
         onMoveEnd={mainPosition.onMoveEnd}
         width={MAIN_WIDTH}
         viewport={viewport}
+        notificationContainer={notificationHost}
+        notification={
+          notificationHost && (
+            <Snackbar
+              open={
+                state.notice === "saved" && !state.error && !state.confirmAction
+              }
+              autoHideDuration={5000}
+              onClose={(_, reason) => {
+                if (reason !== "clickaway") session.emit({ notice: "" });
+              }}
+              sx={{
+                "&&": {
+                  position: "static",
+                  transform: "none",
+                  width: "100%",
+                  minWidth: 0,
+                },
+                pointerEvents: "auto",
+              }}
+            >
+              <Alert
+                severity="success"
+                onClose={() => session.emit({ notice: "" })}
+                sx={{
+                  width: "100%",
+                  minWidth: 0,
+                  boxShadow: "var(--kt-shadow-2)",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {t("saved")}
+              </Alert>
+            </Snackbar>
+          )
+        }
         bodySx={{
           display: "flex",
           flexDirection: "column",
           p: viewport.h < 780 ? 1.5 : 2,
         }}
         actions={
-          <Stack direction="row">
+          <Stack direction="row" sx={{ flexShrink: 0 }}>
             <IconButton
               title={t("undo")}
               aria-label={t("undo")}
@@ -272,7 +323,11 @@ export function Editor({ session }) {
         }
         footer={
           <Stack spacing={1}>
-            <Stack direction="row" spacing={1} alignItems="stretch">
+            <Stack
+              direction={compactFooter ? "column" : "row"}
+              gap={1}
+              alignItems="stretch"
+            >
               {rule && (
                 <Stack
                   component="section"
@@ -282,13 +337,21 @@ export function Editor({ session }) {
                   sx={{
                     flex: 1,
                     minWidth: 0,
+                    p: 0.5,
+                    borderRadius: "16px",
+                    bgcolor: "var(--kt-sf2)",
                     "& .MuiToggleButton-root": {
-                      minHeight: 36,
+                      flex: 1,
+                      minWidth: 0,
+                      minHeight: 40,
                       px: 1,
-                      py: 0.75,
-                      fontSize: 14,
+                      py: 0.5,
+                      border: 0,
+                      borderRadius: "12px",
+                      fontSize: 13,
                       lineHeight: 1.4,
-                      textTransform: "none",
+                      "&:first-of-type": { flex: 1.4 },
+                      "&.Mui-disabled": { border: 0 },
                     },
                   }}
                 >
@@ -300,7 +363,6 @@ export function Editor({ session }) {
                     disabled={busy}
                     title={t("pagePreviewHelp")}
                     onClick={() => session.showWhole()}
-                    sx={{ flex: 1.4 }}
                   >
                     {t("whole")}
                   </ToggleButton>
@@ -311,25 +373,33 @@ export function Editor({ session }) {
                     selected={!!state.translated}
                     disabled={busy}
                     onClick={() => session.showTranslation(!state.translated)}
-                    sx={{ flex: 1 }}
                   >
                     {t(state.translated ? "original" : "translation")}
                   </ToggleButton>
                 </Stack>
               )}
-              <Button
-                size="small"
+              <LoadingButton
                 variant="contained"
-                disableElevation
+                fullWidth={compactFooter || !rule}
+                loading={state.saving}
+                loadingPosition="start"
+                loadingIndicator={
+                  <CircularProgress
+                    size={16}
+                    color="inherit"
+                    aria-label={t("saving")}
+                  />
+                }
                 disabled={busy || !state.dirty}
                 aria-label={t("save")}
                 aria-busy={state.saving}
                 title={state.dirty ? t("unsaved") : undefined}
                 onClick={() => session.save()}
-                sx={{ minHeight: 36, px: 2, flexShrink: 0 }}
+                startIcon={<SaveOutlinedIcon />}
+                sx={{ flexShrink: 0, minHeight: 48 }}
               >
-                {state.saving ? t("saving") : t("save")}
-              </Button>
+                {t("save")}
+              </LoadingButton>
             </Stack>
             {state.error && (
               <Alert
@@ -354,7 +424,7 @@ export function Editor({ session }) {
         }
       >
         <Stack
-          spacing={1}
+          spacing={1.5}
           sx={{
             minHeight: 0,
             "& > :not(section)": { flexShrink: 0 },
@@ -366,14 +436,34 @@ export function Editor({ session }) {
             forcePopupIcon
             slotProps={{
               popper: {
-                container: () =>
-                  patternField.current?.closest(".notranslate") ||
-                  document.body,
-                sx: { zIndex: 2147483647 },
+                container: () => getEditorPortalContainer(patternField.current),
+                sx: {
+                  zIndex: 2147483647,
+                  "& .MuiAutocomplete-paper": {
+                    mt: 0.5,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    borderRadius: "12px",
+                    bgcolor: "var(--kt-sf0)",
+                    boxShadow: "var(--kt-shadow-2)",
+                  },
+                  "& .MuiAutocomplete-option": {
+                    borderRadius: "8px",
+                    "&.Mui-focused": { bgcolor: "var(--kt-sf3)" },
+                    '&[aria-selected="true"]': {
+                      bgcolor: "var(--kt-secc)",
+                      color: "var(--kt-onsecc)",
+                    },
+                  },
+                },
               },
             }}
             ListboxProps={{
-              style: { overscrollBehavior: "contain", fontSize: 15 },
+              style: {
+                overscrollBehavior: "contain",
+                fontSize: 14,
+                padding: 4,
+              },
             }}
             disabled={busy}
             options={state.domainOptions || []}
@@ -392,6 +482,7 @@ export function Editor({ session }) {
               <TextField
                 {...params}
                 label={i18n("pattern")}
+                variant="filled"
                 size="small"
                 error={!!state.patternError}
                 helperText={
@@ -406,21 +497,48 @@ export function Editor({ session }) {
             )}
           />
           {state.loading && (
-            <Typography role="status">{t("loading")}</Typography>
+            <Stack
+              direction="row"
+              gap={1.5}
+              alignItems="center"
+              role="status"
+              sx={{ p: 1 }}
+            >
+              <CircularProgress size={20} />
+              <Typography variant="body2">{t("loading")}</Typography>
+            </Stack>
           )}
           {rule && (
             <>
-              <EditorSelect
-                label={i18n("auto_scan_page")}
-                disabled={busy}
-                value={rule.autoScan}
-                onChange={(event) =>
-                  session.updateDraft({ autoScan: event.target.value })
-                }
+              <Stack
+                component="label"
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                gap={2}
+                sx={{
+                  px: 1.5,
+                  py: 1,
+                  minHeight: 52,
+                  borderRadius: "12px",
+                  bgcolor: "var(--kt-sf2)",
+                }}
               >
-                <MenuItem value="false">{i18n("disable")}</MenuItem>
-                <MenuItem value="true">{i18n("enable")}</MenuItem>
-              </EditorSelect>
+                <Typography variant="body2" sx={{ fontWeight: 650 }}>
+                  {i18n("auto_scan_page")}
+                </Typography>
+                <Switch
+                  disabled={busy}
+                  checked={rule.autoScan === "true"}
+                  inputProps={{ "aria-label": i18n("auto_scan_page") }}
+                  onChange={(event) =>
+                    session.updateDraft({
+                      autoScan: String(event.target.checked),
+                    })
+                  }
+                  sx={{ flexShrink: 0 }}
+                />
+              </Stack>
               {(rule.scanAll === "true" ||
                 rule.isPlainText === true ||
                 rule.isPlainText === "true") && (
@@ -429,7 +547,7 @@ export function Editor({ session }) {
               <Stack
                 component="section"
                 aria-label={t("currentGroup")}
-                spacing={1}
+                spacing={1.5}
                 sx={{
                   minWidth: 0,
                   minHeight: 0,
@@ -437,11 +555,25 @@ export function Editor({ session }) {
                   "& > :not([aria-label])": { flexShrink: 0 },
                 }}
               >
-                <Divider textAlign="left">
-                  <Typography variant="caption" color="text.secondary">
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  sx={{ pt: 0.5 }}
+                >
+                  <Typography
+                    variant="body2"
+                    component="h2"
+                    sx={{ fontWeight: 650 }}
+                  >
                     {t("currentGroup")}
                   </Typography>
-                </Divider>
+                  <Chip
+                    size="small"
+                    label={state.entries.length}
+                    sx={{ bgcolor: "var(--kt-sf2)" }}
+                  />
+                </Stack>
                 <EditorSelect
                   label={t("purpose")}
                   value={state.field}
@@ -457,9 +589,11 @@ export function Editor({ session }) {
                 <Stack direction="row" gap={1}>
                   <Button
                     variant="contained"
+                    color="secondary"
+                    startIcon={<AdsClickRoundedIcon />}
                     disabled={busy}
                     onClick={() => session.pick()}
-                    sx={{ flex: 1 }}
+                    sx={{ flex: 1, minWidth: 0 }}
                   >
                     {t("pick")}
                   </Button>
@@ -468,6 +602,7 @@ export function Editor({ session }) {
                     startIcon={<AddIcon />}
                     disabled={busy}
                     onClick={() => session.add()}
+                    sx={{ flex: 1, minWidth: 0 }}
                   >
                     {t("manualAdd")}
                   </Button>
@@ -490,47 +625,55 @@ export function Editor({ session }) {
                   aria-label={t("entries")}
                 >
                   {state.entries.length === 0 && (
-                    <Typography color="text.secondary">{t("empty")}</Typography>
+                    <Stack
+                      alignItems="center"
+                      spacing={1}
+                      sx={{
+                        p: 2.5,
+                        border: "1px dashed",
+                        borderColor: "divider",
+                        borderRadius: "12px",
+                        color: "text.secondary",
+                      }}
+                    >
+                      <CodeRoundedIcon />
+                      <Typography variant="body2">{t("empty")}</Typography>
+                    </Stack>
                   )}
                   {state.entries.map((entry) => (
-                    <Box
+                    <Card
                       key={entry.selector}
+                      variant="outlined"
                       onMouseEnter={() => session.hover(entry.selector)}
                       onMouseLeave={() => session.refresh()}
                       sx={{
                         ...cardStyle(state.editing === entry.selector),
-                        position: "relative",
+                        display: "flex",
+                        alignItems: "center",
                         flexShrink: 0,
                       }}
                     >
-                      <ButtonBase
+                      <CardActionArea
                         disabled={busy}
                         aria-label={entry.selector}
                         aria-pressed={state.editing === entry.selector}
                         onClick={() => session.edit(entry.selector)}
                         sx={{
-                          display: "block",
-                          width: "100%",
-                          textAlign: "left",
-                          p: 1.25,
-                          "&:hover": { bgcolor: "action.hover" },
-                          "&.Mui-focusVisible": {
-                            boxShadow: "inset 0 0 0 2px",
-                            color: "primary.main",
-                          },
+                          ...cardActionStyle,
+                          flex: 1,
                         }}
                       >
                         <Stack direction="row" alignItems="start" gap={1}>
-                          <Box
+                          <Typography
+                            component="code"
                             sx={{
                               ...codeStyle,
                               flex: 1,
                               minWidth: 0,
-                              color: "primary.main",
                             }}
                           >
                             {entry.selector}
-                          </Box>
+                          </Typography>
                           <Chip
                             size="small"
                             color={entry.invalid ? "error" : "default"}
@@ -542,26 +685,23 @@ export function Editor({ session }) {
                           color="text.secondary"
                           component="div"
                           sx={{
-                            mt: 1,
-                            pr: "132px",
-                            minHeight: 32,
-                            display: "flex",
-                            alignItems: "center",
+                            mt: 0.75,
                           }}
                         >
                           {t(entry.source)}
                         </Typography>
-                      </ButtonBase>
-                      <Button
+                      </CardActionArea>
+                      <IconButton
                         size="small"
-                        color="inherit"
+                        title={t("delete")}
+                        aria-label={`${t("delete")}: ${entry.selector}`}
                         disabled={busy}
                         onClick={() => session.remove(entry.selector)}
-                        sx={{ position: "absolute", bottom: 8, right: 8 }}
+                        sx={{ m: 0.5, flexShrink: 0 }}
                       >
-                        {t("delete")}
-                      </Button>
-                    </Box>
+                        <DeleteOutlineRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </Card>
                   ))}
                 </Stack>
                 <Divider />
@@ -621,6 +761,7 @@ export function Editor({ session }) {
             <Stack spacing={1.5}>
               <TextField
                 label={t("input")}
+                variant="filled"
                 autoFocus={!state.selected}
                 multiline
                 minRows={2}
@@ -667,12 +808,11 @@ export function Editor({ session }) {
           )}
         </FloatingPanel>
       )}
+      <Box ref={setNotificationHost} />
       <Dialog
         open={!!state.confirmAction}
         disablePortal
-        container={() =>
-          patternField.current?.closest(".notranslate") || document.body
-        }
+        container={() => getEditorPortalContainer(patternField.current)}
         disableEnforceFocus
         disableScrollLock
         onClose={() => !state.saving && session.emit({ confirmAction: "" })}
@@ -690,7 +830,7 @@ export function Editor({ session }) {
             </Alert>
           )}
         </DialogContent>
-        <DialogActions sx={{ flexWrap: "wrap", gap: 1 }}>
+        <DialogActions sx={{ flexWrap: "wrap", gap: 1, px: 3, pb: 3 }}>
           <Button
             disabled={state.saving}
             onClick={() => session.emit({ confirmAction: "" })}
@@ -719,9 +859,9 @@ export function Editor({ session }) {
 export default function RuleEditor(props) {
   return (
     <SettingProvider context="ruleEditor">
-      <Theme options={themeOptions}>
+      <M3Theme options={themeOptions}>
         <Editor {...props} />
-      </Theme>
+      </M3Theme>
     </SettingProvider>
   );
 }

--- a/src/views/RuleEditor/index.test.js
+++ b/src/views/RuleEditor/index.test.js
@@ -1,6 +1,8 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { Editor } from ".";
+import { CacheProvider } from "@emotion/react";
+import createCache from "@emotion/cache";
+import RuleEditor from ".";
 import { storage } from "../../libs/storage";
 import {
   STOKEY_RULE_EDITOR_POSITION,
@@ -8,9 +10,11 @@ import {
 } from "../../config";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-jest.mock("../../hooks/Theme", () => ({
-  __esModule: true,
-  default: ({ children }) => children,
+jest.mock("../../hooks/ColorMode", () => ({
+  useDarkMode: () => ({ darkMode: "light" }),
+}));
+jest.mock("../../hooks/SystemColorScheme", () => ({
+  useSystemDarkPreference: () => false,
 }));
 jest.mock("../../hooks/Setting", () => ({
   SettingProvider: ({ children }) => children,
@@ -21,7 +25,7 @@ jest.mock("../../libs/storage", () => ({
 }));
 jest.mock("../../libs/sync", () => ({ syncData: jest.fn() }));
 
-let root, container, session, originalResizeObserver;
+let root, container, cache, session, originalResizeObserver;
 beforeEach(() => {
   storage.getObj.mockReset().mockResolvedValue(null);
   storage.setObj.mockReset().mockResolvedValue();
@@ -33,6 +37,7 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  cache = createCache({ key: "rule-editor-test" });
   const state = {
     context: { effective: { autoScan: "false" } },
     field: "selector",
@@ -59,6 +64,7 @@ beforeEach(() => {
     confirmAction: jest.fn(),
     emit: jest.fn(),
     showWhole: jest.fn(),
+    showTranslation: jest.fn(),
     setField: jest.fn(),
     setPattern: jest.fn(),
     commitPattern: jest.fn(),
@@ -66,11 +72,29 @@ beforeEach(() => {
 });
 afterEach(() => {
   act(() => root.unmount());
+  cache.sheet.flush();
   container.remove();
   globalThis.ResizeObserver = originalResizeObserver;
 });
 const render = () =>
-  act(async () => root.render(<Editor session={session} onExit={jest.fn()} />));
+  act(async () =>
+    root.render(
+      <CacheProvider value={cache}>
+        <RuleEditor session={session} />
+      </CacheProvider>
+    )
+  );
+const mountInShadow = () => {
+  act(() => root.unmount());
+  cache.sheet.flush();
+  const shadow = container.attachShadow({ mode: "open" });
+  const wrapper = document.createElement("div");
+  wrapper.className = "notranslate";
+  shadow.appendChild(wrapper);
+  cache = createCache({ key: "rule-editor-test", container: shadow });
+  root = createRoot(wrapper);
+  return shadow;
+};
 const click = (element) =>
   act(() => element.dispatchEvent(new MouseEvent("click", { bubbles: true })));
 
@@ -82,11 +106,7 @@ test("the entire rule card selects the entry while delete acts independently", a
   click(card);
   expect(session.edit).toHaveBeenCalledTimes(3);
   expect(session.edit).toHaveBeenLastCalledWith(".story");
-  click(
-    [...container.querySelectorAll("button")].find(
-      (button) => button.textContent === "rule_editor_delete"
-    )
-  );
+  click(container.querySelector('[aria-label="rule_editor_delete: .story"]'));
   expect(session.remove).toHaveBeenCalledWith(".story");
   expect(session.edit).toHaveBeenCalledTimes(3);
 });
@@ -108,23 +128,24 @@ test("selector input and save live only in the closable inspector", async () => 
   expect(session.closeInspector).toHaveBeenCalledTimes(1);
 });
 
-test("themed menus reuse settings labels and keep automatic scanning values", async () => {
+test("the M3 scan switch keeps string values and the purpose menu keeps settings labels", async () => {
   await render();
   expect(container.querySelector("select")).toBeNull();
-  const selects = container.querySelectorAll('div[role="combobox"]');
-  expect(selects[0].textContent).toContain("disable");
+  const scan = container.querySelector('input[aria-label="auto_scan_page"]');
+  expect(scan.checked).toBe(false);
   expect(container.textContent).toContain("auto_scan_page");
-  expect(selects[1].textContent).toContain("target_selector");
-  act(() =>
-    selects[0].dispatchEvent(
-      new MouseEvent("mousedown", { bubbles: true, button: 0 })
-    )
-  );
-  click(document.querySelector('[role="option"][data-value="true"]'));
+  const purpose = container.querySelector('div[role="combobox"]');
+  expect(purpose.textContent).toContain("target_selector");
+  click(scan);
   expect(session.updateDraft).toHaveBeenCalledWith({ autoScan: "true" });
   expect(session.save).not.toHaveBeenCalled();
+  session.getSnapshot().context.effective.autoScan = "true";
+  await render();
+  expect(scan.checked).toBe(true);
+  click(scan);
+  expect(session.updateDraft).toHaveBeenLastCalledWith({ autoScan: "false" });
   act(() =>
-    selects[1].dispatchEvent(
+    purpose.dispatchEvent(
       new MouseEvent("mousedown", { bubbles: true, button: 0 })
     )
   );
@@ -140,22 +161,65 @@ test("conflicts appear in the footer and take precedence over stale save notices
   await render();
   const footer = container.querySelector("footer");
   expect(footer.querySelectorAll('[role="alert"]')).toHaveLength(1);
+  expect(container.querySelector(".MuiSnackbar-root")).toBeNull();
   expect(footer.textContent).not.toContain("rule_editor_saved");
   expect(footer.textContent.indexOf("rule_editor_whole")).toBeLessThan(
     footer.textContent.indexOf("rule_editor_rule-conflict")
   );
 });
 
-test("save confirmation appears after the preview in the footer", async () => {
+test("save confirmation follows its panel without entering the layout", async () => {
   session.getSnapshot().notice = "saved";
   await render();
   const footer = container.querySelector("footer");
-  expect(footer.querySelector('[role="alert"]').textContent).toContain(
+  const snackbar = container.querySelector(".MuiSnackbar-root");
+  expect(snackbar.querySelector('[role="alert"]').textContent).toContain(
     "rule_editor_saved"
   );
-  expect(footer.textContent.indexOf("rule_editor_whole")).toBeLessThan(
-    footer.textContent.indexOf("rule_editor_saved")
+  expect(snackbar.closest("aside")).toBeNull();
+  expect(snackbar.closest(".kt-m3-root")).toBe(
+    container.querySelector(".kt-m3-root")
   );
+  const notification = snackbar.closest("[data-rule-editor-notification]");
+  expect(getComputedStyle(notification).position).toBe("fixed");
+  const previousLeft = parseFloat(getComputedStyle(notification).left);
+  const move = container.querySelector("aside [data-rule-editor-move]");
+  await act(async () =>
+    move.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "ArrowLeft",
+        bubbles: true,
+      })
+    )
+  );
+  expect(parseFloat(getComputedStyle(notification).left)).toBe(
+    previousLeft - 24
+  );
+  expect(footer.querySelector('[role="alert"]')).toBeNull();
+  click(snackbar.querySelector("button"));
+  expect(session.emit).toHaveBeenCalledWith({ notice: "" });
+});
+
+test("saving keeps the button label and preview borders stable", async () => {
+  await render();
+  const save = container.querySelector('[aria-label="rule_editor_save"]');
+  const previews = [...container.querySelectorAll(".MuiToggleButton-root")];
+  const borders = () =>
+    previews.map((button) => {
+      const style = getComputedStyle(button);
+      return [style.borderTopWidth, style.borderBottomWidth];
+    });
+  const before = borders();
+  session.getSnapshot().saving = true;
+  await render();
+  expect(save.textContent).toBe("rule_editor_save");
+  expect(save.getAttribute("aria-busy")).toBe("true");
+  expect(save.disabled).toBe(true);
+  expect(
+    save.querySelector('[role="progressbar"]').getAttribute("aria-label")
+  ).toBe("rule_editor_saving");
+  expect(borders()).toEqual(before);
+  expect(container.querySelector("footer [role='alert']")).toBeNull();
 });
 
 test("both panels restore saved positions and persist keyboard movement", async () => {
@@ -196,12 +260,7 @@ test("invalid saved positions fall back to finite viewport coordinates", async (
 });
 
 test("shadow-tree menus keep focus on options and support arrow navigation", async () => {
-  act(() => root.unmount());
-  const shadow = container.attachShadow({ mode: "open" });
-  const wrapper = document.createElement("div");
-  wrapper.className = "notranslate";
-  shadow.appendChild(wrapper);
-  root = createRoot(wrapper);
+  const shadow = mountInShadow();
   await render();
   const scan = shadow.querySelector('div[role="combobox"]');
   act(() =>
@@ -210,6 +269,7 @@ test("shadow-tree menus keep focus on options and support arrow navigation", asy
     )
   );
   const list = shadow.querySelector('[role="listbox"]');
+  expect(list.closest(".kt-m3-root")).toBe(shadow.querySelector(".kt-m3-root"));
   const options = list.querySelectorAll('[role="option"]');
   expect(shadow.activeElement).toBe(options[0]);
   act(() =>
@@ -219,7 +279,7 @@ test("shadow-tree menus keep focus on options and support arrow navigation", asy
   );
   expect(shadow.activeElement).toBe(options[1]);
   click(options[1]);
-  expect(session.updateDraft).toHaveBeenCalledWith({ autoScan: "true" });
+  expect(session.setField).toHaveBeenCalledWith("ignoreSelector");
 });
 
 test("site pattern supports custom input and dropdown choices without saving", async () => {
@@ -239,6 +299,9 @@ test("site pattern supports custom input and dropdown choices without saving", a
   expect(session.commitPattern).toHaveBeenCalledTimes(1);
   click(container.querySelector(".MuiAutocomplete-popupIndicator"));
   const options = document.querySelectorAll('[role="option"]');
+  expect(options[0].closest(".kt-m3-root")).toBe(
+    container.querySelector(".kt-m3-root")
+  );
   expect([...options].map((item) => item.textContent)).toEqual([
     "localhost",
     "localhost:*",
@@ -277,16 +340,33 @@ test("the unsaved dialog offers save, discard and keep editing", async () => {
 });
 
 test("confirmation in a shadow tree keeps the editor host accessible", async () => {
-  act(() => root.unmount());
-  const shadow = container.attachShadow({ mode: "open" });
-  const wrapper = document.createElement("div");
-  wrapper.className = "notranslate";
-  shadow.appendChild(wrapper);
-  root = createRoot(wrapper);
+  const shadow = mountInShadow();
   session.getSnapshot().confirmAction = "exit";
   await render();
   expect(shadow.querySelector('[role="dialog"]')).not.toBeNull();
+  expect(
+    shadow.querySelector('[role="dialog"]').closest('[aria-hidden="true"]')
+  ).toBeNull();
   expect(container.getAttribute("aria-hidden")).not.toBe("true");
+});
+
+test("the editor keeps its M3 font, filled fields and pill buttons on small-root pages", async () => {
+  const originalSize = document.documentElement.style.fontSize;
+  document.documentElement.style.fontSize = "10px";
+  try {
+    await render();
+    const themeRoot = container.querySelector(".kt-m3-root");
+    expect(themeRoot.dataset.theme).toBe("light");
+    expect(themeRoot.style.getPropertyValue("--kt-pri")).toBe("#0B57D0");
+    const save = container.querySelector('[aria-label="rule_editor_save"]');
+    expect(getComputedStyle(save).fontFamily).toContain("Google Sans");
+    expect(getComputedStyle(save).fontSize).toBe("13px");
+    expect(getComputedStyle(save).borderRadius).toBe("999px");
+    expect(container.querySelector(".MuiFilledInput-root")).not.toBeNull();
+    expect(container.querySelector(".MuiOutlinedInput-root")).toBeNull();
+  } finally {
+    document.documentElement.style.fontSize = originalSize;
+  }
 });
 
 test.each([false, true])(

--- a/src/views/RuleEditor/portal.js
+++ b/src/views/RuleEditor/portal.js
@@ -1,0 +1,9 @@
+// Keep popups inside the editor's palette and shadow-tree style boundary.
+export function getEditorPortalContainer(element) {
+  return (
+    element?.closest(".kt-m3-root") ||
+    element?.closest(".notranslate") ||
+    element?.ownerDocument?.body ||
+    document.body
+  );
+}


### PR DESCRIPTION
## 改动说明

将可视化网站规则编辑器统一到 `dev` 的 Material 3 主题，保留原有规则编辑、草稿、撤销/重做和保存流程。

- 使用填充式输入框、自动扫描开关、定位选择卡片，以及适配窄屏的预览和保存工具栏。
- 保存成功提示显示在标题下方，跟随面板移动，在副面板重叠时保持可见，且不挤压编辑器布局。
- 共享主题覆盖保留 Material 3 默认样式，并保持 Shadow DOM 内的字体和菜单可读性。
- 修复循环审查发现的滚轮穿透问题：保存提示移入 Portal 后也会隔离滚轮事件；保留 Ctrl+滚轮的浏览器缩放行为。

## 审查与验证

本轮循环审查和独立复审已完成，未发现剩余可操作修改项。

针对提交 `6caa85026be82192ca6ff0a46fd36eef430145ca`：

- 在 `ssh test-env` 运行 6 个 Jest 测试套件，80 项测试全部通过。
- 新增回归用例在修复前的普通 DOM 和 Shadow DOM 场景均失败，修复后通过；覆盖纵向/横向滚轮、事件冒泡与 Ctrl+滚轮例外。
- 8 个变更文件的 Prettier 检查通过。
- Chrome 与 Firefox 生产构建通过；压缩包结构与 manifest 校验通过。

## 内置浏览器测试与录像

本次在 Codex 内置浏览器中实际操作并录制，使用当前提交的真实 `RuleEditorManager`、`RuleEditorSession`、`ShadowDomManager`、Material 3 主题和规则持久化逻辑。翻译执行器使用固定测试数据，未调用外部翻译服务；这是组件集成验收，不是安装扩展后的端到端测试。

https://github.com/user-attachments/assets/95dee4cb-9c6f-4ad9-a005-774b67ea010f

[下载原始 MP4（备用）](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/kiss-translator-pr9-6caa8502-browser-test.mp4)

已验收：

- 中文／英文、浅色／深色主题，以及 `1280 × 900` 桌面和 `390 × 844` 窄屏布局。
- 自动扫描开关、撤销／重做、网页元素拾取、手动添加 CSS 选择器、保存并重新打开。
- Shadow DOM 菜单的方向键导航，以及未保存草稿的“继续编辑”和“放弃修改”流程。
- 保存提示上的滚轮输入保持网页 `scrollY` 不变；在编辑器外滚动，网页正常移动 `420 px`。
- 保存提示随面板拖动 `(-120, +60) px`，窄屏保存按钮保持可达，提示在重叠副面板上方仍可点击关闭。

10 项浏览器检查全部通过，录制期间未发现页面控制台错误或警告。视频约 64 秒，保留 353 个实际捕获的页面帧及操作顺序；长于 2 秒的静止等待缩短为 2 秒，短于 1/30 秒的帧间隔延长至 1/30 秒，窄屏画面等比补黑边；无配音。

[浏览器检查结果](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/browser-checks.json) · [录制与编码说明](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/video-provenance.md) · [测试页面脚本与证据包](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/browser-evidence.zip)


[视频与证据的 SHA-256 校验值](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/BROWSER-SHA256SUMS.txt)

## 测试安装包

以下产物均对应当前提交 `6caa85026be82192ca6ff0a46fd36eef430145ca`：

| 浏览器 | 下载 |
| --- | --- |
| Chrome / Edge | [测试安装包 ZIP](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/kiss-translator-pr9-6caa8502-chrome.zip) |
| Firefox | [测试安装包 ZIP](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/kiss-translator-pr9-6caa8502-firefox.zip) |

[构建来源与安装说明](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/build-provenance.md) · [SHA-256 校验值](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/SHA256SUMS.txt) · [验证日志](https://github.com/moooyo/kiss-translator-m3/releases/download/pr-9-6caa8502/kiss-translator-pr9-6caa8502-verification-logs.zip)

Chrome / Edge：解压后在扩展管理页开启开发者模式，选择“加载已解压的扩展程序”。Firefox：在 `about:debugging#/runtime/this-firefox` 临时载入解压后的 `manifest.json`。

测试包通过 [GitHub 预发布附件](https://github.com/moooyo/kiss-translator-m3/releases/tag/pr-9-6caa8502) 托管，供本 PR 验收使用。

